### PR TITLE
[plural entity names] Updating unit tests to use plural entity names

### DIFF
--- a/ml_git/constants.py
+++ b/ml_git/constants.py
@@ -79,9 +79,9 @@ class StoreType(Enum):
 
 @unique
 class EntityType(Enum):
-    DATASET = 'dataset'
+    DATASETS = 'datasets'
     LABELS = 'labels'
-    MODEL = 'model'
+    MODELS = 'models'
 
     @staticmethod
     def to_list():

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -55,7 +55,7 @@ def switch_to_tmp_dir(tmp_path):
 
 def write_config(git_path, path):
     config = """
-    dataset:
+    datasets:
     git: %s
     store:
         s3:

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -36,20 +36,20 @@ class AdminTestCases(unittest.TestCase):
     def test_remote_add(self):
         remote_default = 'git_local_server.git'
         new_remote = 'git_local_server2.git'
-        dataset = 'dataset'
+        dataset = 'datasets'
         init_mlgit()
         remote_add(dataset, new_remote)
         self.assertTrue(os.path.isdir('.ml-git'))
         config = yaml_load('.ml-git/config.yaml')
-        self.assertEqual(config['dataset']['git'], new_remote)
+        self.assertEqual(config['datasets']['git'], new_remote)
         self.assertNotEqual(remote_default, new_remote)
         remote_add(dataset, '')
         config_ = yaml_load('.ml-git/config.yaml')
-        self.assertEqual(config_['dataset']['git'], '')
+        self.assertEqual(config_['datasets']['git'], '')
         remote_add(dataset, new_remote)
         self.assertTrue(os.path.isdir('.ml-git'))
         config__ = yaml_load('.ml-git/config.yaml')
-        self.assertEqual(config__['dataset']['git'], new_remote)
+        self.assertEqual(config__['datasets']['git'], new_remote)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_store_add(self):
@@ -95,28 +95,28 @@ class AdminTestCases(unittest.TestCase):
     def test_remote_add_global_config(self):
         remote_default = 'git_local_server.git'
         new_remote = 'git_local_server2.git'
-        dataset = 'dataset'
+        datasets = 'datasets'
         init_mlgit()
         with mock.patch('pathlib.Path.home', return_value=self.tmp_dir):
-            remote_add(dataset, new_remote, global_conf=True)
+            remote_add(datasets, new_remote, global_conf=True)
 
         self.assertTrue(os.path.exists('.mlgitconfig'))
         config = yaml_load('.ml-git/config.yaml')
         config_global = yaml_load('.mlgitconfig')
-        self.assertEqual(config_global['dataset']['git'], new_remote)
-        self.assertNotEqual(config['dataset']['git'], remote_default)
+        self.assertEqual(config_global[datasets]['git'], new_remote)
+        self.assertNotEqual(config[datasets]['git'], remote_default)
 
         with mock.patch('pathlib.Path.home', return_value=self.tmp_dir):
-            remote_add(dataset, '', global_conf=True)
+            remote_add(datasets, '', global_conf=True)
 
         config_ = yaml_load('.mlgitconfig')
-        self.assertEqual(config_['dataset']['git'], '')
+        self.assertEqual(config_[datasets]['git'], '')
 
         with mock.patch('pathlib.Path.home', return_value=self.tmp_dir):
-            remote_add(dataset, new_remote, global_conf=True)
+            remote_add(datasets, new_remote, global_conf=True)
 
         config__ = yaml_load('.mlgitconfig')
-        self.assertEqual(config__['dataset']['git'], new_remote)
+        self.assertEqual(config__[datasets]['git'], new_remote)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_store_add_global_config(self):
@@ -165,13 +165,13 @@ class AdminTestCases(unittest.TestCase):
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_remote_del(self):
         remote_default = 'git_local_server.git'
-        dataset = 'dataset'
+        datasets = 'datasets'
         init_mlgit()
         config = yaml_load('.ml-git/config.yaml')
-        self.assertEqual(config['dataset']['git'], '')
-        remote_add(dataset, remote_default)
+        self.assertEqual(config[datasets]['git'], '')
+        remote_add(datasets, remote_default)
         config = yaml_load('.ml-git/config.yaml')
-        self.assertEqual(config['dataset']['git'], remote_default)
-        remote_del(dataset)
+        self.assertEqual(config[datasets]['git'], remote_default)
+        remote_del(datasets)
         config_ = yaml_load('.ml-git/config.yaml')
-        self.assertEqual(config_['dataset']['git'], '')
+        self.assertEqual(config_[datasets]['git'], '')

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -12,6 +12,7 @@ from unittest import mock
 import pytest
 
 from ml_git.admin import init_mlgit, remote_add, store_add, clone_config_repository, store_del, remote_del
+from ml_git.constants import EntityType
 from ml_git.utils import yaml_load
 
 
@@ -36,20 +37,20 @@ class AdminTestCases(unittest.TestCase):
     def test_remote_add(self):
         remote_default = 'git_local_server.git'
         new_remote = 'git_local_server2.git'
-        dataset = 'datasets'
+        dataset = EntityType.DATASETS.value
         init_mlgit()
         remote_add(dataset, new_remote)
         self.assertTrue(os.path.isdir('.ml-git'))
         config = yaml_load('.ml-git/config.yaml')
-        self.assertEqual(config['datasets']['git'], new_remote)
+        self.assertEqual(config[dataset]['git'], new_remote)
         self.assertNotEqual(remote_default, new_remote)
         remote_add(dataset, '')
         config_ = yaml_load('.ml-git/config.yaml')
-        self.assertEqual(config_['datasets']['git'], '')
+        self.assertEqual(config_[dataset]['git'], '')
         remote_add(dataset, new_remote)
         self.assertTrue(os.path.isdir('.ml-git'))
         config__ = yaml_load('.ml-git/config.yaml')
-        self.assertEqual(config__['datasets']['git'], new_remote)
+        self.assertEqual(config__[dataset]['git'], new_remote)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_store_add(self):
@@ -95,7 +96,7 @@ class AdminTestCases(unittest.TestCase):
     def test_remote_add_global_config(self):
         remote_default = 'git_local_server.git'
         new_remote = 'git_local_server2.git'
-        datasets = 'datasets'
+        datasets = EntityType.DATASETS.value
         init_mlgit()
         with mock.patch('pathlib.Path.home', return_value=self.tmp_dir):
             remote_add(datasets, new_remote, global_conf=True)
@@ -165,7 +166,7 @@ class AdminTestCases(unittest.TestCase):
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_remote_del(self):
         remote_default = 'git_local_server.git'
-        datasets = 'datasets'
+        datasets = EntityType.DATASETS.value
         init_mlgit()
         config = yaml_load('.ml-git/config.yaml')
         self.assertEqual(config[datasets]['git'], '')

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -54,44 +54,44 @@ class ConfigTestCases(unittest.TestCase):
         self.assertFalse(validate_spec_hash({}))
 
         # Non-integer version
-        spec['dataset']['version'] = 'string'
+        spec['datasets']['version'] = 'string'
         self.assertFalse(validate_spec_hash(spec))
 
         # Missing version
-        spec['dataset'].pop('version')
+        spec['datasets'].pop('version')
         self.assertFalse(validate_spec_hash(spec))
 
         # Missing dataset
-        spec.pop('dataset')
+        spec.pop('datasets')
         self.assertFalse(validate_spec_hash(spec))
 
         # Empty category list
         spec = get_sample_spec('somebucket')
-        spec['dataset']['categories'] = {}
+        spec['datasets']['categories'] = {}
         self.assertFalse(validate_spec_hash(spec))
 
         # Missing categories
-        spec['dataset'].pop('categories')
+        spec['datasets'].pop('categories')
         self.assertFalse(validate_spec_hash(spec))
 
         # Missing store
         spec = get_sample_spec('somebucket')
-        spec['dataset']['manifest'].pop('store')
+        spec['datasets']['manifest'].pop('store')
         self.assertFalse(validate_spec_hash(spec))
 
         # Missing manifest
-        spec['dataset'].pop('manifest')
+        spec['datasets'].pop('manifest')
 
         # Bad bucket URL format
         spec = get_sample_spec('somebucket')
-        spec['dataset']['manifest']['store'] = 'invalid'
+        spec['datasets']['manifest']['store'] = 'invalid'
         self.assertFalse(validate_spec_hash(spec))
 
         # Missing and empty dataset name
         spec = get_sample_spec('somebucket')
-        spec['dataset']['name'] = ''
+        spec['datasets']['name'] = ''
         self.assertFalse(validate_spec_hash(spec))
-        spec['dataset'].pop('name')
+        spec['datasets'].pop('name')
         self.assertFalse(validate_spec_hash(spec))
 
     def test_config_verbose(self):
@@ -158,22 +158,22 @@ class ConfigTestCases(unittest.TestCase):
         self.assertEqual(batch_size, BATCH_SIZE_VALUE)
 
     def test_merge_conf(self):
-        local_conf = {'dataset': {'git': ''}}
-        global_conf = {'dataset': {'git': 'url'}, 'model': {'git': 'url'}, 'store': {}}
+        local_conf = {'datasets': {'git': ''}}
+        global_conf = {'datasets': {'git': 'url'}, 'models': {'git': 'url'}, 'store': {}}
         merge_conf(local_conf, global_conf)
-        self.assertEqual(local_conf['dataset']['git'], 'url')
-        self.assertEqual(local_conf['model']['git'], 'url')
+        self.assertEqual(local_conf['datasets']['git'], 'url')
+        self.assertEqual(local_conf['models']['git'], 'url')
         self.assertTrue('store' in local_conf)
 
     @pytest.mark.usefixtures('restore_config')
     def test_merge_local_with_global_config(self):
-        global_conf = {'dataset': {'git': 'url'}, 'model': {'git': 'url'}, 'store': {}}
+        global_conf = {'datasets': {'git': 'url'}, 'models': {'git': 'url'}, 'store': {}}
 
         with mock.patch('ml_git.config.global_config_load', return_value=global_conf):
             merge_local_with_global_config()
 
-        self.assertEqual(mlgit_config['dataset']['git'], 'url')
-        self.assertEqual(mlgit_config['model']['git'], 'url')
+        self.assertEqual(mlgit_config['datasets']['git'], 'url')
+        self.assertEqual(mlgit_config['models']['git'], 'url')
         self.assertNotEqual(mlgit_config['store'], {})
 
     @pytest.mark.usefixtures('restore_config', 'switch_to_tmp_dir')
@@ -183,8 +183,8 @@ class ConfigTestCases(unittest.TestCase):
         init_mlgit()
         self.assertTrue(os.path.isdir('.ml-git'))
         config = yaml_load('.ml-git/config.yaml')
-        self.assertEqual(config['dataset']['git'], remote_default)
-        global_conf = {'dataset': {'git': 'url'}, 'model': {'git': 'url'}, 'labels': {'git': new_remote}, 'store': {}}
+        self.assertEqual(config['datasets']['git'], remote_default)
+        global_conf = {'datasets': {'git': 'url'}, 'models': {'git': 'url'}, 'labels': {'git': new_remote}, 'store': {}}
 
         with mock.patch('ml_git.config.global_config_load', return_value=global_conf):
             save_global_config_in_local()
@@ -200,7 +200,7 @@ class ConfigTestCases(unittest.TestCase):
         new_gdrive_store_options = ['git_repo', '.credentials', 'mlgit', 'gdriveh', 'X']
 
         with mock.patch('builtins.input', return_value='1'):
-            has_new_store, store_type, bucket, profile, endpoint_url, git_repo = start_wizard_questions('dataset')
+            has_new_store, store_type, bucket, profile, endpoint_url, git_repo = start_wizard_questions('datasets')
             self.assertEqual(store_type, 's3')
             self.assertEqual(bucket, 'mlgit-datasets')
             self.assertIsNone(profile)
@@ -209,10 +209,10 @@ class ConfigTestCases(unittest.TestCase):
             self.assertFalse(has_new_store)
 
         with mock.patch('builtins.input', new=lambda *args, **kwargs: invalid_store_options.pop()):
-            self.assertRaises(Exception, lambda: start_wizard_questions('dataset'))
+            self.assertRaises(Exception, lambda: start_wizard_questions('datasets'))
 
         with mock.patch('builtins.input', new=lambda *args, **kwargs: new_s3_store_options.pop()):
-            has_new_store, store_type, bucket, profile, endpoint_url, git_repo = start_wizard_questions('dataset')
+            has_new_store, store_type, bucket, profile, endpoint_url, git_repo = start_wizard_questions('datasets')
             self.assertEqual(store_type, 's3h')
             self.assertEqual(bucket, 'mlgit')
             self.assertEqual(profile, 'default')
@@ -221,7 +221,7 @@ class ConfigTestCases(unittest.TestCase):
             self.assertTrue(has_new_store)
 
         with mock.patch('builtins.input', new=lambda *args, **kwargs: new_gdrive_store_options.pop()):
-            has_new_store, store_type, bucket, profile, endpoint_url, git_repo = start_wizard_questions('dataset')
+            has_new_store, store_type, bucket, profile, endpoint_url, git_repo = start_wizard_questions('datasets')
             self.assertEqual(store_type, 'gdriveh')
             self.assertEqual(bucket, 'mlgit')
             self.assertEqual(profile, '.credentials')

--- a/tests/unit/test_dir/.ml-git/config.yaml
+++ b/tests/unit/test_dir/.ml-git/config.yaml
@@ -1,4 +1,4 @@
-dataset:
+datasets:
   git: git_local_server.git
 store:
   s3:

--- a/tests/unit/test_dir/datasets/dataex/dataex.spec
+++ b/tests/unit/test_dir/datasets/dataex/dataex.spec
@@ -3,5 +3,5 @@ datasets:
   - weather
   manifest:
     store: s3h://some-bucket-name
-  name: noaa-severe-weather-inventory
-  version: 14
+  name: somename
+  version: 1

--- a/tests/unit/test_dir/hdata/dataset-ex.spec
+++ b/tests/unit/test_dir/hdata/dataset-ex.spec
@@ -1,4 +1,4 @@
-dataset:
+datasets:
   categories:
   - vision-computing
   - images

--- a/tests/unit/test_dir/hdata/dataset-spec-3.spec
+++ b/tests/unit/test_dir/hdata/dataset-spec-3.spec
@@ -1,4 +1,4 @@
-dataset:
+datasets:
   categories: x
   manifest:
     files: MANIFEST.yaml

--- a/tests/unit/test_dir/mdata/metadata/dataset-ex-2/dataset-ex-2.spec
+++ b/tests/unit/test_dir/mdata/metadata/dataset-ex-2/dataset-ex-2.spec
@@ -1,4 +1,4 @@
-dataset:
+datasets:
   categories:
   - vision-computing
   - images

--- a/tests/unit/test_dir/mdata/metadata/dataset-ex/dataset-ex.spec
+++ b/tests/unit/test_dir/mdata/metadata/dataset-ex/dataset-ex.spec
@@ -1,4 +1,4 @@
-dataset:
+datasets:
   categories:
   - vision-computing
   - images

--- a/tests/unit/test_dir/minit/datasets/index/metadata/dataset-ex/dataset-ex.spec
+++ b/tests/unit/test_dir/minit/datasets/index/metadata/dataset-ex/dataset-ex.spec
@@ -1,0 +1,6 @@
+datasets:
+  categories: imgs
+  manifest:
+    store: s3h://br.edu.ufcg.virtus.hp.ml.gitml.test0
+  name: dataset-ex
+  version: 1

--- a/tests/unit/test_dir/specdata/bad1/invalid-name.spec
+++ b/tests/unit/test_dir/specdata/bad1/invalid-name.spec
@@ -1,4 +1,4 @@
-dataset:
+datasets:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/specdata/invalid2.spec
+++ b/tests/unit/test_dir/specdata/invalid2.spec
@@ -1,4 +1,4 @@
-dataset:
+datasets:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/specdata/invalid3.spec
+++ b/tests/unit/test_dir/specdata/invalid3.spec
@@ -1,4 +1,4 @@
-dataset:
+datasets:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/specdata/invalid4.spec
+++ b/tests/unit/test_dir/specdata/invalid4.spec
@@ -1,4 +1,4 @@
-dataset:
+datasets:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/specdata/noaa-severe-weather-inventory/noaa-severe-weather-inventory.spec
+++ b/tests/unit/test_dir/specdata/noaa-severe-weather-inventory/noaa-severe-weather-inventory.spec
@@ -1,4 +1,4 @@
-dataset:
+datasets:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/specdata/sample.spec
+++ b/tests/unit/test_dir/specdata/sample.spec
@@ -1,4 +1,4 @@
-dataset:
+datasets:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/specdata/valid2.spec
+++ b/tests/unit/test_dir/specdata/valid2.spec
@@ -1,4 +1,4 @@
-dataset:
+datasets:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/udata/data.json
+++ b/tests/unit/test_dir/udata/data.json
@@ -1,5 +1,5 @@
 {
-  "dataset": {
+  "datasets": {
     "categories": "imgs",
     "manifest": {
       "store": "s3h://br.edu.ufcg.virtus.hp.ml.gitml.test0"

--- a/tests/unit/test_dir/udata/data.yaml
+++ b/tests/unit/test_dir/udata/data.yaml
@@ -1,4 +1,4 @@
-dataset:
+datasets:
   git: https://github.com/ANYTHING.tmp21j9vqp2.git
 store:
   s3:

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -12,6 +12,7 @@ from unittest import mock
 import pytest
 from git import GitError, Repo
 
+from ml_git.constants import EntityType
 from ml_git.metadata import Metadata
 from ml_git.repository import Repository
 from ml_git.utils import clear
@@ -33,13 +34,13 @@ config = {
     'mlgit_path': './mdata',
     'mlgit_conf': 'config.yaml',
 
-    'datasets': {
+    EntityType.DATASETS.value: {
         'git': os.path.join(os.getcwd(), 'git_local_server.git'),
     },
-    'labels': {
+    EntityType.LABELS.value: {
         'git': os.path.join(os.getcwd(), 'git_local_server.git'),
     },
-    'models': {
+    EntityType.MODELS.value: {
         'git': os.path.join(os.getcwd(), 'git_local_server.git'),
     },
 
@@ -56,10 +57,10 @@ config = {
     'verbose': 'info',
 }
 
-repotype = 'datasets'
+repotype = EntityType.DATASETS.value
 
 metadata_config = {
-    'datasets': {
+    repotype: {
         'categories': 'images',
         'manifest': {
             'files': 'MANIFEST.yaml',
@@ -148,9 +149,9 @@ class MetadataTestCases(unittest.TestCase):
             'mlgit_path': './mdata',
             'mlgit_conf': 'config.yaml',
             'verbose': 'info',
-            'datasets': {'git': '', },
-            'labels': {'git': '', },
-            'models': {'git': '', }, }
+            EntityType.DATASETS.value: {'git': '', },
+            EntityType.LABELS.value: {'git': '', },
+            EntityType.MODELS.value: {'git': '', }, }
 
         m = Metadata('', self.test_dir, config, repotype)
         m.clone_config_repo()
@@ -159,7 +160,7 @@ class MetadataTestCases(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_test_dir')
     def test_blank_remote_url(self):
         config_cp = deepcopy(config)
-        config_cp['datasets']['git'] = ''
+        config_cp[EntityType.DATASETS.value]['git'] = ''
         m = Metadata(spec, self.test_dir, config_cp, repotype)
         self.assertRaises(GitError, m.validate_blank_remote_url)
         clear(m.path)

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -33,13 +33,13 @@ config = {
     'mlgit_path': './mdata',
     'mlgit_conf': 'config.yaml',
 
-    'dataset': {
+    'datasets': {
         'git': os.path.join(os.getcwd(), 'git_local_server.git'),
     },
     'labels': {
         'git': os.path.join(os.getcwd(), 'git_local_server.git'),
     },
-    'model': {
+    'models': {
         'git': os.path.join(os.getcwd(), 'git_local_server.git'),
     },
 
@@ -56,10 +56,10 @@ config = {
     'verbose': 'info',
 }
 
-repotype = 'dataset'
+repotype = 'datasets'
 
 metadata_config = {
-    'dataset': {
+    'datasets': {
         'categories': 'images',
         'manifest': {
             'files': 'MANIFEST.yaml',
@@ -148,9 +148,9 @@ class MetadataTestCases(unittest.TestCase):
             'mlgit_path': './mdata',
             'mlgit_conf': 'config.yaml',
             'verbose': 'info',
-            'dataset': {'git': '', },
+            'datasets': {'git': '', },
             'labels': {'git': '', },
-            'model': {'git': '', }, }
+            'models': {'git': '', }, }
 
         m = Metadata('', self.test_dir, config, repotype)
         m.clone_config_repo()
@@ -159,7 +159,7 @@ class MetadataTestCases(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_test_dir')
     def test_blank_remote_url(self):
         config_cp = deepcopy(config)
-        config_cp['dataset']['git'] = ''
+        config_cp['datasets']['git'] = ''
         m = Metadata(spec, self.test_dir, config_cp, repotype)
         self.assertRaises(GitError, m.validate_blank_remote_url)
         clear(m.path)

--- a/tests/unit/test_refs.py
+++ b/tests/unit/test_refs.py
@@ -9,6 +9,7 @@ import unittest
 import pytest
 
 from ml_git.config import config_load
+from ml_git.constants import EntityType
 from ml_git.refs import Refs
 from ml_git.utils import yaml_load
 
@@ -21,8 +22,8 @@ class RefsTestCases(unittest.TestCase):
         spec_path = 'dataset-ex'
         ml_dir = os.path.join(self.tmp_dir, config['mlgit_path'])
         os.mkdir(ml_dir)
-        refs_dir = os.path.join(ml_dir, 'datasets', 'refs')
-        refs = Refs(refs_dir, spec_path, 'datasets')
+        refs_dir = os.path.join(ml_dir, EntityType.DATASETS.value, 'refs')
+        refs = Refs(refs_dir, spec_path, EntityType.DATASETS.value)
         self.assertIsNotNone(refs)
         self.assertTrue(os.path.exists(os.path.join(refs_dir, spec_path)))
 
@@ -31,7 +32,7 @@ class RefsTestCases(unittest.TestCase):
         spec_path = 'dataset-ex'
         ml_dir = os.path.join(self.tmp_dir, config['mlgit_path'])
         os.mkdir(ml_dir)
-        refs_dir = os.path.join(ml_dir, 'datasets', 'refs')
+        refs_dir = os.path.join(ml_dir, EntityType.DATASETS.value, 'refs')
         refs = Refs(refs_dir, spec_path)
         sha = 'b569b7e4cd82206b451315123669057ef5f1ac3b'
         tag = 'images__dataset_ex__1'
@@ -46,7 +47,7 @@ class RefsTestCases(unittest.TestCase):
         spec_path = 'dataset-ex'
         ml_dir = os.path.join(self.tmp_dir, config['mlgit_path'])
         os.mkdir(ml_dir)
-        refs_dir = os.path.join(ml_dir, 'datasets', 'refs')
+        refs_dir = os.path.join(ml_dir, EntityType.DATASETS.value, 'refs')
         refs = Refs(refs_dir, spec_path)
         sha = 'b569b7e4cd82206b451315123669057ef5f1ac3b'
         tag = 'images__dataset_ex__1'

--- a/tests/unit/test_refs.py
+++ b/tests/unit/test_refs.py
@@ -21,8 +21,8 @@ class RefsTestCases(unittest.TestCase):
         spec_path = 'dataset-ex'
         ml_dir = os.path.join(self.tmp_dir, config['mlgit_path'])
         os.mkdir(ml_dir)
-        refs_dir = os.path.join(ml_dir, 'dataset', 'refs')
-        refs = Refs(refs_dir, spec_path, 'dataset')
+        refs_dir = os.path.join(ml_dir, 'datasets', 'refs')
+        refs = Refs(refs_dir, spec_path, 'datasets')
         self.assertIsNotNone(refs)
         self.assertTrue(os.path.exists(os.path.join(refs_dir, spec_path)))
 
@@ -31,7 +31,7 @@ class RefsTestCases(unittest.TestCase):
         spec_path = 'dataset-ex'
         ml_dir = os.path.join(self.tmp_dir, config['mlgit_path'])
         os.mkdir(ml_dir)
-        refs_dir = os.path.join(ml_dir, 'dataset', 'refs')
+        refs_dir = os.path.join(ml_dir, 'datasets', 'refs')
         refs = Refs(refs_dir, spec_path)
         sha = 'b569b7e4cd82206b451315123669057ef5f1ac3b'
         tag = 'images__dataset_ex__1'
@@ -46,7 +46,7 @@ class RefsTestCases(unittest.TestCase):
         spec_path = 'dataset-ex'
         ml_dir = os.path.join(self.tmp_dir, config['mlgit_path'])
         os.mkdir(ml_dir)
-        refs_dir = os.path.join(ml_dir, 'dataset', 'refs')
+        refs_dir = os.path.join(ml_dir, 'datasets', 'refs')
         refs = Refs(refs_dir, spec_path)
         sha = 'b569b7e4cd82206b451315123669057ef5f1ac3b'
         tag = 'images__dataset_ex__1'

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -24,10 +24,10 @@ class SpecTestCases(unittest.TestCase):
         file = os.path.join(testdir, 'sample.spec')
         spec_hash = yaml_load(file)
         yaml_save(spec_hash, tmpfile)
-        version = spec_hash['dataset']['version']
+        version = spec_hash['datasets']['version']
         incr_version(tmpfile)
         incremented_hash = yaml_load(tmpfile)
-        self.assertEqual(incremented_hash['dataset']['version'], version + 1)
+        self.assertEqual(incremented_hash['datasets']['version'], version + 1)
 
         incr_version('non-existent-file')
 
@@ -54,7 +54,7 @@ class SpecTestCases(unittest.TestCase):
     def test_search_spec_file(self):
         categories_path = ''
         specpath = 'dataset-ex'
-        spec_dir = os.path.join(self.tmp_dir, 'dataset')
+        spec_dir = os.path.join(self.tmp_dir, 'datasets')
         spec_dir_c = os.path.join(spec_dir, categories_path, specpath)
 
         os.mkdir(spec_dir)
@@ -92,7 +92,7 @@ class SpecTestCases(unittest.TestCase):
     def test_increment_version_in_dataset_spec(self):
         dataset = 'test_dataset'
         dir1 = get_spec_file_dir(dataset)
-        dir2 = os.path.join('.ml-git', 'dataset', 'index', 'metadata', dataset)  # Linked path to the original
+        dir2 = os.path.join('.ml-git', 'datasets', 'index', 'metadata', dataset)  # Linked path to the original
         os.makedirs(os.path.join(self.tmp_dir, dir1))
         os.makedirs(os.path.join(self.tmp_dir, dir2))
         file1 = os.path.join(self.tmp_dir, dir1, '%s.spec' % dataset)
@@ -110,7 +110,7 @@ class SpecTestCases(unittest.TestCase):
         yaml_save(spec, file1)
         os.link(file1, file2)
         self.assertTrue(increment_version_in_spec(
-            os.path.join(get_root_path(), self.tmp_dir, 'dataset', dataset, dataset + '.spec')))
+            os.path.join(get_root_path(), self.tmp_dir, 'datasets', dataset, dataset + '.spec')))
 
     def test_get_version(self):
         file = os.path.join(testdir, 'valid.spec')
@@ -119,18 +119,18 @@ class SpecTestCases(unittest.TestCase):
         self.assertTrue(get_version(file) < 0)
 
     def test_update_store_spec(self):
-        spec_path = os.path.join(os.getcwd(), os.sep.join(['dataset', 'dataex', 'dataex.spec']))
+        spec_path = os.path.join(os.getcwd(), os.sep.join(['datasets', 'dataex', 'dataex.spec']))
 
-        update_store_spec('dataset', 'dataex', 's3h', 'fakestore')
+        update_store_spec('datasets', 'dataex', 's3h', 'fakestore')
         spec1 = yaml_load(spec_path)
-        self.assertEqual(spec1['dataset']['manifest']['store'], 's3h://fakestore')
+        self.assertEqual(spec1['datasets']['manifest']['store'], 's3h://fakestore')
 
-        update_store_spec('dataset', 'dataex', 's3h', 'some-bucket-name')
+        update_store_spec('datasets', 'dataex', 's3h', 'some-bucket-name')
         spec2 = yaml_load(spec_path)
-        self.assertEqual(spec2['dataset']['manifest']['store'], 's3h://some-bucket-name')
+        self.assertEqual(spec2['datasets']['manifest']['store'], 's3h://some-bucket-name')
 
     def test_validate_bucket_name(self):
-        repo_type = 'dataset'
+        repo_type = 'datasets'
         config = yaml_load(os.path.join(os.getcwd(), '.ml-git', 'config.yaml'))
         spec_with_wrong_bucket_name = yaml_load(os.path.join(testdir, 'invalid4.spec'))
         self.assertFalse(validate_bucket_name(spec_with_wrong_bucket_name[repo_type], config))
@@ -150,6 +150,6 @@ class SpecTestCases(unittest.TestCase):
         file = os.path.join(testdir, 'sample.spec')
         spec_hash = yaml_load(file)
         yaml_save(spec_hash, tmpfile)
-        set_version_in_spec(3, tmpfile, 'dataset')
+        set_version_in_spec(3, tmpfile, 'datasets')
         spec_hash = yaml_load(tmpfile)
-        self.assertEqual(spec_hash['dataset']['version'], 3)
+        self.assertEqual(spec_hash['datasets']['version'], 3)

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -9,6 +9,7 @@ import unittest
 import pytest
 import os
 
+from ml_git.constants import EntityType
 from ml_git.spec import yaml_load, incr_version, is_valid_version, search_spec_file, SearchSpecException, spec_parse, \
     get_spec_file_dir, increment_version_in_spec, get_root_path, get_version, update_store_spec, validate_bucket_name, \
     set_version_in_spec
@@ -24,10 +25,10 @@ class SpecTestCases(unittest.TestCase):
         file = os.path.join(testdir, 'sample.spec')
         spec_hash = yaml_load(file)
         yaml_save(spec_hash, tmpfile)
-        version = spec_hash['datasets']['version']
+        version = spec_hash[EntityType.DATASETS.value]['version']
         incr_version(tmpfile)
         incremented_hash = yaml_load(tmpfile)
-        self.assertEqual(incremented_hash['datasets']['version'], version + 1)
+        self.assertEqual(incremented_hash[EntityType.DATASETS.value]['version'], version + 1)
 
         incr_version('non-existent-file')
 
@@ -54,7 +55,7 @@ class SpecTestCases(unittest.TestCase):
     def test_search_spec_file(self):
         categories_path = ''
         specpath = 'dataset-ex'
-        spec_dir = os.path.join(self.tmp_dir, 'datasets')
+        spec_dir = os.path.join(self.tmp_dir, EntityType.DATASETS.value)
         spec_dir_c = os.path.join(spec_dir, categories_path, specpath)
 
         os.mkdir(spec_dir)
@@ -92,7 +93,7 @@ class SpecTestCases(unittest.TestCase):
     def test_increment_version_in_dataset_spec(self):
         dataset = 'test_dataset'
         dir1 = get_spec_file_dir(dataset)
-        dir2 = os.path.join('.ml-git', 'datasets', 'index', 'metadata', dataset)  # Linked path to the original
+        dir2 = os.path.join('.ml-git', EntityType.DATASETS.value, 'index', 'metadata', dataset)  # Linked path to the original
         os.makedirs(os.path.join(self.tmp_dir, dir1))
         os.makedirs(os.path.join(self.tmp_dir, dir2))
         file1 = os.path.join(self.tmp_dir, dir1, '%s.spec' % dataset)
@@ -110,7 +111,7 @@ class SpecTestCases(unittest.TestCase):
         yaml_save(spec, file1)
         os.link(file1, file2)
         self.assertTrue(increment_version_in_spec(
-            os.path.join(get_root_path(), self.tmp_dir, 'datasets', dataset, dataset + '.spec')))
+            os.path.join(get_root_path(), self.tmp_dir, EntityType.DATASETS.value, dataset, dataset + '.spec')))
 
     def test_get_version(self):
         file = os.path.join(testdir, 'valid.spec')
@@ -119,18 +120,19 @@ class SpecTestCases(unittest.TestCase):
         self.assertTrue(get_version(file) < 0)
 
     def test_update_store_spec(self):
-        spec_path = os.path.join(os.getcwd(), os.sep.join(['datasets', 'dataex', 'dataex.spec']))
+        DATASETS = EntityType.DATASETS.value
+        spec_path = os.path.join(os.getcwd(), os.sep.join([DATASETS, 'dataex', 'dataex.spec']))
 
-        update_store_spec('datasets', 'dataex', 's3h', 'fakestore')
+        update_store_spec(DATASETS, 'dataex', 's3h', 'fakestore')
         spec1 = yaml_load(spec_path)
-        self.assertEqual(spec1['datasets']['manifest']['store'], 's3h://fakestore')
+        self.assertEqual(spec1[DATASETS]['manifest']['store'], 's3h://fakestore')
 
-        update_store_spec('datasets', 'dataex', 's3h', 'some-bucket-name')
+        update_store_spec(DATASETS, 'dataex', 's3h', 'some-bucket-name')
         spec2 = yaml_load(spec_path)
-        self.assertEqual(spec2['datasets']['manifest']['store'], 's3h://some-bucket-name')
+        self.assertEqual(spec2[DATASETS]['manifest']['store'], 's3h://some-bucket-name')
 
     def test_validate_bucket_name(self):
-        repo_type = 'datasets'
+        repo_type = EntityType.DATASETS.value
         config = yaml_load(os.path.join(os.getcwd(), '.ml-git', 'config.yaml'))
         spec_with_wrong_bucket_name = yaml_load(os.path.join(testdir, 'invalid4.spec'))
         self.assertFalse(validate_bucket_name(spec_with_wrong_bucket_name[repo_type], config))
@@ -150,6 +152,6 @@ class SpecTestCases(unittest.TestCase):
         file = os.path.join(testdir, 'sample.spec')
         spec_hash = yaml_load(file)
         yaml_save(spec_hash, tmpfile)
-        set_version_in_spec(3, tmpfile, 'datasets')
+        set_version_in_spec(3, tmpfile, EntityType.DATASETS.value)
         spec_hash = yaml_load(tmpfile)
-        self.assertEqual(spec_hash['datasets']['version'], 3)
+        self.assertEqual(spec_hash[EntityType.DATASETS.value]['version'], 3)


### PR DESCRIPTION
Depends on PR #69 .

Updating unit tests to use plural entity names and adding new tests for the project update scenario.