### PR TITLE
Adding mandatory option to set mutability during entity creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ml-git is a tool which provides a Distributed Version Control system to enable efficient dataset management. Like its name emphasizes, it is inspired in git concepts and workflows, ml-git enables the following operations:
 
 - Manage a repository of different datasets, labels and models.
-- Versioning immutable versions of models, labels and documents.
 - Distribute these ML artifacts between members of a team or across organizations.
 - Apply the right data governance and security models to their artifacts.
 
@@ -11,7 +10,7 @@ ml-git is a tool which provides a Distributed Version Control system to enable e
 
 **Prerequisites:**
 
-- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
+- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [Python 3.7+](https://www.python.org/downloads/release/python-370/)
 
 Download ml-git from repository and execute commands below:
@@ -102,7 +101,7 @@ $ ml-git clone https://github.com/user/ml_git_configuration_file_example.git --t
 This command will help you to start a new project, it creates your project artifact metadata:
 
 ```
-$ ml-git dataset create --category=computer-vision --category=images --bucket-name=your_bucket --import=../import-path dataset-ex 
+$ ml-git dataset create --category=computer-vision --category=images --bucket-name=your_bucket --import=../import-path --mutability=mutable dataset-ex 
 ```
 
 Demonstration video:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ $ ml-git clone https://github.com/user/ml_git_configuration_file_example.git --t
 This command will help you to start a new project, it creates your project artifact metadata:
 
 ```
-$ ml-git dataset create --category=computer-vision --category=images --bucket-name=your_bucket --import=../import-path --mutability=mutable dataset-ex 
+$ ml-git dataset create --category=computer-vision --category=images --bucket-name=your_bucket --import=../import-path --mutability=strict dataset-ex 
 ```
 
 Demonstration video:

--- a/docs/first_project.md
+++ b/docs/first_project.md
@@ -123,7 +123,7 @@ Ml-git expects any dataset to be specified under _dataset/_ directory of your pr
 To create this specification file for a new entity you must run the following command:
 
 ```
-$ ml-git dataset create imagenet8 --category=computer-vision --category=images --mutability=mutable --store-type=s3h --bucket-name=mlgit-datasets --version=1 
+$ ml-git dataset create imagenet8 --category=computer-vision --category=images --mutability=strict --store-type=s3h --bucket-name=mlgit-datasets --version=1 
 ```
 
 After that a file must have been created in dataset/imagenet8/imagenet8.spec and should look like this:
@@ -133,7 +133,7 @@ dataset:
   categories:
     - computer-vision
     - images
-  mutability: mutable
+  mutability: strict
   manifest:
     store: s3h://mlgit-datasets
   name: imagenet8
@@ -155,7 +155,7 @@ dataset:
   categories:
     - computer-vision
     - images
-  mutability: mutable
+  mutability: strict
   manifest:
     store: s3h://mlgit-datasets
   name: imagenet8

--- a/docs/first_project.md
+++ b/docs/first_project.md
@@ -120,20 +120,24 @@ config:
 To create and upload a dataset to a store, you must be in an already initialized project, if necessary read [section 1](#initial-config) to initialize and configure a project.
 
 Ml-git expects any dataset to be specified under _dataset/_ directory of your project and it expects a specification file with the name of the dataset.
+To create this specification file for a new entity you must run the following command:
 
 ```
-$ mkdir -p dataset/imagenet8
-$ echo "
+$ ml-git dataset create imagenet8 --category=computer-vision --category=images --mutability=mutable --store-type=s3h --bucket-name=mlgit-datasets --version=1 
+```
+
+After that a file must have been created in dataset/imagenet8/imagenet8.spec and should look like this:
+
+```
 dataset:
   categories:
     - computer-vision
     - images
-  mutability: strict
+  mutability: mutable
   manifest:
     store: s3h://mlgit-datasets
   name: imagenet8
   version: 1
-" > dataset/imagenet8/imagenet8.spec
 ```
 
 There are 5 main items in the spec file:
@@ -141,11 +145,8 @@ There are 5 main items in the spec file:
 2. __version__: the version should be an integer, incremented each time there is new version pushed into ml-git.  You can use the --bumpversion argument to do the increment automatically for you when you add more files to a dataset.
 3. __categories__ : describes a tree structure to characterize the dataset category. That information is used by ml-git to create a directory structure in the git repository managing the metadata.
 4. __manifest__: describes the data store in which the data is actually stored. In this case a S3 bucket named _mlgit-datasets_. The AWS credential profile name and AWS region should be found in the ml-git config file.
-5. __mutability__: describes the mutability option that your project will have, choosing an option that can never be changed. The mutability options are "strict", "flexible" and "mutable".
-    * __strict__ :  this option the spec is strict by default and the files in a dataset can never be changed.
-    * __flexible__: this option is like strict but using the __ml-git__ __unlock__ command the files in a dataset can be modified.
-    * __mutable__ : this option can modify the files in a dataset.
-   
+5. __mutability__: describes the mutability option that your project will have, choosing an option that can never be changed. The mutability options are "strict", "flexible" and "mutable". If you want to know more about each type of mutability and how it works, please take a look at [mutability documentation](mutability_helper.md).
+
 The items listed above are mandatory in the spec. An important point to note here is that if the user wishes, he can add new items that will be versioned with the spec. 
 The example below presents a spec with the entity's owner information to be versioned. Those information were put under metadata field just for purpose of organization.
 
@@ -154,7 +155,7 @@ dataset:
   categories:
     - computer-vision
     - images
-  mutability: strict
+  mutability: mutable
   manifest:
     store: s3h://mlgit-datasets
   name: imagenet8
@@ -331,18 +332,7 @@ config:
 Now, you can create your first labels set for say mscoco. ml-git expects any labels set to be specified under _labels/_ directory of your project and it expects a specification file with the name of the _labels_.
 
 ```
-$ mkdir -p labels/mscoco-captions
-$ echo "
-labels:
-  categories:
-    - computer-vision
-    - captions
-  mutability: strict
-  manifest:
-    store: s3h://mlgit-labels
-  name: mscoco-captions
-  version: 1
-" > labels/mscoco-captions/mscoco-captions.spec
+$ ml-git labels create mscoco-captions --category=computer-vision --category=captions --mutability=mutable --store-type=s3h --bucket-name=mlgit-labels --version=1
 ```
 
 There are 4 main items in the spec file:

--- a/docs/mlgit_commands.md
+++ b/docs/mlgit_commands.md
@@ -216,12 +216,12 @@ Options:
 Examples:
  - To create an entity with s3 as store and importing files from a path of your computer:
 ```
-ml-git dataset create imagenet8 --store-type=s3h --category=computer-vision --category=images --version=0 --import='/path/to/dataset' --mutability=mutable
+ml-git dataset create imagenet8 --store-type=s3h --category=computer-vision --category=images --version=0 --import='/path/to/dataset' --mutability=strict
 ```
 
 - To create an entity with s3 as store and importing files from a google drive URL:
 ```
-ml-git dataset create imagenet8 --store-type=s3h --category=computer-vision --category=images --import-url='gdrive.url' --credentials-path='/path/to/gdrive/credentials' --mutability=mutable --unzip
+ml-git dataset create imagenet8 --store-type=s3h --category=computer-vision --category=images --import-url='gdrive.url' --credentials-path='/path/to/gdrive/credentials' --mutability=strict --unzip
 ```
 
 </details>

--- a/docs/mlgit_commands.md
+++ b/docs/mlgit_commands.md
@@ -191,6 +191,8 @@ Usage: ml-git dataset create [OPTIONS] ARTIFACT_NAME
 
 Options:
   --category TEXT                 Artifact's category name.  [required]
+  --mutability [strict|flexible|mutable]
+                                  Mutability type.  [required]
   --store-type [s3h|azureblobh|gdriveh]
                                   Data store type [default: s3h].
   --version-number, --version INTEGER RANGE
@@ -198,7 +200,7 @@ Options:
                                   [DEPRECATED:--version-number]
   --import TEXT                   Path to be imported to the project. NOTE:
                                   Mutually exclusive with argument:
-                                  import_url, credentials_path.
+                                  credentials_path, import_url.
   --wizard-config                 If specified, ask interactive questions. at
                                   console for git & store configurations.
   --bucket-name TEXT              Bucket name
@@ -214,12 +216,12 @@ Options:
 Examples:
  - To create an entity with s3 as store and importing files from a path of your computer:
 ```
-ml-git dataset create imagenet8 --store-type=s3h --category=computer-vision --category=images --version=0 --import='/path/to/dataset'
+ml-git dataset create imagenet8 --store-type=s3h --category=computer-vision --category=images --version=0 --import='/path/to/dataset' --mutability=mutable
 ```
 
 - To create an entity with s3 as store and importing files from a google drive URL:
 ```
-ml-git dataset create imagenet8 --store-type=s3h --category=computer-vision --category=images --import-url='gdrive.url' --credentials-path='/path/to/gdrive/credentials' --unzip
+ml-git dataset create imagenet8 --store-type=s3h --category=computer-vision --category=images --import-url='gdrive.url' --credentials-path='/path/to/gdrive/credentials' --mutability=mutable --unzip
 ```
 
 </details>

--- a/docs/mlgit_internals.md
+++ b/docs/mlgit_internals.md
@@ -401,7 +401,7 @@ dataset:
   categories:
     - computer-vision
     - images
-  mutability: strict
+  mutability: mutable
   manifest:
     store: s3h://mlgit-datasets
   name: imagenet8
@@ -415,7 +415,7 @@ dataset:
   categories:
   - computer-vision
   - images
-  mutability: strict
+  mutability: mutable
   manifest:
     files: MANIFEST.yaml
     store: s3h://mlgit-datasets
@@ -494,6 +494,10 @@ ml-git_project/
 ```
 
 The parameters passed ```--category``` and ```--version``` are used to fill the spec file.
+
+The parameter ```--mutability``` must be used to define the entity's mutability, which can be: strict, flexible, mutable.
+If you want to know more about each type of mutability and how it works, please take a look at [mutability helper documentation](mutability_helper.md).
+
 The parameter ```--import``` is used to import files from a src folder to data folder.
 The optional parameter ```--wizard-questions``` if passed, ask interactive questions at console for git & store configurations and update the config.yaml file.
 The parameter ```--store-type``` must be used to define the entity's storage, which can be: s3h, azureblobh, gdriveh.

--- a/docs/mlgit_internals.md
+++ b/docs/mlgit_internals.md
@@ -401,7 +401,7 @@ dataset:
   categories:
     - computer-vision
     - images
-  mutability: mutable
+  mutability: strict
   manifest:
     store: s3h://mlgit-datasets
   name: imagenet8
@@ -415,7 +415,7 @@ dataset:
   categories:
   - computer-vision
   - images
-  mutability: mutable
+  mutability: strict
   manifest:
     files: MANIFEST.yaml
     store: s3h://mlgit-datasets

--- a/docs/mutability_helper.md
+++ b/docs/mutability_helper.md
@@ -33,7 +33,7 @@ If you create an entity without using the create command and without mutability,
 
 Note:
 ```
-For entities that were created before the mutability parameter became mandatory (version 0.0.1) and that did not define mutability, ml-git treats these entities as strict.
+For entities that were created before the mutability parameter became mandatory and that did not define mutability, ml-git treats these entities as strict.
 ```
 
 Because it is an attribute defined in the spec, you can define a type of mutability for each entity that the project has. For example, you can have in the same project a dataset-ex1 that has strict mutability while a dataset-ex2 has flexible mutability.

--- a/docs/mutability_helper.md
+++ b/docs/mutability_helper.md
@@ -1,0 +1,73 @@
+# Mutability #
+
+### What is the mutability?
+
+Mutability is the attribute that defines whether an entity's files can be changed by the user from one version to another.
+
+It is important to note that for all types of mutability the user is able to add and remove files, the mutability attribute refers to editing files already added.
+
+You must define carefully because once mutability is defined, it cannot be changed.
+
+
+### Where to define mutability policy?
+
+Mutability is defined when creating a new entity. 
+
+With the command ```ml-git (dataset|label|model) create``` you must pass the mandatory attribute ```mutability``` to define the type of mutability for the created entity.
+
+Your entity specification file (.spec) should look like this:
+
+```
+dataset:
+  categories:
+    - computer-vision
+    - images
+  mutability: flexible
+  manifest:
+    store: s3h://mlgit-datasets
+  name: imagenet8
+  version: 1
+```
+
+If you create an entity without using the create command and without mutability, when trying to perform the ```ml-git (dataset|label|model) add``` the command will not be executed and you will be informed that you must define a mutability for that new entity.
+
+Note:
+```
+For entities that were created before the mutability parameter became mandatory (version 0.0.1) and that did not define mutability, ml-git treats these entities as strict.
+```
+
+Because it is an attribute defined in the spec, you can define a type of mutability for each entity that the project has. For example, you can have in the same project a dataset-ex1 that has strict mutability while a dataset-ex2 has flexible mutability.
+
+### Polices
+
+
+Currently the user can define one of the following three types of mutability for their entities:
+
+* Mutable:
+    * Disable ml-git cache (will slow down some operations).
+    * Files that were already added may be changed and added again.
+
+* Flexible:
+  * Added files will be set to read-only after added to avoid any changes.
+  * If you want to change a file, you MUST use `ml-git <ml-entity> unlock <file>`. About unlock command:
+      * Decouple the file from ml-git cache to avoid propagating changes and creating "corruptions".
+      * Enable file write permission, so that you can edit the file.
+      * If you modify a file without previously executing the unlock command, the file will be considered corrupted.
+
+* Strict:
+  * Added files will be set to read-only after added to avoid any changes.
+  * Once added, the files could not be modified in any other tag.
+
+### Choosing the type of mutability
+
+The type of mutability must be chosen based on the characteristics of the entity you are working with. 
+You must define carefully because once mutability is defined, it cannot be changed.
+
+If you are working with **images**, it is recommended that the type of mutability chosen is **strict**, since it is not common for images to be changed. Rather, new images are added to the set. In a scenario such as data augmentation, new images will be created from the originals, but the originals must remain intact.
+
+If you are working with shared cache we encourage to use mutability **strict** only. Take a look at the document about [centralized cache.](centralized_cache_and_objects.md)
+
+When dealing with files that must be modified over time, such as a **csv** file with your dataset labels, or your **model file**, we encourage you to use **flexible or mutable**. The choice will depend on how often you believe these files will be modified.
+
+
+

--- a/ml_git/commands/descriptor.py
+++ b/ml_git/commands/descriptor.py
@@ -11,6 +11,7 @@ from ml_git.commands import entity
 from ml_git.commands.custom_options import MutuallyExclusiveOption, OptionRequiredIf, DeprecatedOption, \
     DeprecatedOptionsCommand
 from ml_git.commands.utils import set_verbose_mode
+from ml_git.constants import Mutability
 
 commands = [
 
@@ -484,6 +485,7 @@ commands = [
 
         'options': {
             '--category': {'required': True, 'multiple': True, 'help': 'Artifact\'s category name.'},
+            '--mutability': {'required': True, 'type': click.Choice(Mutability.list()), 'help': 'Mutability type.'},
             '--store-type': {'type': click.Choice(['s3h', 'azureblobh', 'gdriveh']),
                              'help': 'Data store type [default: s3h].', 'default': 's3h'},
             ('--version-number', '--version'): {'help': 'Number of artifact version.', 'default': 1,

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -300,7 +300,7 @@ def validate_spec_hash(the_hash, repotype='dataset'):
 
 
 def create_workspace_tree_structure(repo_type, artifact_name, categories, store_type, bucket_name, version,
-                                    imported_dir):
+                                    imported_dir, mutability):
     # get root path to create directories and files
     path = get_root_path()
     artifact_path = os.path.join(path, repo_type, artifact_name)
@@ -325,6 +325,7 @@ def create_workspace_tree_structure(repo_type, artifact_name, categories, store_
                 'store': store
             },
             'name': artifact_name,
+            'mutability': mutability,
             'version': version
         }
     }

--- a/ml_git/constants.py
+++ b/ml_git/constants.py
@@ -54,6 +54,10 @@ class Mutability(Enum):
     FLEXIBLE = 'flexible'
     MUTABLE = 'mutable'
 
+    @staticmethod
+    def list():
+        return list(map(lambda c: c.value, Mutability))
+
 
 @unique
 class StoreType(Enum):

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -2,6 +2,7 @@
 © Copyright 2020 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
+from ml_git.config import get_sample_spec_doc
 
 output_messages = {
     'INFO_CHECKOUT_LATEST_TAG': 'Performing checkout on the entity\'s lastest tag (%s)',
@@ -12,5 +13,8 @@ output_messages = {
     'ERROR_WITHOUT_TAG_FOR_THIS_ENTITY': 'No entity with that name was found.',
     'ERROR_MULTIPLES_ENTITIES_WITH_SAME_NAME': 'You have more than one entity with the same name. Use one of the following tags to perform the checkout:\n',
     'ERROR_WRONG_VERSION_NUMBER_TO_CHECKOUT': 'The version specified for that entity does not exist. Last entity tag:\n\t%s',
-    'ERROR_UNINITIALIZED_METADATA': 'You don\'t have any metadata initialized'
+    'ERROR_UNINITIALIZED_METADATA': 'You don\'t have any metadata initialized',
+    'ERROR_MISSING_MUTABILITY': 'Missing option "--mutability".  Choose from:\n\tstrict,\n\tflexible,\n\tmutable.',
+    'ERROR_SPEC_WITHOUT_MUTABILITY': 'You need to define a mutability type when creating a new entity. '
+                                     'Your spec should look something like this:' + get_sample_spec_doc('some-bucket')
 }

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -893,7 +893,7 @@ class Repository(object):
 
         try:
             mutability = spec_file[repo_type]['mutability']
-            if mutability not in list(map(lambda c: c.value, Mutability)):
+            if mutability not in Mutability.list():
                 log.error('Invalid mutability type.', class_name=REPOSITORY_CLASS_NAME)
                 return
         except Exception:
@@ -929,8 +929,8 @@ class Repository(object):
         credentials_path = kwargs['credentials_path']
         repo_type = self.__repo_type
         try:
-            create_workspace_tree_structure(repo_type, artifact_name, categories, store_type, bucket_name, version,
-                                            imported_dir)
+            create_workspace_tree_structure(repo_type, artifact_name, categories, store_type, bucket_name,
+                                            version, imported_dir, kwargs['mutability'])
             if start_wizard:
                 has_new_store, store_type, bucket, profile, endpoint_url, git_repo = start_wizard_questions(repo_type)
                 if has_new_store:

--- a/tests/integration/gdrive_store/test_32_gdrive_store.py
+++ b/tests/integration/gdrive_store/test_32_gdrive_store.py
@@ -8,6 +8,7 @@ import unittest
 
 import pytest
 
+from ml_git.constants import Mutability
 from tests.integration.commands import MLGIT_IMPORT, MLGIT_CREATE, MLGIT_INIT
 from tests.integration.helper import ML_GIT_DIR, CREDENTIALS_PATH, ERROR_MESSAGE
 from tests.integration.helper import check_output, clear, init_repository, add_file
@@ -78,19 +79,19 @@ class GdrivePushFilesAcceptanceTests(unittest.TestCase):
     def test_03_create_gdrive(self):
         self.assertIn(messages[0], check_output(MLGIT_INIT))
 
-        self.assertIn(messages[38], check_output(MLGIT_CREATE % ('dataset', 'dataset-ex') +
-                                                 ' --category=imgs --bucket-name=test'
-                                                 ' --import-url=%s --credentials-path=%s' % (self.gdrive_links['test-folder'],
-                                                                                             CREDENTIALS_PATH)))
+        self.assertIn(messages[38], check_output(MLGIT_CREATE % ('dataset', 'dataset-ex')
+                                                 + ' --category=imgs --bucket-name=test --import-url=%s --credentials-path=%s '
+                                                 % (self.gdrive_links['test-folder'], CREDENTIALS_PATH)
+                                                 + 'mutability=%s' % (Mutability.STRICT.value)))
 
         file_a_test_folder = os.path.join('dataset', 'dataset-ex', 'data', 'test-folder', 'A')
 
         self.assertTrue(os.path.exists(file_a_test_folder))
 
-        self.assertIn(messages[38], check_output(MLGIT_CREATE % ('dataset', 'dataset-ex2') +
-                                                 ' --category=imgs --bucket-name=test'
-                                                 ' --import-url=%s --credentials-path=%s' % (self.gdrive_links['B'],
-                                                                                             CREDENTIALS_PATH)))
+        self.assertIn(messages[38], check_output(MLGIT_CREATE % ('dataset', 'dataset-ex2')
+                                                 + ' --category=imgs --bucket-name=test --import-url=%s --credentials-path=%s'
+                                                 % (self.gdrive_links['B'], CREDENTIALS_PATH)
+                                                 + 'mutability=%s' % (Mutability.STRICT.value)))
 
         file_b = os.path.join('dataset', 'dataset-ex2', 'data', 'B')
 

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -15,7 +15,7 @@ from zipfile import ZipFile
 
 from ruamel.yaml import YAML
 
-from ml_git.constants import StoreType, GLOBAL_ML_GIT_CONFIG
+from ml_git.constants import StoreType, GLOBAL_ML_GIT_CONFIG, Mutability
 from tests.integration.commands import MLGIT_INIT, MLGIT_REMOTE_ADD, MLGIT_ENTITY_INIT, MLGIT_ADD, \
     MLGIT_STORE_ADD_WITH_TYPE, MLGIT_REMOTE_ADD_GLOBAL, MLGIT_STORE_ADD
 from tests.integration.output_messages import messages
@@ -124,6 +124,7 @@ def init_repository(entity, self, version=1, store_type='s3h', profile=PROFILE, 
                 'files': 'MANIFEST.yaml',
                 'store': '%s://mlgit' % store_type
             },
+            'mutability': Mutability.STRICT.value,
             'name': artifact_name,
             'version': version
         }

--- a/tests/integration/output_messages.py
+++ b/tests/integration/output_messages.py
@@ -63,7 +63,7 @@ messages = [
     'No current tag for [%s]. commit first',  # 55
     'ML %s\n|-- computer-vision\n|   |-- images\n|   |   |-- %s-ex\n',  # 56
     '-- %s : %s-ex --\ncategories:\n- computer-vision\n- images\nmanifest:\n  amount: 5\n  '
-    'files: MANIFEST.yaml\n  size: 14 KB\n  store: s3h://mlgit\nname: %s-ex\nversion: %s\n\n',  # 57
+    'files: MANIFEST.yaml\n  size: 14 KB\n  store: s3h://mlgit\nmutability: strict\nname: %s-ex\nversion: %s\n\n',  # 57
     '%d missing descriptor files. Consider using the --thorough option.',  # 58
     '%d missing descriptor files. Download:',  # 59
     'Corruption detected for chunk [%s]',  # 60

--- a/tests/integration/test_19_create.py
+++ b/tests/integration/test_19_create.py
@@ -7,7 +7,8 @@ import os
 import unittest
 
 import pytest
-from ml_git.constants import StoreType
+from ml_git.constants import StoreType, Mutability
+from ml_git.ml_git_message import output_messages
 
 from tests.integration.commands import MLGIT_CREATE, MLGIT_INIT
 from tests.integration.helper import check_output, ML_GIT_DIR, IMPORT_PATH, create_file, ERROR_MESSAGE, yaml_processor, \
@@ -22,8 +23,8 @@ class CreateAcceptanceTests(unittest.TestCase):
         os.makedirs(os.path.join(self.tmp_dir, IMPORT_PATH))
         self.assertIn(messages[38], check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
                                                  + ' --category=imgs --store-type=' + store_type + ' --bucket-name=minio'
-                                                 + ' --version=1 --import="' + os.path.join(self.tmp_dir,
-                                                                                                   IMPORT_PATH) + '"'))
+                                                 + ' --version=1 --import="' + os.path.join(self.tmp_dir, IMPORT_PATH) +
+                                                 '" --mutability=' + Mutability.STRICT.value))
 
     def check_folders(self, entity_type, store_type=StoreType.S3H.value):
         folder_data = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'data')
@@ -48,6 +49,18 @@ class CreateAcceptanceTests(unittest.TestCase):
         self.create_command(entity_type, store_type)
         self.check_folders(entity_type, store_type)
 
+    def create_with_mutability(self, entity_type, mutability):
+        self.assertIn(messages[0], check_output(MLGIT_INIT))
+        self.assertIn(messages[38], check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
+                                                 + ' --category=img --version-number=1 '
+                                                   '--credentials-path=test --mutability=' + mutability))
+        spec = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'dataset-ex.spec')
+        with open(spec, 'r') as s:
+            spec_file = yaml_processor.load(s)
+            self.assertEqual(spec_file['dataset']['mutability'], mutability)
+            self.assertEqual(spec_file['dataset']['name'], 'dataset-ex')
+            self.assertEqual(spec_file['dataset']['version'], 1)
+
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_01_create_dataset(self):
         self._create_entity('dataset')
@@ -68,7 +81,7 @@ class CreateAcceptanceTests(unittest.TestCase):
 
         self.assertIn(messages[38], check_output(
             'ml-git dataset create dataset-ex --category=imgs --store-type=s3h --bucket-name=minio '
-            '--version=1 --import="%s"' % os.path.join(self.tmp_dir, IMPORT_PATH)))
+            '--version=1 --import="%s" --mutability=strict' % os.path.join(self.tmp_dir, IMPORT_PATH)))
 
         folder_data = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'data')
         spec = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'dataset-ex.spec')
@@ -96,7 +109,8 @@ class CreateAcceptanceTests(unittest.TestCase):
         self.assertFalse(os.path.exists(dataset_path))
         self.assertIn(ERROR_MESSAGE, check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
                                                   + ' --category=imgs --store-type=s3h --bucket-name=minio'
-                                                  + ' --version=1 --import=' + IMPORT_PATH+'wrong'))
+                                                  + ' --version=1 --import=' + IMPORT_PATH+'wrong'
+                                                  + ' --mutability=' + Mutability.STRICT.value))
         self.assertFalse(os.path.exists(dataset_path))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
@@ -107,7 +121,8 @@ class CreateAcceptanceTests(unittest.TestCase):
 
         self.assertIn(messages[88], check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
                                                  + ' --category=imgs --store-type=s3h --bucket-name=minio'
-                                                 + ' --version=1 --import=' + IMPORT_PATH))
+                                                 + ' --version=1 --import=' + IMPORT_PATH
+                                                 + ' --mutability=' + Mutability.STRICT.value))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_07_create_entity_with_gdriveh_storage(self):
@@ -122,14 +137,16 @@ class CreateAcceptanceTests(unittest.TestCase):
         entity_type = 'dataset'
         self.assertIn(messages[0], check_output(MLGIT_INIT))
         self.assertIn(messages[89], check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
-                                                 + ' --category=img --version=1 --import="import_path" --import-url="import_url"'))
+                                                 + ' --category=img --version=1 --import="import_path" --import-url="import_url"'
+                                                 + ' --mutability=' + Mutability.STRICT.value))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_10_create_with_import_url_without_credentials_path(self):
         entity_type = 'dataset'
         self.assertIn(messages[0], check_output(MLGIT_INIT))
         self.assertIn(messages[90], check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
-                                                 + ' --category=img --version=1 --import-url="import_url"'))
+                                                 + ' --category=img --version=1 --import-url="import_url"'
+                                                 + ' --mutability=' + Mutability.STRICT.value))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_11_create_with_wrong_import_url(self):
@@ -137,7 +154,7 @@ class CreateAcceptanceTests(unittest.TestCase):
         self.assertIn(messages[0], check_output(MLGIT_INIT))
         self.assertIn(messages[91] % 'import_url', check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
                                                                 + ' --category=img --version=1 --import-url="import_url" '
-                                                                  '--credentials-path=test'))
+                                                                  '--credentials-path=test' + ' --mutability=' + Mutability.STRICT.value))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_12_create_with_unzip_option(self):
@@ -148,7 +165,8 @@ class CreateAcceptanceTests(unittest.TestCase):
         create_zip_file(IMPORT_PATH, 3)
         self.assertTrue(os.path.exists(os.path.join(import_path, 'file.zip')))
         self.assertIn(messages[92], check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
-                                                 + ' --category=imgs --import="' + import_path + '" --unzip'))
+                                                 + ' --category=imgs --import="' + import_path + '" --unzip'
+                                                 + ' --mutability=' + Mutability.STRICT.value))
         folder_data = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'data', 'file')
         self.assertTrue(os.path.exists(folder_data))
         files = [f for f in os.listdir(folder_data)]
@@ -163,8 +181,34 @@ class CreateAcceptanceTests(unittest.TestCase):
         self.assertIn(messages[0], check_output(MLGIT_INIT))
         os.makedirs(os.path.join(self.tmp_dir, IMPORT_PATH))
         result = check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex') + ' --category=imgs --store-type=s3h --bucket-name=minio'
-                              + ' --version-number=1 --import="' + os.path.join(self.tmp_dir, IMPORT_PATH) + '"')
+                              + ' --version-number=1 --import="' + os.path.join(self.tmp_dir, IMPORT_PATH) + '"'
+                              + ' --mutability=' + Mutability.STRICT.value)
 
         self.assertIn(messages[100] % ('--version-number', '--version'), result)
         self.assertIn(messages[38], result)
         self.check_folders(entity_type, StoreType.S3H.value)
+
+    @pytest.mark.usefixtures('switch_to_tmp_dir')
+    def test_13_create_with_mutability_mutable(self):
+        entity_type = 'dataset'
+        mutability = 'mutable'
+        self.create_with_mutability(entity_type, mutability)
+
+    @pytest.mark.usefixtures('switch_to_tmp_dir')
+    def test_14_create_with_mutability_flexible(self):
+        entity_type = 'dataset'
+        mutability = 'flexible'
+        self.create_with_mutability(entity_type, mutability)
+
+    @pytest.mark.usefixtures('switch_to_tmp_dir')
+    def test_15_create_with_mutability_strict(self):
+        entity_type = 'dataset'
+        mutability = 'strict'
+        self.create_with_mutability(entity_type, mutability)
+
+    @pytest.mark.usefixtures('switch_to_tmp_dir')
+    def test_15_create_without_mutability_option(self):
+        entity_type = 'dataset'
+        self.assertIn(messages[0], check_output(MLGIT_INIT))
+        self.assertIn(output_messages['ERROR_MISSING_MUTABILITY'], check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
+                                                                                + ' --category=img --version-number=1'))

--- a/tests/integration/test_24_api.py
+++ b/tests/integration/test_24_api.py
@@ -9,6 +9,7 @@ import unittest
 import pytest
 
 from ml_git import api
+from ml_git.constants import Mutability
 from tests.integration.helper import ML_GIT_DIR, CLONE_FOLDER, check_output, init_repository, create_git_clone_repo, \
     clear, yaml_processor
 
@@ -48,6 +49,7 @@ class APIAcceptanceTests(unittest.TestCase):
                     'files': 'MANIFEST.yaml',
                     'store': 's3h://mlgit'
                 },
+                'mutability': Mutability.STRICT.value,
                 'name': 'dataset-ex',
                 'version': 9
             }

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -16,7 +16,7 @@ from ml_git.config import validate_config_spec_hash, get_sample_config_spec, get
     get_index_path, get_objects_path, get_cache_path, get_metadata_path, import_dir, \
     extract_store_info_from_list, create_workspace_tree_structure, get_batch_size, merge_conf, \
     merge_local_with_global_config, mlgit_config, save_global_config_in_local
-from ml_git.constants import BATCH_SIZE_VALUE, BATCH_SIZE
+from ml_git.constants import BATCH_SIZE_VALUE, BATCH_SIZE, Mutability
 from ml_git.utils import get_root_path, yaml_load
 
 
@@ -132,12 +132,13 @@ class ConfigTestCases(unittest.TestCase):
         IMPORT_PATH = os.path.join(os.getcwd(), 'test', 'src')
         os.makedirs(IMPORT_PATH)
         self.assertTrue(create_workspace_tree_structure('repotype', 'artefact_name',
-                                                        ['imgs', 'old', 'blue'], 's3h', 'minio', 2, IMPORT_PATH))
+                                                        ['imgs', 'old', 'blue'], 's3h', 'minio', 2, IMPORT_PATH, Mutability.STRICT.value))
 
         spec_path = os.path.join(os.getcwd(), os.sep.join(['repotype', 'artefact_name', 'artefact_name.spec']))
         spec1 = yaml_load(spec_path)
         self.assertEqual(spec1['repotype']['manifest']['store'], 's3h://minio')
         self.assertEqual(spec1['repotype']['name'], 'artefact_name')
+        self.assertEqual(spec1['repotype']['mutability'], 'strict')
         self.assertEqual(spec1['repotype']['version'], 2)
 
         shutil.rmtree(IMPORT_PATH)


### PR DESCRIPTION
We added the `--mutability` option to the `ml-git create` command, needed to set mutability during entity creation.
