### PR TITLE
[plural entity names] Adding support to plural entity names

### DIFF
--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -14,7 +14,7 @@ from ml_git import log
 from ml_git.config import get_metadata_path
 from ml_git.constants import METADATA_MANAGER_CLASS_NAME, HEAD_1, RGX_ADDED_FILES, RGX_DELETED_FILES, RGX_SIZE_FILES, \
     RGX_AMOUNT_FILES, TAG, AUTHOR, EMAIL, DATE, MESSAGE, ADDED, SIZE, AMOUNT, DELETED, SPEC_EXTENSION, \
-    DEFAULT_BRANCH_FOR_EMPTY_REPOSITORY
+    DEFAULT_BRANCH_FOR_EMPTY_REPOSITORY, EntityType
 from ml_git.manifest import Manifest
 from ml_git.ml_git_message import output_messages
 from ml_git.utils import get_root_path, ensure_path_exists, yaml_load, RootPathException, get_yaml_str
@@ -245,16 +245,16 @@ class MetadataRepo(object):
     def metadata_print(metadata_file, spec_name):
         md = yaml_load(metadata_file)
 
-        sections = ['dataset', 'model', 'labels']
+        sections = EntityType.to_list()
         for section in sections:
-            if section in ['model', 'dataset', 'labels']:
+            if section in EntityType.to_list():
                 try:
                     md[section]  # 'hack' to ensure we don't print something useless
                     # 'dataset' not present in 'model' and vice versa
                     print('-- %s : %s --' % (section, spec_name))
                 except Exception:
                     continue
-            elif section not in ['model', 'dataset', 'labels']:
+            elif section not in EntityType.to_list():
                 print('-- %s --' % (section))
             try:
                 print(get_yaml_str(md[section]))
@@ -292,7 +292,6 @@ class MetadataRepo(object):
 
     def show(self, spec):
         specs = self.metadata_spec_from_name(spec)
-
         for specpath in specs:
             self.metadata_print(specpath, spec)
 
@@ -427,7 +426,7 @@ class MetadataRepo(object):
 
 
 class MetadataManager(MetadataRepo):
-    def __init__(self, config, type='model'):
+    def __init__(self, config, type=EntityType.MODELS.value):
         self.path = get_metadata_path(config, type)
         self.git = config[type]['git']
 

--- a/ml_git/admin.py
+++ b/ml_git/admin.py
@@ -31,7 +31,6 @@ def init_mlgit():
         return
     except Exception:
         pass
-
     try:
         os.mkdir('.ml-git')
     except PermissionError:

--- a/ml_git/api.py
+++ b/ml_git/api.py
@@ -7,17 +7,22 @@ import os
 import shutil
 import tempfile
 
-from ml_git import log, admin
+from ml_git import admin
+from ml_git import log
 from ml_git.admin import init_mlgit
 from ml_git.config import config_load
-from ml_git.constants import StoreType, EntityType
-from ml_git.repository import Repository
+from ml_git.constants import EntityType
+from ml_git.constants import StoreType
 from ml_git.log import init_logger
+from ml_git.repository import Repository
 
 init_logger()
 
 
 def get_repository_instance(repo_type):
+    entity_types = [entity.value for entity in EntityType]
+    if repo_type not in entity_types and repo_type != 'project':
+        raise RuntimeError('Invalid entity type. Valid values are: %s' % entity_types)
     return Repository(config_load(), repo_type)
 
 
@@ -38,10 +43,10 @@ def checkout(entity, tag, sampling=None, retries=2, force=False, dataset=False, 
     """This command allows retrieving the data of a specific version of an ML entity.
 
     Example:
-        checkout('dataset', 'computer-vision__images3__imagenet__1')
+        checkout('datasets', 'computer-vision__images3__imagenet__1')
 
     Args:
-        entity (str): The type of an ML entity. (dataset, labels or model)
+        entity (str): The type of an ML entity. (datasets, labels or models)
         tag (str): An ml-git tag to identify a specific version of an ML entity.
         sampling (dict): group: <amount>:<group> The group sample option consists of amount and group used to
                                  download a sample.\n
@@ -61,7 +66,7 @@ def checkout(entity, tag, sampling=None, retries=2, force=False, dataset=False, 
 
     """
 
-    repo = Repository(config_load(), entity)
+    repo = get_repository_instance(entity)
     repo.update()
     if sampling is not None and not validate_sample(sampling):
         return None
@@ -94,7 +99,7 @@ def clone(repository_url, folder=None, track=False):
 
     """
 
-    repo = Repository(config_load(), 'project')
+    repo = get_repository_instance('project')
     if folder is not None:
         repo.clone_config(repository_url, folder, track)
     else:
@@ -111,17 +116,17 @@ def add(entity_type, entity_name, bumpversion=False, fsck=False, file_path=[]):
     """This command will add all the files under the directory into the ml-git index/staging area.
 
     Example:
-        add('dataset', 'dataset-ex', bumpversion=True)
+        add('datasets', 'dataset-ex', bumpversion=True)
 
     Args:
-        entity_type (str): The type of an ML entity. (dataset, labels or model)
+        entity_type (str): The type of an ML entity. (datasets, labels or models)
         entity_name (str): The name of the ML entity you want to add the files.
         bumpversion (bool, optional): Increment the entity version number when adding more files [default: False].
         fsck (bool, optional): Run fsck after command execution [default: False].
         file_path (list, optional): List of files that must be added by the command [default: all files].
     """
 
-    repo = Repository(config_load(), entity_type)
+    repo = get_repository_instance(entity_type)
     repo.add(entity_name, file_path, bumpversion, fsck)
 
 
@@ -129,10 +134,10 @@ def commit(entity, ml_entity_name, commit_message=None, related_dataset=None, re
     """That command commits the index / staging area to the local repository.
 
     Example:
-        commit('dataset', 'dataset-ex')
+        commit('datasets', 'dataset-ex')
 
     Args:
-        entity (str): The type of an ML entity. (dataset, labels or model).
+        entity (str): The type of an ML entity. (datasets, labels or models)
         ml_entity_name (str): Artefact name to commit.
         commit_message (str, optional): Message of commit.
         related_dataset (str, optional): Artefact name of dataset related to commit.
@@ -144,7 +149,7 @@ def commit(entity, ml_entity_name, commit_message=None, related_dataset=None, re
     specs = dict()
 
     if related_dataset:
-        specs['dataset'] = related_dataset
+        specs['datasets'] = related_dataset
 
     if related_labels:
         specs['labels'] = related_labels
@@ -156,16 +161,16 @@ def push(entity, entity_name,  retries=2, clear_on_fail=False):
     """This command allows pushing the data of a specific version of an ML entity.
 
         Example:
-            push('dataset', 'dataset-ex')
+            push('datasets', 'dataset-ex')
 
         Args:
-            entity (str): The type of an ML entity. (dataset, labels or model).
+            entity (str): The type of an ML entity. (datasets, labels or models)
             entity_name (str): An ml-git entity name to identify a ML entity.
             retries (int, optional): Number of retries to upload the files to the storage [default: 2].
             clear_on_fail (bool, optional): Remove the files from the store in case of failure during the push operation [default: False].
     """
 
-    repo = Repository(config_load(), entity)
+    repo = get_repository_instance(entity)
     repo.push(entity_name, retries, clear_on_fail)
 
 
@@ -173,10 +178,10 @@ def create(entity, entity_name, categories, mutability, **kwargs):
     """This command will create the workspace structure with data and spec file for an entity and set the store configurations.
 
         Example:
-            create('dataset', 'dataset-ex', categories=['computer-vision', 'images'], mutability='strict')
+            create('datasets', 'dataset-ex', categories=['computer-vision', 'images'], mutability='strict')
 
         Args:
-            entity (str): The type of an ML entity. (dataset, labels or model).
+            entity (str): The type of an ML entity. (datasets, labels or models)
             entity_name (str): An ml-git entity name to identify a ML entity.
             categories (list): Artifact's category name.
             mutability (str): Mutability type. The mutability options are strict, flexible and mutable.
@@ -196,7 +201,7 @@ def create(entity, entity_name, categories, mutability, **kwargs):
             'import_url': kwargs.get('import_url', None), 'credentials_path': kwargs.get('credentials_path', None),
             'wizard_config': False}
 
-    repo = Repository(config_load(), entity)
+    repo = get_repository_instance(entity)
     repo.create(args)
 
 
@@ -205,16 +210,16 @@ def init(entity):
 
         Examples:
             init('repository')
-            init('dataset')
+            init('datasets')
 
         Args:
-            entity (str): The type of entity that will be initialized (repository, dataset, labels or model).
+            entity (str): The type of an ML entity. (datasets, labels or models)
     """
 
     if entity == 'repository':
         init_mlgit()
     elif entity in EntityType.to_list():
-        repo = Repository(config_load(), entity)
+        repo = get_repository_instance(entity)
         repo.init()
     else:
         log.error('The type of entity entered is invalid. Valid types are: [repository, dataset, labels or model]')
@@ -245,13 +250,13 @@ def remote_add(entity, remote_url, global_configuration=False):
     """This command will add a remote to store the metadata from this ml-git project.
 
         Examples:
-            remote_add('dataset', 'https://git@github.com/mlgit-datasets')
+            remote_add('datasets', 'https://git@github.com/mlgit-datasets')
 
         Args:
-            entity (str): The type of an ML entity. (repository, dataset, labels or model).
+            entity (str): The type of an ML entity. (datasets, labels or models)
             remote_url(str): URL of an existing remote git repository.
             global_configuration (bool, optional): Use this option to set configuration at global level [default: False].
     """
 
-    repo = Repository(config_load(), entity)
+    repo = get_repository_instance(entity)
     repo.repo_remote_add(entity, remote_url, global_configuration)

--- a/ml_git/api.py
+++ b/ml_git/api.py
@@ -11,8 +11,7 @@ from ml_git import admin
 from ml_git import log
 from ml_git.admin import init_mlgit
 from ml_git.config import config_load
-from ml_git.constants import EntityType
-from ml_git.constants import StoreType
+from ml_git.constants import EntityType, StoreType
 from ml_git.log import init_logger
 from ml_git.repository import Repository
 
@@ -20,9 +19,9 @@ init_logger()
 
 
 def get_repository_instance(repo_type):
-    entity_types = [entity.value for entity in EntityType]
-    if repo_type not in entity_types and repo_type != 'project':
-        raise RuntimeError('Invalid entity type. Valid values are: %s' % entity_types)
+    project_repo_type = 'project'
+    if repo_type not in EntityType.to_list() and repo_type != project_repo_type:
+        raise RuntimeError('Invalid entity type. Valid values are: %s' % EntityType.to_list())
     return Repository(config_load(), repo_type)
 
 

--- a/ml_git/commands/descriptor.py
+++ b/ml_git/commands/descriptor.py
@@ -19,7 +19,7 @@ commands = [
         'name': 'init',
 
         'callback': entity.init,
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'help': 'Init a ml-git %s repository.'
 
@@ -29,7 +29,7 @@ commands = [
         'name': 'list',
 
         'callback': entity.list_entity,
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'help': 'List %s managed under this ml-git repository.'
 
@@ -39,7 +39,7 @@ commands = [
         'name': 'fsck',
 
         'callback': entity.fsck,
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'help': 'Perform fsck on %s in this ml-git repository.'
 
@@ -48,7 +48,7 @@ commands = [
     {
         'name': 'push',
         'callback': entity.push,
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'arguments': {
             'ml-entity-name': {},
@@ -66,7 +66,7 @@ commands = [
     {
         'name': 'checkout',
         'callback': entity.checkout,
-        'groups': [entity.dataset],
+        'groups': [entity.datasets],
 
         'options': {
             '--sample-type': {'type': click.Choice(['group', 'range', 'random'])},
@@ -116,7 +116,7 @@ commands = [
     {
         'name': 'checkout',
         'callback': entity.checkout,
-        'groups': [entity.model],
+        'groups': [entity.models],
         'options': {
             ('--with-labels', '-l'): {'is_flag': True, 'default': False, 'help': help_msg.ASSOCIATED_WITH_LABELS},
             ('--with-dataset', '-d'): {'is_flag': True, 'default': False, 'help': help_msg.ASSOCIATED_WITH_DATASET},
@@ -139,7 +139,7 @@ commands = [
     {
         'name': 'fetch',
         'callback': entity.fetch,
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'arguments': {
             'ml-entity-tag': {},
@@ -165,7 +165,7 @@ commands = [
         'name': 'status',
 
         'callback': entity.status,
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'arguments': {
             'ml-entity-name': {},
@@ -184,7 +184,7 @@ commands = [
         'name': 'show',
 
         'callback': entity.show,
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'arguments': {
             'ml-entity-name': {}
@@ -197,7 +197,7 @@ commands = [
     {
         'name': 'add',
         'callback': entity.add,
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'arguments': {
             'ml-entity-name': {},
@@ -216,7 +216,7 @@ commands = [
     {
         'name': 'commit',
         'callback': entity.commit,
-        'groups': [entity.dataset],
+        'groups': [entity.datasets],
 
         'arguments': {
             'ml-entity-name': {},
@@ -259,7 +259,7 @@ commands = [
     {
         'name': 'commit',
         'callback': entity.commit,
-        'groups': [entity.model],
+        'groups': [entity.models],
 
         'arguments': {
             'ml-entity-name': {},
@@ -315,7 +315,7 @@ commands = [
 
         'callback': entity.reset,
 
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'arguments': {
             'ml-entity-name': {},
@@ -338,7 +338,7 @@ commands = [
 
         'callback': entity.import_tag,
 
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'arguments': {
             'bucket-name': {'required': True},
@@ -369,7 +369,7 @@ commands = [
 
         'callback': entity.export_tag,
 
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'arguments': {
             'ml_entity_tag': {'required': True},
@@ -394,7 +394,7 @@ commands = [
 
         'callback': entity.update,
 
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'help': 'This command will update the metadata repository.'
 
@@ -405,7 +405,7 @@ commands = [
 
         'callback': entity.branch,
 
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'arguments': {
             'ml-entity-name': {}
@@ -420,7 +420,7 @@ commands = [
 
         'callback': entity.remote_fsck,
 
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'options': {
             '--thorough': {'is_flag': True, 'help': help_msg.THOROUGH_OPTION},
@@ -441,7 +441,7 @@ commands = [
 
         'callback': entity.create,
 
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'options': {
             '--category': {'required': True, 'multiple': True, 'help': help_msg.CATEGORY_OPTION},
@@ -478,7 +478,7 @@ commands = [
 
         'callback': entity.unlock,
 
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'arguments': {
             'ml-entity-name': {},
@@ -494,7 +494,7 @@ commands = [
 
         'callback': entity.log,
 
-        'groups': [entity.dataset, entity.model, entity.labels],
+        'groups': [entity.datasets, entity.models, entity.labels],
 
         'arguments': {
             'ml-entity-name': {},

--- a/ml_git/commands/entity.py
+++ b/ml_git/commands/entity.py
@@ -3,14 +3,16 @@
 SPDX-License-Identifier: GPL-2.0-only
 """
 
-from ml_git.commands.utils import repositories, DATASET, MODEL, LABELS
-
-from ml_git.commands.general import mlgit
+import click
 from click_didyoumean import DYMGroup
 
+from ml_git.commands.general import mlgit
+from ml_git.commands.utils import repositories, LABELS, DATASETS, MODELS
 
-@mlgit.group(DATASET, help='Management of datasets within this ml-git repository.', cls=DYMGroup)
-def dataset():
+
+@mlgit.group(DATASETS, help='Management of datasets within this ml-git repository.', cls=DYMGroup)
+@click.pass_context
+def dataset(ctx):
     """
     Management of datasets within this ml-git repository.
     """
@@ -25,8 +27,9 @@ def dt_tag_group():
     pass
 
 
-@mlgit.group(MODEL, help='Management of models within this ml-git repository.', cls=DYMGroup)
-def model():
+@mlgit.group(MODELS, help='Management of models within this ml-git repository.', cls=DYMGroup)
+@click.pass_context
+def model(ctx):
     """
     Management of models within this ml-git repository.
     """
@@ -125,14 +128,14 @@ def commit(context, **kwargs):
     dataset_tag = None
     labels_tag = None
 
-    if repo_type == MODEL:
+    if repo_type == MODELS:
         dataset_tag = kwargs['dataset']
         labels_tag = kwargs['labels']
     elif repo_type == LABELS:
         dataset_tag = kwargs['dataset']
     tags = {}
     if dataset_tag is not None:
-        tags['dataset'] = dataset_tag
+        tags['datasets'] = dataset_tag
     if labels_tag is not None:
         tags['labels'] = labels_tag
 

--- a/ml_git/commands/entity.py
+++ b/ml_git/commands/entity.py
@@ -8,18 +8,19 @@ from click_didyoumean import DYMGroup
 
 from ml_git.commands.general import mlgit
 from ml_git.commands.utils import repositories, LABELS, DATASETS, MODELS
+from ml_git.constants import EntityType
 
 
 @mlgit.group(DATASETS, help='Management of datasets within this ml-git repository.', cls=DYMGroup)
 @click.pass_context
-def dataset(ctx):
+def datasets(ctx):
     """
     Management of datasets within this ml-git repository.
     """
     pass
 
 
-@dataset.group('tag', help='Management of tags for this entity.', cls=DYMGroup)
+@datasets.group('tag', help='Management of tags for this entity.', cls=DYMGroup)
 def dt_tag_group():
     """
     Management of tags for this entity.
@@ -29,14 +30,14 @@ def dt_tag_group():
 
 @mlgit.group(MODELS, help='Management of models within this ml-git repository.', cls=DYMGroup)
 @click.pass_context
-def model(ctx):
+def models(ctx):
     """
     Management of models within this ml-git repository.
     """
     pass
 
 
-@model.group('tag', help='Management of tags for this entity.', cls=DYMGroup)
+@models.group('tag', help='Management of tags for this entity.', cls=DYMGroup)
 def md_tag_group():
     """
     Management of tags for this entity.
@@ -135,9 +136,9 @@ def commit(context, **kwargs):
         dataset_tag = kwargs['dataset']
     tags = {}
     if dataset_tag is not None:
-        tags['datasets'] = dataset_tag
+        tags[EntityType.DATASETS.value] = dataset_tag
     if labels_tag is not None:
-        tags['labels'] = labels_tag
+        tags[EntityType.LABELS.value] = labels_tag
 
     repositories[repo_type].commit(entity_name, tags, version_number, run_fsck, msg)
 

--- a/ml_git/commands/general.py
+++ b/ml_git/commands/general.py
@@ -4,17 +4,17 @@ SPDX-License-Identifier: GPL-2.0-only
 """
 
 import click
+from click_didyoumean import DYMGroup
 from click_plugins import with_plugins
 from pkg_resources import iter_entry_points
 
-from ml_git.commands.custom_group import CustomMultiGroup
 from ml_git.commands.utils import repositories, PROJECT, set_verbose_mode
 from ml_git.utils import check_metadata_directories
 from ml_git.version import get_version
 
 
 @with_plugins(iter_entry_points('mlgit.plugins'))
-@click.group(cls=CustomMultiGroup)
+@click.group(cls=DYMGroup)
 @click.version_option(version=get_version(),  message='%(prog)s %(version)s')
 @click.help_option(hidden=True)
 def mlgit():

--- a/ml_git/commands/general.py
+++ b/ml_git/commands/general.py
@@ -4,19 +4,21 @@ SPDX-License-Identifier: GPL-2.0-only
 """
 
 import click
-from click_didyoumean import DYMGroup
 from click_plugins import with_plugins
 from pkg_resources import iter_entry_points
 
+from ml_git.commands.custom_group import CustomMultiGroup
 from ml_git.commands.utils import repositories, PROJECT, set_verbose_mode
+from ml_git.utils import check_metadata_directories
 from ml_git.version import get_version
 
 
 @with_plugins(iter_entry_points('mlgit.plugins'))
-@click.group(cls=DYMGroup)
+@click.group(cls=CustomMultiGroup)
 @click.version_option(version=get_version(),  message='%(prog)s %(version)s')
 @click.help_option(hidden=True)
 def mlgit():
+    check_metadata_directories()
     pass
 
 

--- a/ml_git/commands/general.py
+++ b/ml_git/commands/general.py
@@ -19,7 +19,6 @@ from ml_git.version import get_version
 @click.help_option(hidden=True)
 def mlgit():
     check_metadata_directories()
-    pass
 
 
 # Concrete ml-git Commands Implementation

--- a/ml_git/commands/remote.py
+++ b/ml_git/commands/remote.py
@@ -6,12 +6,11 @@ SPDX-License-Identifier: GPL-2.0-only
 import click
 from click_didyoumean import DYMGroup
 
-from ml_git.commands.custom_group import CustomMultiGroup
 from ml_git.commands.repository import repository
 from ml_git.commands.utils import LABELS, repositories, set_verbose_mode, DATASETS, MODELS
 
 
-@repository.group('remote', help='Configure remote ml-git metadata repositories.', cls=CustomMultiGroup)
+@repository.group('remote', help='Configure remote ml-git metadata repositories.', cls=DYMGroup)
 def repo_remote():
     """
     Configure remote ml-git metadata repositories.

--- a/ml_git/commands/remote.py
+++ b/ml_git/commands/remote.py
@@ -6,11 +6,12 @@ SPDX-License-Identifier: GPL-2.0-only
 import click
 from click_didyoumean import DYMGroup
 
+from ml_git.commands.custom_group import CustomMultiGroup
 from ml_git.commands.repository import repository
-from ml_git.commands.utils import DATASET, LABELS, MODEL, repositories, set_verbose_mode
+from ml_git.commands.utils import LABELS, repositories, set_verbose_mode, DATASETS, MODELS
 
 
-@repository.group('remote', help='Configure remote ml-git metadata repositories.', cls=DYMGroup)
+@repository.group('remote', help='Configure remote ml-git metadata repositories.', cls=CustomMultiGroup)
 def repo_remote():
     """
     Configure remote ml-git metadata repositories.
@@ -18,15 +19,16 @@ def repo_remote():
     pass
 
 
-@repo_remote.group('dataset', help='Manage remote ml-git dataset metadata repository.', cls=DYMGroup)
-def repo_remote_ds():
+@repo_remote.group(DATASETS, help='Manage remote ml-git datasets metadata repository.', cls=DYMGroup)
+@click.pass_context
+def repo_remote_ds(ctx):
     """
     Manage remote ml-git dataset metadata repository.
     """
     pass
 
 
-@repo_remote.group('labels', help='Manage remote ml-git labels metadata repository.', cls=DYMGroup)
+@repo_remote.group(LABELS, help='Manage remote ml-git labels metadata repository.', cls=DYMGroup)
 def repo_remote_lb():
     """
     Manage remote ml-git labels metadata repository.
@@ -34,8 +36,9 @@ def repo_remote_lb():
     pass
 
 
-@repo_remote.group('model', help='Manage remote ml-git model metadata repository.', cls=DYMGroup)
-def repo_remote_md():
+@repo_remote.group(MODELS, help='Manage remote ml-git models metadata repository.', cls=DYMGroup)
+@click.pass_context
+def repo_remote_md(ctx):
     """
     Manage remote ml-git model metadata repository.
     """
@@ -48,7 +51,7 @@ def repo_remote_md():
 @click.option('--verbose', is_flag=True, expose_value=False, callback=set_verbose_mode, help='Debug mode')
 @click.help_option(hidden=True)
 def repo_remote_ds_add(**kwargs):
-    repositories[DATASET].repo_remote_add(DATASET, kwargs['remote_url'], kwargs['global'])
+    repositories[DATASETS].repo_remote_add(DATASETS, kwargs['remote_url'], kwargs['global'])
 
 
 @repo_remote_lb.command('add', help='Add remote labels metadata REMOTE_URL to this ml-git repository')
@@ -66,7 +69,7 @@ def repo_remote_lb_add(**kwargs):
 @click.option('--verbose', is_flag=True, expose_value=False, callback=set_verbose_mode, help='Debug mode')
 @click.help_option(hidden=True)
 def repo_remote_md_add(**kwargs):
-    repositories[MODEL].repo_remote_add(MODEL, kwargs['remote_url'], kwargs['global'])
+    repositories[MODELS].repo_remote_add(MODELS, kwargs['remote_url'], kwargs['global'])
 
 
 @repo_remote_ds.command('del', help='Remove remote dataset metadata REMOTE_URL from this ml-git repository')
@@ -74,7 +77,7 @@ def repo_remote_md_add(**kwargs):
 @click.help_option(hidden=True)
 @click.option('--verbose', is_flag=True, expose_value=False, callback=set_verbose_mode, help='Debug mode')
 def repo_remote_ds_del(**kwargs):
-    repositories[DATASET].repo_remote_del(kwargs['global'])
+    repositories[DATASETS].repo_remote_del(kwargs['global'])
 
 
 @repo_remote_lb.command('del', help='Remove remote labels metadata REMOTE_URL from this ml-git repository')
@@ -90,4 +93,4 @@ def repo_remote_lb_del(**kwargs):
 @click.help_option(hidden=True)
 @click.option('--verbose', is_flag=True, expose_value=False, callback=set_verbose_mode, help='Debug mode')
 def repo_remote_md_del(**kwargs):
-    repositories[MODEL].repo_remote_del(kwargs['global'])
+    repositories[MODELS].repo_remote_del(kwargs['global'])

--- a/ml_git/commands/utils.py
+++ b/ml_git/commands/utils.py
@@ -14,7 +14,7 @@ MODELS = EntityType.MODELS.value
 PROJECT = 'project'
 
 
-def init_repository(entity_type='datasets'):
+def init_repository(entity_type=DATASETS):
     return Repository(config_load(), entity_type)
 
 

--- a/ml_git/commands/utils.py
+++ b/ml_git/commands/utils.py
@@ -4,23 +4,24 @@ SPDX-License-Identifier: GPL-2.0-only
 """
 
 from ml_git.config import config_load
+from ml_git.constants import EntityType
 from ml_git.log import set_level
 from ml_git.repository import Repository
 
-DATASET = 'dataset'
-LABELS = 'labels'
-MODEL = 'model'
+DATASETS = EntityType.DATASETS.value
+LABELS = EntityType.LABELS.value
+MODELS = EntityType.MODELS.value
 PROJECT = 'project'
 
 
-def init_repository(entity_type='dataset'):
+def init_repository(entity_type='datasets'):
     return Repository(config_load(), entity_type)
 
 
 repositories = {
-    DATASET: init_repository(DATASET),
+    DATASETS: init_repository(DATASETS),
     LABELS: init_repository(LABELS),
-    MODEL: init_repository(MODEL),
+    MODELS: init_repository(MODELS),
     PROJECT: init_repository(PROJECT)
 }
 

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -20,13 +20,13 @@ mlgit_config = {
     'mlgit_path': '.ml-git',
     'mlgit_conf': 'config.yaml',
 
-    'datasets': {
+    EntityType.DATASETS.value: {
         'git': '',
     },
-    'models': {
+    EntityType.MODELS.value: {
         'git': '',
     },
-    'labels': {
+    EntityType.LABELS.value: {
         'git': '',
     },
 
@@ -128,9 +128,9 @@ def mlgit_config_save(mlgit_file=__get_conf_filepath()):
         return
 
     config = {
-        'datasets': mlgit_config['datasets'],
-        'models': mlgit_config['models'],
-        'labels': mlgit_config['labels'],
+        EntityType.DATASETS.value: mlgit_config[EntityType.DATASETS.value],
+        EntityType.MODELS.value: mlgit_config[EntityType.MODELS.value],
+        EntityType.LABELS.value: mlgit_config[EntityType.LABELS.value],
         'store': mlgit_config['store'],
         'batch_size': mlgit_config['batch_size']
     }
@@ -143,9 +143,9 @@ def save_global_config_in_local(mlgit_file=__get_conf_filepath()):
     merge_local_with_global_config()
 
     config = {
-        'datasets': mlgit_config['datasets'],
-        'models': mlgit_config['models'],
-        'labels': mlgit_config['labels'],
+        EntityType.DATASETS.value: mlgit_config[EntityType.DATASETS.value],
+        EntityType.MODELS.value: mlgit_config[EntityType.MODELS.value],
+        EntityType.LABELS.value: mlgit_config[EntityType.LABELS.value],
         'store': mlgit_config['store'],
         'batch_size': mlgit_config['batch_size']
     }
@@ -164,13 +164,13 @@ def repo_config(repo):
     return mlgit_config['repos'][repo]
 
 
-def get_index_path(config, type='datasets'):
+def get_index_path(config, type=EntityType.DATASETS.value):
     root_path = get_root_path()
     default = os.path.join(root_path, config['mlgit_path'], type, 'index')
     return getOrElse(config[type], 'index_path', default)
 
 
-def get_index_metadata_path(config, type='datasets'):
+def get_index_metadata_path(config, type=EntityType.DATASETS.value):
     default = os.path.join(get_index_path(config, type), 'metadata')
     return getOrElse(config[type], 'index_metadata_path', default)
 
@@ -187,13 +187,13 @@ def get_batch_size(config):
     return batch_size
 
 
-def get_objects_path(config, type='datasets'):
+def get_objects_path(config, type=EntityType.DATASETS.value):
     root_path = get_root_path()
     default = os.path.join(root_path, config['mlgit_path'], type, 'objects')
     return getOrElse(config[type], 'objects_path', default)
 
 
-def get_cache_path(config, type='datasets'):
+def get_cache_path(config, type=EntityType.DATASETS.value):
     root_path = get_root_path()
     default = os.path.join(root_path, config['mlgit_path'], type, 'cache')
     return getOrElse(config[type], 'cache_path', default)
@@ -205,7 +205,7 @@ def get_metadata_path(config, type=EntityType.DATASETS.value):
     return getOrElse(config[type], 'metadata_path', default)
 
 
-def get_refs_path(config, type='datasets'):
+def get_refs_path(config, type=EntityType.DATASETS.value):
     root_path = get_root_path()
     default = os.path.join(root_path, config['mlgit_path'], type, 'refs')
     return getOrElse(config[type], 'refs_path', default)
@@ -251,7 +251,7 @@ def validate_bucket_config(the_bucket_hash, store_type=StoreType.S3H.value):
     return True
 
 
-def get_sample_spec_doc(bucket, repotype='datasets'):
+def get_sample_spec_doc(bucket, repotype=EntityType.DATASETS.value):
     doc = '''
       %s:
         categories:
@@ -267,12 +267,12 @@ def get_sample_spec_doc(bucket, repotype='datasets'):
     return doc
 
 
-def get_sample_spec(bucket, repotype='datasets'):
+def get_sample_spec(bucket, repotype=EntityType.DATASETS.value):
     c = yaml_load_str(get_sample_spec_doc(bucket, repotype))
     return c
 
 
-def validate_spec_hash(the_hash, repotype='datasets'):
+def validate_spec_hash(the_hash, repotype=EntityType.DATASETS.value):
     if the_hash in [None, {}]:
         return False
 

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -11,7 +11,7 @@ from halo import Halo
 
 from ml_git import spec
 from ml_git.constants import FAKE_STORE, BATCH_SIZE_VALUE, BATCH_SIZE, StoreType, GLOBAL_ML_GIT_CONFIG, \
-    PUSH_THREADS_COUNT, SPEC_EXTENSION
+    PUSH_THREADS_COUNT, SPEC_EXTENSION, EntityType
 from ml_git.utils import getOrElse, yaml_load, yaml_save, get_root_path, yaml_load_str
 
 push_threads = os.cpu_count()*5
@@ -20,10 +20,10 @@ mlgit_config = {
     'mlgit_path': '.ml-git',
     'mlgit_conf': 'config.yaml',
 
-    'dataset': {
+    'datasets': {
         'git': '',
     },
-    'model': {
+    'models': {
         'git': '',
     },
     'labels': {
@@ -128,8 +128,8 @@ def mlgit_config_save(mlgit_file=__get_conf_filepath()):
         return
 
     config = {
-        'dataset': mlgit_config['dataset'],
-        'model': mlgit_config['model'],
+        'datasets': mlgit_config['datasets'],
+        'models': mlgit_config['models'],
         'labels': mlgit_config['labels'],
         'store': mlgit_config['store'],
         'batch_size': mlgit_config['batch_size']
@@ -143,8 +143,8 @@ def save_global_config_in_local(mlgit_file=__get_conf_filepath()):
     merge_local_with_global_config()
 
     config = {
-        'dataset': mlgit_config['dataset'],
-        'model': mlgit_config['model'],
+        'datasets': mlgit_config['datasets'],
+        'models': mlgit_config['models'],
         'labels': mlgit_config['labels'],
         'store': mlgit_config['store'],
         'batch_size': mlgit_config['batch_size']
@@ -164,13 +164,13 @@ def repo_config(repo):
     return mlgit_config['repos'][repo]
 
 
-def get_index_path(config, type='dataset'):
+def get_index_path(config, type='datasets'):
     root_path = get_root_path()
     default = os.path.join(root_path, config['mlgit_path'], type, 'index')
     return getOrElse(config[type], 'index_path', default)
 
 
-def get_index_metadata_path(config, type='dataset'):
+def get_index_metadata_path(config, type='datasets'):
     default = os.path.join(get_index_path(config, type), 'metadata')
     return getOrElse(config[type], 'index_metadata_path', default)
 
@@ -187,25 +187,25 @@ def get_batch_size(config):
     return batch_size
 
 
-def get_objects_path(config, type='dataset'):
+def get_objects_path(config, type='datasets'):
     root_path = get_root_path()
     default = os.path.join(root_path, config['mlgit_path'], type, 'objects')
     return getOrElse(config[type], 'objects_path', default)
 
 
-def get_cache_path(config, type='dataset'):
+def get_cache_path(config, type='datasets'):
     root_path = get_root_path()
     default = os.path.join(root_path, config['mlgit_path'], type, 'cache')
     return getOrElse(config[type], 'cache_path', default)
 
 
-def get_metadata_path(config, type='dataset'):
+def get_metadata_path(config, type=EntityType.DATASETS.value):
     root_path = get_root_path()
     default = os.path.join(root_path, config['mlgit_path'], type, 'metadata')
     return getOrElse(config[type], 'metadata_path', default)
 
 
-def get_refs_path(config, type='dataset'):
+def get_refs_path(config, type='datasets'):
     root_path = get_root_path()
     default = os.path.join(root_path, config['mlgit_path'], type, 'refs')
     return getOrElse(config[type], 'refs_path', default)
@@ -251,7 +251,7 @@ def validate_bucket_config(the_bucket_hash, store_type=StoreType.S3H.value):
     return True
 
 
-def get_sample_spec_doc(bucket, repotype='dataset'):
+def get_sample_spec_doc(bucket, repotype='datasets'):
     doc = '''
       %s:
         categories:
@@ -267,12 +267,12 @@ def get_sample_spec_doc(bucket, repotype='dataset'):
     return doc
 
 
-def get_sample_spec(bucket, repotype='dataset'):
+def get_sample_spec(bucket, repotype='datasets'):
     c = yaml_load_str(get_sample_spec_doc(bucket, repotype))
     return c
 
 
-def validate_spec_hash(the_hash, repotype='dataset'):
+def validate_spec_hash(the_hash, repotype='datasets'):
     if the_hash in [None, {}]:
         return False
 

--- a/ml_git/constants.py
+++ b/ml_git/constants.py
@@ -79,9 +79,9 @@ class StoreType(Enum):
 
 @unique
 class EntityType(Enum):
-    DATASET = 'dataset'
+    DATASETS = 'datasets'
     LABELS = 'labels'
-    MODEL = 'model'
+    MODELS = 'models'
 
     @staticmethod
     def to_list():

--- a/ml_git/file_system/local.py
+++ b/ml_git/file_system/local.py
@@ -31,12 +31,11 @@ from ml_git.spec import spec_parse, search_spec_file
 from ml_git.storages.store_utils import store_factory
 from ml_git.utils import yaml_load, ensure_path_exists, get_path_with_categories, convert_path, \
     normalize_path, posix_path, set_write_read, change_mask_for_routine, run_function_per_group
-DATASETS = EntityType.DATASETS.value
 
 
 class LocalRepository(MultihashFS):
 
-    def __init__(self, config, objects_path, repo_type=DATASETS, block_size=256 * 1024, levels=2):
+    def __init__(self, config, objects_path, repo_type=EntityType.DATASETS.value, block_size=256 * 1024, levels=2):
         self.is_shared_objects = repo_type in config and 'objects_path' in config[repo_type]
         with change_mask_for_routine(self.is_shared_objects):
             super(LocalRepository, self).__init__(objects_path, block_size, levels)

--- a/ml_git/file_system/local.py
+++ b/ml_git/file_system/local.py
@@ -18,7 +18,7 @@ from ml_git import log
 from ml_git.config import get_index_path, get_objects_path, get_refs_path, get_index_metadata_path, \
     get_metadata_path, get_batch_size, get_push_threads_count
 from ml_git.constants import LOCAL_REPOSITORY_CLASS_NAME, STORE_FACTORY_CLASS_NAME, REPOSITORY_CLASS_NAME, \
-    Mutability, StoreType, SPEC_EXTENSION, MANIFEST_FILE, INDEX_FILE
+    Mutability, StoreType, SPEC_EXTENSION, MANIFEST_FILE, INDEX_FILE, EntityType
 from ml_git.file_system.cache import Cache
 from ml_git.file_system.hashfs import MultihashFS
 from ml_git.file_system.index import MultihashIndex, FullIndex, Status
@@ -31,11 +31,12 @@ from ml_git.spec import spec_parse, search_spec_file
 from ml_git.storages.store_utils import store_factory
 from ml_git.utils import yaml_load, ensure_path_exists, get_path_with_categories, convert_path, \
     normalize_path, posix_path, set_write_read, change_mask_for_routine, run_function_per_group
+DATASETS = EntityType.DATASETS.value
 
 
 class LocalRepository(MultihashFS):
 
-    def __init__(self, config, objects_path, repo_type='dataset', block_size=256 * 1024, levels=2):
+    def __init__(self, config, objects_path, repo_type=DATASETS, block_size=256 * 1024, levels=2):
         self.is_shared_objects = repo_type in config and 'objects_path' in config[repo_type]
         with change_mask_for_routine(self.is_shared_objects):
             super(LocalRepository, self).__init__(objects_path, block_size, levels)

--- a/ml_git/metadata.py
+++ b/ml_git/metadata.py
@@ -182,9 +182,8 @@ class Metadata(MetadataManager):
             r = Refs(refs_path, d_spec, dataset)
             tag, sha = r.head()
             if tag is not None:
-                log.info(
-                    'Associate datasets [%s]-[%s] to the %s.' % (d_spec, tag, self.__repo_type),
-                    class_name=LOCAL_REPOSITORY_CLASS_NAME)
+                log.info(output_messages['INFO_ASSOCIATE_DATASETS'] % (d_spec, tag, self.__repo_type),
+                         class_name=LOCAL_REPOSITORY_CLASS_NAME)
                 metadata[self.__repo_type][dataset] = {}
                 metadata[self.__repo_type][dataset]['tag'] = tag
                 metadata[self.__repo_type][dataset]['sha'] = sha

--- a/ml_git/metadata.py
+++ b/ml_git/metadata.py
@@ -12,7 +12,7 @@ from ml_git import log
 from ml_git._metadata import MetadataManager
 from ml_git.config import get_refs_path, get_sample_spec_doc
 from ml_git.constants import METADATA_CLASS_NAME, LOCAL_REPOSITORY_CLASS_NAME, ROOT_FILE_NAME, Mutability, \
-    SPEC_EXTENSION, MANIFEST_FILE
+    SPEC_EXTENSION, MANIFEST_FILE, EntityType
 from ml_git.manifest import Manifest
 from ml_git.ml_git_message import output_messages
 from ml_git.plugin_interface.data_plugin_constants import ADD_METADATA
@@ -22,7 +22,7 @@ from ml_git.utils import ensure_path_exists, yaml_save, yaml_load, clear, get_fi
 
 
 class Metadata(MetadataManager):
-    def __init__(self, spec, metadata_path, config, repo_type='dataset'):
+    def __init__(self, spec, metadata_path, config, repo_type=EntityType.DATASETS.value):
         self.__repo_type = repo_type
         self._spec = spec
         self.__path = metadata_path
@@ -173,30 +173,33 @@ class Metadata(MetadataManager):
         return store
 
     def _add_associate_entity_metadata(self, metadata, specs):
-        if 'dataset' in specs and self.__repo_type in ['labels', 'model']:
-            d_spec = specs['dataset']
-            refs_path = get_refs_path(self.__config, 'dataset')
-            r = Refs(refs_path, d_spec, 'dataset')
+        dataset = EntityType.DATASETS.value
+        labels = EntityType.LABELS.value
+        model = EntityType.MODELS.value
+        if dataset in specs and self.__repo_type in [labels, model]:
+            d_spec = specs[dataset]
+            refs_path = get_refs_path(self.__config, dataset)
+            r = Refs(refs_path, d_spec, dataset)
             tag, sha = r.head()
             if tag is not None:
                 log.info(
-                    'Associate dataset [%s]-[%s] to the %s.' % (d_spec, tag, self.__repo_type),
+                    'Associate datasets [%s]-[%s] to the %s.' % (d_spec, tag, self.__repo_type),
                     class_name=LOCAL_REPOSITORY_CLASS_NAME)
-                metadata[self.__repo_type]['dataset'] = {}
-                metadata[self.__repo_type]['dataset']['tag'] = tag
-                metadata[self.__repo_type]['dataset']['sha'] = sha
-        if 'labels' in specs and self.__repo_type in ['model']:
-            l_spec = specs['labels']
-            refs_path = get_refs_path(self.__config, 'labels')
-            r = Refs(refs_path, l_spec, 'labels')
+                metadata[self.__repo_type][dataset] = {}
+                metadata[self.__repo_type][dataset]['tag'] = tag
+                metadata[self.__repo_type][dataset]['sha'] = sha
+        if labels in specs and self.__repo_type in [model]:
+            l_spec = specs[labels]
+            refs_path = get_refs_path(self.__config, labels)
+            r = Refs(refs_path, l_spec, labels)
             tag, sha = r.head()
             if tag is not None:
                 log.info(
                     'Associate labels [%s]-[%s] to the %s.' % (l_spec, tag, self.__repo_type),
                     class_name=LOCAL_REPOSITORY_CLASS_NAME)
-                metadata[self.__repo_type]['labels'] = {}
-                metadata[self.__repo_type]['labels']['tag'] = tag
-                metadata[self.__repo_type]['labels']['sha'] = sha
+                metadata[self.__repo_type][labels] = {}
+                metadata[self.__repo_type][labels]['tag'] = tag
+                metadata[self.__repo_type][labels]['sha'] = sha
 
     def _get_amount_and_size_of_workspace_files(self, full_metadata_path, ws_path):
         full_path = os.path.join(full_metadata_path, MANIFEST_FILE)
@@ -256,9 +259,12 @@ class Metadata(MetadataManager):
         return message
 
     def clone_config_repo(self):
-        dataset = self.__config['dataset']['git'] if 'dataset' in self.__config else ''
-        model = self.__config['model']['git'] if 'model' in self.__config else ''
-        labels = self.__config['labels']['git'] if 'labels' in self.__config else ''
+        DATASETS = EntityType.DATASETS.value
+        MODELS = EntityType.MODELS.value
+        LABELS = EntityType.LABELS.value
+        dataset = self.__config[DATASETS]['git'] if DATASETS in self.__config else ''
+        model = self.__config[MODELS]['git'] if MODELS in self.__config else ''
+        labels = self.__config[LABELS]['git'] if LABELS in self.__config else ''
 
         if not (dataset or model or labels):
             log.error('No repositories found, verify your configurations!', class_name=METADATA_CLASS_NAME)
@@ -266,11 +272,11 @@ class Metadata(MetadataManager):
             return
 
         if dataset:
-            self.initialize_metadata('dataset')
+            self.initialize_metadata(DATASETS)
         if model:
-            self.initialize_metadata('model')
+            self.initialize_metadata(MODELS)
         if labels:
-            self.initialize_metadata('labels')
+            self.initialize_metadata(LABELS)
 
         log.info('Successfully loaded configuration files!', class_name=METADATA_CLASS_NAME)
 

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -22,6 +22,10 @@ output_messages = {
     'INFO_REMOVED_FILES': 'A total of %s files have been removed from %s',
     'INFO_RECLAIMED_SPACE': 'Total reclaimed space %s.',
     'INFO_ENTITY_DELETED': 'Entity %s was deleted',
+    'INFO_DIRECTORY_STRUCTURE_WRONG': 'It was observed that the directories of this project follow the scheme of old versions of ml-git.\n' +
+                                      '\tTo continue using this project it is necessary to update the directories. Ml-git can do this update on its own.',
+    'INFO_WANT_UPDATE_NOW': '\tDo you want to update your project now? (Yes/No) ',
+    'INFO_PROJECT_UPDATE_SUCCESSFULLY': 'Project updated successfully',
 
     'ERROR_WITHOUT_TAG_FOR_THIS_ENTITY': 'No entity with that name was found.',
     'ERROR_MULTIPLES_ENTITIES_WITH_SAME_NAME': 'You have more than one entity with the same name. Use one of the following tags to perform the checkout:\n',
@@ -35,8 +39,9 @@ output_messages = {
                                      'Your spec should look something like this:' + get_sample_spec_doc('some-bucket'),
     'ERROR_AWS_KEY_NOT_EXIST': 'The AWS Access Key Id you provided does not exist in our records.',
     'ERROR_BUCKET_DOES_NOT_EXIST': 'This bucket does not exist -- [%s]',
-    'ERROR_INVALID_ENTITY_TYPE': 'The entity type informed is invalid.',
+    'ERROR_INVALID_ENTITY_TYPE': 'Invalid entity type. Valid values are:',
     'ERROR_INVALID_STATUS_DIRECTORY': 'The directory informed is invalid.',
+    'ERROR_NEED_UPDATE_PROJECT': 'To continue using this project it is necessary to update it.',
 
     'WARN_HAS_CONFIGURED_REMOTE': 'YOU ALREADY HAS A CONFIGURED REMOTE. All data stored in this repository will be sent to the new one on the first push.',
 }

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -2,7 +2,19 @@
 © Copyright 2020 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
-from ml_git.config import get_sample_spec_doc
+
+doc = '''
+  datasets:
+    categories:
+    - vision-computing
+    - images
+    mutability: strict
+    manifest:
+      files: MANIFEST.yaml
+      store: s3h://some-bucket
+    name: datasets-ex
+    version: 5
+'''
 
 output_messages = {
     'DEBUG_REMOVE_REMOTE': 'Removing remote from local repository [%s]',
@@ -26,7 +38,11 @@ output_messages = {
                                       '\tTo continue using this project it is necessary to update the directories. Ml-git can do this update on its own.',
     'INFO_WANT_UPDATE_NOW': '\tDo you want to update your project now? (Yes/No) ',
     'INFO_PROJECT_UPDATE_SUCCESSFULLY': 'Project updated successfully',
+    'INFO_ASSOCIATE_DATASETS': 'Associate datasets [%s]-[%s] to the %s.',
+    'INFO_UPDATE_THE_PROJECT': 'It was observed that the directories of this project follow the scheme of old versions of ml-git.\n' +
+             '\tTo continue using this project it is necessary to update the directories.',
 
+    'INFO_AKS_IF_WANT_UPDATE_PROJECT': '\tDo you want to update your project now? (Yes/No) ',
     'ERROR_WITHOUT_TAG_FOR_THIS_ENTITY': 'No entity with that name was found.',
     'ERROR_MULTIPLES_ENTITIES_WITH_SAME_NAME': 'You have more than one entity with the same name. Use one of the following tags to perform the checkout:\n',
     'ERROR_WRONG_VERSION_NUMBER_TO_CHECKOUT': 'The version specified for that entity does not exist. Last entity tag:\n\t%s',
@@ -36,12 +52,13 @@ output_messages = {
     'ERROR_REMOTE_NOT_FOUND': 'Remote URL not found.',
     'ERROR_MISSING_MUTABILITY': 'Missing option "--mutability".  Choose from:\n\tstrict,\n\tflexible,\n\tmutable.',
     'ERROR_SPEC_WITHOUT_MUTABILITY': 'You need to define a mutability type when creating a new entity. '
-                                     'Your spec should look something like this:' + get_sample_spec_doc('some-bucket'),
+                                     'Your spec should look something like this:' + doc,
     'ERROR_AWS_KEY_NOT_EXIST': 'The AWS Access Key Id you provided does not exist in our records.',
     'ERROR_BUCKET_DOES_NOT_EXIST': 'This bucket does not exist -- [%s]',
     'ERROR_INVALID_ENTITY_TYPE': 'Invalid entity type. Valid values are:',
     'ERROR_INVALID_STATUS_DIRECTORY': 'The directory informed is invalid.',
     'ERROR_NEED_UPDATE_PROJECT': 'To continue using this project it is necessary to update it.',
+    'ERROR_PROJECT_NEED_BE_UPDATED': 'To continue using this project it is necessary to update it.',
 
     'WARN_HAS_CONFIGURED_REMOTE': 'YOU ALREADY HAS A CONFIGURED REMOTE. All data stored in this repository will be sent to the new one on the first push.',
 }

--- a/ml_git/refs.py
+++ b/ml_git/refs.py
@@ -2,15 +2,14 @@
 © Copyright 2020 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
-
 from ml_git.utils import ensure_path_exists, yaml_save, yaml_load
 from ml_git import log
-from ml_git.constants import REFS_CLASS_NAME
+from ml_git.constants import REFS_CLASS_NAME, EntityType
 import os
 
 
 class Refs(object):
-    def __init__(self, refspath, spec, repotype='dataset'):
+    def __init__(self, refspath, spec, repotype=EntityType.DATASETS.value):
         self._repotype = repotype
         self._spec = spec
         self._path = os.path.join(refspath, spec)

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -654,7 +654,7 @@ class Repository(object):
         options['with_labels'] = False
         if dt_tag is not None:
             try:
-                self.__repo_type = 'datasets'
+                self.__repo_type = EntityType.DATASETS.value
                 m = Metadata('', metadata_path, self.__config, self.__repo_type)
                 log.info('Initializing related dataset download', class_name=REPOSITORY_CLASS_NAME)
                 if not m.check_exists():
@@ -807,9 +807,9 @@ class Repository(object):
         dataset_tag, labels_tag = None, None
         spec_path = os.path.join(metadata_path, categories_path, spec_name + '.spec')
         if dataset is True:
-            dataset_tag = get_entity_tag(spec_path, repo_type, 'datasets')
+            dataset_tag = get_entity_tag(spec_path, repo_type, EntityType.DATASETS.value)
         if labels is True:
-            labels_tag = get_entity_tag(spec_path, repo_type, 'labels')
+            labels_tag = get_entity_tag(spec_path, repo_type, EntityType.LABELS.value)
         return dataset_tag, labels_tag
 
     def reset(self, spec, reset_type, head):

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -36,7 +36,7 @@ from ml_git.utils import yaml_load, ensure_path_exists, get_root_path, get_path_
 
 
 class Repository(object):
-    def __init__(self, config, repo_type='dataset'):
+    def __init__(self, config, repo_type=EntityType.DATASETS):
 
         self._validate_entity_type(repo_type)
         self.__config = config
@@ -103,17 +103,13 @@ class Repository(object):
                 log.error('You cannot add new data to an entity that is based on a checkout with the --sampling option.',
                           class_name=REPOSITORY_CLASS_NAME)
                 return
-
             if not mutability:
                 return
-
             if not check_mutability:
                 log.error('Spec mutability cannot be changed.', class_name=REPOSITORY_CLASS_NAME)
                 return
-
             if not self._has_new_data(repo, spec):
                 return None
-
             ref = Refs(refs_path, spec, repo_type)
             tag, sha = ref.branch()
 
@@ -658,7 +654,7 @@ class Repository(object):
         options['with_labels'] = False
         if dt_tag is not None:
             try:
-                self.__repo_type = 'dataset'
+                self.__repo_type = 'datasets'
                 m = Metadata('', metadata_path, self.__config, self.__repo_type)
                 log.info('Initializing related dataset download', class_name=REPOSITORY_CLASS_NAME)
                 if not m.check_exists():
@@ -811,7 +807,7 @@ class Repository(object):
         dataset_tag, labels_tag = None, None
         spec_path = os.path.join(metadata_path, categories_path, spec_name + '.spec')
         if dataset is True:
-            dataset_tag = get_entity_tag(spec_path, repo_type, 'dataset')
+            dataset_tag = get_entity_tag(spec_path, repo_type, 'datasets')
         if labels is True:
             labels_tag = get_entity_tag(spec_path, repo_type, 'labels')
         return dataset_tag, labels_tag

--- a/ml_git/spec.py
+++ b/ml_git/spec.py
@@ -7,8 +7,10 @@ import os
 
 from ml_git import log
 from ml_git import utils
-from ml_git.constants import ML_GIT_PROJECT_NAME, SPEC_EXTENSION
+from ml_git.constants import ML_GIT_PROJECT_NAME, SPEC_EXTENSION, EntityType
 from ml_git.utils import get_root_path, yaml_load
+
+DATASETS = EntityType.DATASETS.value
 
 
 class SearchSpecException(Exception):
@@ -61,7 +63,7 @@ def spec_parse(spec):
 """Increment the version number inside the given dataset specification file."""
 
 
-def incr_version(file, repotype='dataset'):
+def incr_version(file, repotype=DATASETS):
     spec_hash = utils.yaml_load(file)
     if is_valid_version(spec_hash, repotype):
         spec_hash[repotype]['version'] += 1
@@ -73,10 +75,10 @@ def incr_version(file, repotype='dataset'):
         return -1
 
 
-def get_version(file, repotype='dataset'):
+def get_version(file, repotype=DATASETS):
     spec_hash = utils.yaml_load(file)
     if is_valid_version(spec_hash, repotype):
-        return spec_hash['dataset']['version']
+        return spec_hash[DATASETS]['version']
     else:
         log.error('Invalid version, could not get.  File:\n     %s' % file, class_name=ML_GIT_PROJECT_NAME)
         return -1
@@ -85,7 +87,7 @@ def get_version(file, repotype='dataset'):
 """Validate the version inside the dataset specification file hash can be located and is an int."""
 
 
-def is_valid_version(the_hash, repotype='dataset'):
+def is_valid_version(the_hash, repotype=DATASETS):
     if the_hash is None or the_hash == {}:
         return False
     if repotype not in the_hash or 'version' not in the_hash[repotype]:
@@ -97,12 +99,12 @@ def is_valid_version(the_hash, repotype='dataset'):
     return True
 
 
-def get_spec_file_dir(entity_name, repotype='dataset'):
+def get_spec_file_dir(entity_name, repotype=DATASETS):
     dir1 = os.path.join(repotype, entity_name)
     return dir1
 
 
-def set_version_in_spec(version_number, spec_path, repotype='dataset'):
+def set_version_in_spec(version_number, spec_path, repotype=DATASETS):
     spec_hash = utils.yaml_load(spec_path)
     spec_hash[repotype]['version'] = version_number
     utils.yaml_save(spec_hash, spec_path)
@@ -112,7 +114,7 @@ def set_version_in_spec(version_number, spec_path, repotype='dataset'):
 """When --bumpversion is specified during 'dataset add', this increments the version number in the right place"""
 
 
-def increment_version_in_spec(entity_name, repotype='dataset'):
+def increment_version_in_spec(entity_name, repotype=DATASETS):
     # Primary location: dataset/<the_dataset>/<the_dataset>.spec
     # Location: .ml-git/dataset/index/metadata/<the_dataset>/<the_dataset>.spec is linked to the primary location
     if entity_name is None:

--- a/ml_git/utils.py
+++ b/ml_git/utils.py
@@ -327,11 +327,9 @@ def check_metadata_directories():
 def update_directories_to_plural(root_path, old_value, new_value):
     data_path = os.path.join(root_path, old_value)
     if os.path.exists(data_path):
-        set_write_read(data_path)
         os.rename(data_path, os.path.join(root_path, new_value))
     metadata_path = os.path.join(root_path, ROOT_FILE_NAME, old_value)
     if os.path.exists(metadata_path):
-        set_write_read(metadata_path)
         os.rename(metadata_path, os.path.join(root_path, ROOT_FILE_NAME, new_value))
 
 


### PR DESCRIPTION
The ml-git code has been modified to work with `datasets`, `models `and `labels`.

```
ml-git --help

Usage: ml-git [OPTIONS] COMMAND [ARGS]...

Options:
  --version  Show the version and exit.

Commands:
  clone       Clone a ml-git repository ML_GIT_REPOSITORY_URL
  datasets    Management of datasets within this ml-git repository.
  labels      Management of labels sets within this ml-git repository.
  models      Management of models within this ml-git repository.
  repository  Management of this ml-git repository.
```

Logic has also been added to allow automatic updating of an old project. This logic changes the directories of the current project, the keys in the config file and also in the spec file of each entity.

**Example:** 

User workspace:
```
project/
├── dataset
│   └── dataset-ex1
├── labels
│   └── labels-ex1
├── model
│   └── model-ex1
├── .ml-git
│   ├── dataset
│   ├── model
│   ├── label
│   └── config
└── imagenet8.spec
```

Execute any command:
```
> ml-git datasets add dataset-ex
> INFO - MLGit: It was observed that the directories of this project follow the scheme of old versions of ml-git.
>         To continue using this project it is necessary to update the directories.
>         Do you want to update your project now? (Yes/No) Yes
> INFO - MLGit: Project updated successfully
```

After update:
```
project/
├── datasets <- Change here
│   └── dataset-ex1
├── labels
│   └── labels-ex1
├── models <- Change here
│   └── model-ex1
├── .ml-git
│   ├── datasets <- Change here
│   ├── models <- Change here
│   ├── label
│   └── config
└── imagenet8.spec
```