### PR TITLE
[bugfix] Moving directory creation to after checkout validity checks

### DIFF
--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -688,7 +688,6 @@ class Repository(object):
             categories_path, spec_name, _ = spec_parse(tag)
             root_path = get_root_path()
             ws_path = os.path.join(root_path, os.sep.join([repo_type, categories_path]))
-            ensure_path_exists(ws_path)
         except Exception as e:
             log.error(e, class_name=LOCAL_REPOSITORY_CLASS_NAME)
             return None, None
@@ -714,12 +713,12 @@ class Repository(object):
         dataset_tag, labels_tag = self._get_related_tags(categories_path, dataset, labels, metadata_path, repo_type, spec_name)
 
         fetch_success = self._fetch(tag, samples, retries, bare)
-
         if not fetch_success:
             objs = Objects('', objects_path)
             objs.fsck(remove_corrupted=True)
             self._checkout_ref('master')
             return None, None
+        ensure_path_exists(ws_path)
 
         try:
             spec_index_path = os.path.join(get_index_metadata_path(self.__config, repo_type), spec_name)

--- a/tests/integration/test_08_checkout_tag.py
+++ b/tests/integration/test_08_checkout_tag.py
@@ -20,6 +20,7 @@ from tests.integration.output_messages import messages
 
 @pytest.mark.usefixtures('tmp_dir', 'aws_session')
 class CheckoutTagAcceptanceTests(unittest.TestCase):
+    entity_path = os.path.join('dataset', 'computer_vision', 'images', 'dataset-ex')
 
     def set_up_checkout(self, entity):
         init_repository(entity, self)
@@ -39,15 +40,17 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
 
     def check_amount_of_files(self, entity_type, expected_files, sampling=True):
         entity_dir = os.path.join(self.tmp_dir, entity_type, 'computer-vision', 'images', entity_type+'-ex')
+        if expected_files == 0:
+            self.assertFalse(os.path.exists(entity_dir))
+            self.assertFalse(self.check_sampling_flag('dataset'))
+            return
         self.assertTrue(os.path.exists(entity_dir))
         file_count = 0
         for path in pathlib.Path(entity_dir).iterdir():
             if path.is_file():
                 file_count += 1
         self.assertEqual(file_count, expected_files)
-        if expected_files == 0:
-            self.assertFalse(self.check_sampling_flag('dataset'))
-        elif sampling:
+        if sampling:
             self.assertTrue(self.check_sampling_flag('dataset'))
 
     def check_sampling_flag(self, entity):


### PR DESCRIPTION
Fixing a error ocurred when a checkout with parameters is done wrong, ml-git creates a sequence of empty directories.