### PR TITLE
[plural entity names] Updating integration tests to use plural entity names

### DIFF
--- a/tests/integration/gdrive_store/test_32_gdrive_store.py
+++ b/tests/integration/gdrive_store/test_32_gdrive_store.py
@@ -10,7 +10,7 @@ import pytest
 
 from ml_git.constants import Mutability
 from tests.integration.commands import MLGIT_IMPORT, MLGIT_CREATE, MLGIT_INIT
-from tests.integration.helper import ML_GIT_DIR, CREDENTIALS_PATH, ERROR_MESSAGE
+from tests.integration.helper import ML_GIT_DIR, CREDENTIALS_PATH, ERROR_MESSAGE, DATASETS, DATASET_NAME
 from tests.integration.helper import check_output, clear, init_repository, add_file
 from tests.integration.output_messages import messages
 
@@ -21,35 +21,35 @@ class GdrivePushFilesAcceptanceTests(unittest.TestCase):
     @pytest.mark.usefixtures('switch_to_tmp_dir_with_gdrive_credentials', 'start_local_git_server')
     def test_01_push_and_checkout(self):
         cpath = 'credentials-json'
-        init_repository('dataset', self, store_type='gdriveh', profile=cpath)
-        add_file(self, 'dataset', '--bumpversion', 'new')
-        metadata_path = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata')
-        self.assertIn(messages[17] % (metadata_path, os.path.join('computer-vision', 'images', 'dataset-ex')),
-                      check_output('ml-git dataset commit dataset-ex'))
+        init_repository(DATASETS, self, store_type='gdriveh', profile=cpath)
+        add_file(self, DATASETS, '--bumpversion', 'new')
+        metadata_path = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata')
+        self.assertIn(messages[17] % (metadata_path, os.path.join('computer-vision', 'images', DATASET_NAME)),
+                      check_output('ml-git datasets commit datasets-ex'))
 
-        HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'refs', 'dataset-ex', 'HEAD')
+        HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'refs', DATASET_NAME, 'HEAD')
 
         self.assertTrue(os.path.exists(HEAD))
-        self.assertNotIn(ERROR_MESSAGE, check_output('ml-git dataset push dataset-ex'))
+        self.assertNotIn(ERROR_MESSAGE, check_output('ml-git datasets push datasets-ex'))
         os.chdir(metadata_path)
 
-        tag = 'computer-vision__images__dataset-ex__2'
+        tag = 'computer-vision__images__datasets-ex__2'
         self.assertIn(tag, check_output('git describe --tags'))
 
         os.chdir(self.tmp_dir)
 
-        workspace = os.path.join(self.tmp_dir, 'dataset')
+        workspace = os.path.join(self.tmp_dir, DATASETS)
         clear(workspace)
         clear(os.path.join(self.tmp_dir, ML_GIT_DIR))
-        init_repository('dataset', self, store_type='gdriveh', profile=cpath)
+        init_repository(DATASETS, self, store_type='gdriveh', profile=cpath)
 
-        self.assertNotIn(ERROR_MESSAGE, check_output('ml-git dataset checkout %s' % tag))
+        self.assertNotIn(ERROR_MESSAGE, check_output('ml-git datasets checkout %s' % tag))
 
-        objects = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'objects')
-        refs = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'refs')
-        cache = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'cache')
-        spec_file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'dataset-ex.spec')
-        file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'newfile0')
+        objects = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'objects')
+        refs = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'refs')
+        cache = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'cache')
+        spec_file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'datasets-ex.spec')
+        file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile0')
 
         self.assertTrue(os.path.exists(objects))
         self.assertTrue(os.path.exists(refs))
@@ -60,18 +60,18 @@ class GdrivePushFilesAcceptanceTests(unittest.TestCase):
     @pytest.mark.usefixtures('switch_to_tmp_dir_with_gdrive_credentials', 'start_local_git_server')
     def test_02_import_with_gdrive(self):
         cpath = 'credentials-json'
-        init_repository('dataset', self)
+        init_repository(DATASETS, self)
 
-        file_path_b = os.path.join('dataset-ex', 'B')
+        file_path_b = os.path.join(DATASET_NAME, 'B')
         self.assertNotIn(ERROR_MESSAGE, check_output(
-            MLGIT_IMPORT % ('dataset', 'mlgit', 'dataset-ex') + ' --store-type=gdrive --object=B --credentials=' + CREDENTIALS_PATH))
+            MLGIT_IMPORT % (DATASETS, 'mlgit', DATASET_NAME) + ' --store-type=gdrive --object=B --credentials=' + CREDENTIALS_PATH))
 
         self.assertTrue(os.path.exists(file_path_b))
 
-        file_path = os.path.join('dataset-ex', 'test-folder', 'A')
+        file_path = os.path.join(DATASET_NAME, 'test-folder', 'A')
 
         self.assertNotIn(ERROR_MESSAGE, check_output(
-            MLGIT_IMPORT % ('dataset', 'mlgit', 'dataset-ex') + ' --store-type=gdrive --path=test-folder --credentials=' + cpath))
+            MLGIT_IMPORT % (DATASETS, 'mlgit', DATASET_NAME) + ' --store-type=gdrive --path=test-folder --credentials=' + cpath))
 
         self.assertTrue(os.path.exists(file_path))
 
@@ -79,20 +79,20 @@ class GdrivePushFilesAcceptanceTests(unittest.TestCase):
     def test_03_create_gdrive(self):
         self.assertIn(messages[0], check_output(MLGIT_INIT))
 
-        self.assertIn(messages[38], check_output(MLGIT_CREATE % ('dataset', 'dataset-ex')
+        self.assertIn(messages[38], check_output(MLGIT_CREATE % (DATASETS, DATASET_NAME)
                                                  + ' --category=imgs --bucket-name=test --import-url=%s --credentials-path=%s '
                                                  % (self.gdrive_links['test-folder'], CREDENTIALS_PATH)
                                                  + 'mutability=%s' % (Mutability.STRICT.value)))
 
-        file_a_test_folder = os.path.join('dataset', 'dataset-ex', 'data', 'test-folder', 'A')
+        file_a_test_folder = os.path.join(DATASETS, DATASET_NAME, 'data', 'test-folder', 'A')
 
         self.assertTrue(os.path.exists(file_a_test_folder))
 
-        self.assertIn(messages[38], check_output(MLGIT_CREATE % ('dataset', 'dataset-ex2')
+        self.assertIn(messages[38], check_output(MLGIT_CREATE % (DATASETS, 'datasets-ex2')
                                                  + ' --category=imgs --bucket-name=test --import-url=%s --credentials-path=%s'
                                                  % (self.gdrive_links['B'], CREDENTIALS_PATH)
                                                  + 'mutability=%s' % (Mutability.STRICT.value)))
 
-        file_b = os.path.join('dataset', 'dataset-ex2', 'data', 'B')
+        file_b = os.path.join(DATASETS, 'datasets-ex2', 'data', 'B')
 
         self.assertTrue(os.path.exists(file_b))

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -15,7 +15,7 @@ from zipfile import ZipFile
 
 from ruamel.yaml import YAML
 
-from ml_git.constants import StoreType, GLOBAL_ML_GIT_CONFIG, Mutability
+from ml_git.constants import StoreType, GLOBAL_ML_GIT_CONFIG, Mutability, EntityType
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_INIT, MLGIT_REMOTE_ADD, MLGIT_ENTITY_INIT, MLGIT_ADD, \
     MLGIT_STORE_ADD_WITH_TYPE, MLGIT_REMOTE_ADD_GLOBAL, MLGIT_STORE_ADD, MLGIT_STORE_ADD_WITHOUT_CREDENTIALS, \
@@ -37,6 +37,11 @@ CREDENTIALS_PATH = os.path.join(os.getcwd(), 'tests', 'integration', 'credential
 MINIO_ENDPOINT_URL = 'http://127.0.0.1:9000'
 GDRIVE_LINKS = os.path.join(os.getcwd(), 'tests', 'integration', 'gdrive-files-links.json')
 GLOBAL_CONFIG_PATH = os.path.join(os.getcwd(), 'tests', 'integration', 'globalconfig')
+
+DATASETS = EntityType.DATASETS.value
+DATASET_NAME = 'datasets-ex'
+MODELS = EntityType.MODELS.value
+LABELS = EntityType.LABELS.value
 
 
 def get_yaml_processor(typ='safe', default_flow_style=False):
@@ -154,9 +159,9 @@ def add_file(self, entity, bumpversion, name=None, artifact_name=None, file_cont
     with open(os.path.join(self.tmp_dir, entity, artifact_name, 'newfile4'), 'wt') as z:
         z.write(str(file_content * 100))
     # Create assert do ml-git add
-    if entity == 'dataset':
-        self.assertIn(messages[13] % 'dataset', check_output(MLGIT_ADD % (entity, artifact_name, bumpversion)))
-    elif entity == 'model':
+    if entity == DATASETS:
+        self.assertIn(messages[13] % 'datasets', check_output(MLGIT_ADD % (entity, artifact_name, bumpversion)))
+    elif entity == MODELS:
         self.assertIn(messages[14], check_output(MLGIT_ADD % (entity, artifact_name, bumpversion)))
     else:
         self.assertIn(messages[15], check_output(MLGIT_ADD % (entity, artifact_name, bumpversion)))
@@ -196,7 +201,7 @@ def clean_git():
 
 def create_git_clone_repo(git_dir, tmp_dir, git_path=GIT_PATH):
     config = {
-        'dataset': {
+        'datasets': {
             'git': os.path.join(tmp_dir, git_path),
         },
         'store': {
@@ -298,7 +303,7 @@ def delete_global_config():
         __remove_file(global_config_file)
 
 
-def change_git_in_config(ml_git_dir, git_url, entity='dataset'):
+def change_git_in_config(ml_git_dir, git_url, entity=DATASETS):
     with open(os.path.join(ml_git_dir, 'config.yaml'), 'r') as config_file:
         config = yaml_processor.load(config_file)
         config[entity]['git'] = git_url

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -40,6 +40,7 @@ GLOBAL_CONFIG_PATH = os.path.join(os.getcwd(), 'tests', 'integration', 'globalco
 
 DATASETS = EntityType.DATASETS.value
 DATASET_NAME = 'datasets-ex'
+DATASET_TAG = 'computer-vision__images__datasets-ex__1'
 MODELS = EntityType.MODELS.value
 LABELS = EntityType.LABELS.value
 
@@ -160,7 +161,7 @@ def add_file(self, entity, bumpversion, name=None, artifact_name=None, file_cont
         z.write(str(file_content * 100))
     # Create assert do ml-git add
     if entity == DATASETS:
-        self.assertIn(messages[13] % 'datasets', check_output(MLGIT_ADD % (entity, artifact_name, bumpversion)))
+        self.assertIn(messages[13] % DATASETS, check_output(MLGIT_ADD % (entity, artifact_name, bumpversion)))
     elif entity == MODELS:
         self.assertIn(messages[14], check_output(MLGIT_ADD % (entity, artifact_name, bumpversion)))
     else:
@@ -201,7 +202,7 @@ def clean_git():
 
 def create_git_clone_repo(git_dir, tmp_dir, git_path=GIT_PATH):
     config = {
-        'datasets': {
+        DATASETS: {
             'git': os.path.join(tmp_dir, git_path),
         },
         'store': {

--- a/tests/integration/output_messages.py
+++ b/tests/integration/output_messages.py
@@ -18,7 +18,7 @@ messages = [
     'ERROR - Repository: Unable to find remote repository. Add the remote first.',  # 11
     'INFO - Admin: Add remote repository [%s] for [model]',  # 12
     'INFO - Repository: %s adding path',  # 13
-    'INFO - Repository: model adding path',  # 14
+    'INFO - Repository: models adding path',  # 14
     'INFO - Repository: labels adding path',  # 15
     'ERROR - Repository: The entity name passed is wrong. Please check again',  # 16
     'INFO - Metadata Manager: Commit repo[%s] --- file[%s]',  # 17

--- a/tests/integration/test_02_add_remote.py
+++ b/tests/integration/test_02_add_remote.py
@@ -10,7 +10,7 @@ import pytest
 
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_INIT, MLGIT_REMOTE_ADD
-from tests.integration.helper import check_output, ML_GIT_DIR, GIT_PATH, yaml_processor
+from tests.integration.helper import check_output, ML_GIT_DIR, GIT_PATH, yaml_processor, DATASETS, LABELS, MODELS
 from tests.integration.output_messages import messages
 
 
@@ -27,39 +27,39 @@ class AddRemoteAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_01_add_remote_dataset(self):
-        self._add_remote('dataset')
+        self._add_remote(DATASETS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_02_add_remote_labels(self):
-        self._add_remote('labels')
+        self._add_remote(LABELS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_03_add_remote_model(self):
-        self._add_remote('model')
+        self._add_remote(MODELS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_04_add_remote_subfolder(self):
         self.assertIn(messages[0], check_output(MLGIT_INIT))
         os.chdir(os.path.join(self.tmp_dir, ML_GIT_DIR))
-        self.assertIn(messages[2] % (GIT_PATH, 'dataset'), check_output(MLGIT_REMOTE_ADD % ('dataset', GIT_PATH)))
+        self.assertIn(messages[2] % (GIT_PATH, DATASETS), check_output(MLGIT_REMOTE_ADD % (DATASETS, GIT_PATH)))
         self.check_remote_in_config(os.path.join('config.yaml'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_05_add_remote_uninitialized_directory(self):
-        self.assertIn(messages[34], check_output(MLGIT_REMOTE_ADD % ('dataset', GIT_PATH)))
+        self.assertIn(messages[34], check_output(MLGIT_REMOTE_ADD % (DATASETS, GIT_PATH)))
         self.assertFalse(os.path.exists('.ml-git'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_06_change_remote_repository(self):
         self.assertIn(output_messages['INFO_INITIALIZED_PROJECT'] % self.tmp_dir, check_output(MLGIT_INIT))
-        self.assertIn(output_messages['INFO_ADD_REMOTE'] % (GIT_PATH, 'dataset'), check_output(MLGIT_REMOTE_ADD % ('dataset', GIT_PATH)))
+        self.assertIn(output_messages['INFO_ADD_REMOTE'] % (GIT_PATH, DATASETS), check_output(MLGIT_REMOTE_ADD % (DATASETS, GIT_PATH)))
         self.check_remote_in_config(os.path.join(ML_GIT_DIR, 'config.yaml'))
-        output_message = check_output(MLGIT_REMOTE_ADD % ('dataset', 'second_path'))
+        output_message = check_output(MLGIT_REMOTE_ADD % (DATASETS, 'second_path'))
         self.assertIn(output_messages['WARN_HAS_CONFIGURED_REMOTE'], output_message)
-        self.assertIn(output_messages['INFO_CHANGING_REMOTE'] % (GIT_PATH, 'second_path', 'dataset'), output_message)
+        self.assertIn(output_messages['INFO_CHANGING_REMOTE'] % (GIT_PATH, 'second_path', DATASETS), output_message)
         self.check_remote_in_config(os.path.join(ML_GIT_DIR, 'config.yaml'), 'second_path')
 
     def check_remote_in_config(self, path, git_repo=GIT_PATH):
         with open(path, 'r') as c:
             config = yaml_processor.load(c)
-            self.assertEqual(git_repo, config['dataset']['git'])
+            self.assertEqual(git_repo, config[DATASETS]['git'])

--- a/tests/integration/test_04_init_entity.py
+++ b/tests/integration/test_04_init_entity.py
@@ -11,7 +11,7 @@ import pytest
 
 from tests.integration.commands import MLGIT_INIT, MLGIT_REMOTE_ADD, MLGIT_STORE_ADD, MLGIT_ENTITY_INIT
 from tests.integration.helper import ML_GIT_DIR, GIT_PATH, \
-    GIT_WRONG_REP, BUCKET_NAME, PROFILE, STORE_TYPE, GLOBAL_CONFIG_PATH, delete_global_config
+    GIT_WRONG_REP, BUCKET_NAME, PROFILE, STORE_TYPE, GLOBAL_CONFIG_PATH, delete_global_config, DATASETS, LABELS, MODELS
 from tests.integration.helper import check_output
 from tests.integration.output_messages import messages
 
@@ -32,43 +32,43 @@ class InitEntityAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_initialize_dataset(self):
-        self.set_up_init('dataset', os.path.join(self.tmp_dir, GIT_PATH))
-        self._initialize_entity('dataset')
+        self.set_up_init(DATASETS, os.path.join(self.tmp_dir, GIT_PATH))
+        self._initialize_entity(DATASETS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_initialize_dataset_twice_entity(self):
-        self.set_up_init('dataset', os.path.join(self.tmp_dir, GIT_PATH))
-        self._initialize_entity('dataset')
-        self.assertIn(messages[9] % os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata'),
-                      check_output(MLGIT_ENTITY_INIT % 'dataset'))
+        self.set_up_init(DATASETS, os.path.join(self.tmp_dir, GIT_PATH))
+        self._initialize_entity(DATASETS)
+        self.assertIn(messages[9] % os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata'),
+                      check_output(MLGIT_ENTITY_INIT % DATASETS))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_initialize_dataset_from_subfolder(self):
-        self.set_up_init('dataset', os.path.join(self.tmp_dir, GIT_PATH))
+        self.set_up_init(DATASETS, os.path.join(self.tmp_dir, GIT_PATH))
         os.chdir(os.path.join(self.tmp_dir, ML_GIT_DIR))
-        self.assertIn(messages[8] % (os.path.join(self.tmp_dir, GIT_PATH), os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata')),
-                      check_output(MLGIT_ENTITY_INIT % 'dataset'))
+        self.assertIn(messages[8] % (os.path.join(self.tmp_dir, GIT_PATH), os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata')),
+                      check_output(MLGIT_ENTITY_INIT % DATASETS))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_initialize_dataset_from_wrong_repository(self):
         self.assertIn(messages[0], check_output(MLGIT_INIT))
-        self.assertIn(messages[2] % (GIT_WRONG_REP, 'dataset'), check_output(MLGIT_REMOTE_ADD % ('dataset', GIT_WRONG_REP)))
+        self.assertIn(messages[2] % (GIT_WRONG_REP, DATASETS), check_output(MLGIT_REMOTE_ADD % (DATASETS, GIT_WRONG_REP)))
         self.assertIn(messages[7] % (STORE_TYPE, BUCKET_NAME, PROFILE), check_output(MLGIT_STORE_ADD % (BUCKET_NAME, PROFILE)))
-        self.assertIn(messages[10] % GIT_WRONG_REP, check_output(MLGIT_ENTITY_INIT % 'dataset'))
+        self.assertIn(messages[10] % GIT_WRONG_REP, check_output(MLGIT_ENTITY_INIT % DATASETS))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     @mock.patch.dict(os.environ, {'HOME': GLOBAL_CONFIG_PATH})
     def test_05_initialize_dataset_without_repository_and_storage(self):
         delete_global_config()
         self.assertIn(messages[0], check_output(MLGIT_INIT))
-        self.assertIn(messages[11], check_output(MLGIT_ENTITY_INIT % 'dataset'))
+        self.assertIn(messages[11], check_output(MLGIT_ENTITY_INIT % DATASETS))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_06_initialize_labels(self):
-        self.set_up_init('labels', os.path.join(self.tmp_dir, GIT_PATH))
-        self._initialize_entity('labels')
+        self.set_up_init(LABELS, os.path.join(self.tmp_dir, GIT_PATH))
+        self._initialize_entity(LABELS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_07_initialize_model(self):
-        self.set_up_init('model', os.path.join(self.tmp_dir, GIT_PATH))
-        self._initialize_entity('model')
+        self.set_up_init(MODELS, os.path.join(self.tmp_dir, GIT_PATH))
+        self._initialize_entity(MODELS)

--- a/tests/integration/test_05_add_files.py
+++ b/tests/integration/test_05_add_files.py
@@ -10,7 +10,7 @@ from stat import S_IWUSR, S_IREAD
 import pytest
 
 from tests.integration.helper import ML_GIT_DIR, create_spec, init_repository, ERROR_MESSAGE, MLGIT_ADD, \
-    create_file
+    create_file, DATASETS, DATASET_NAME, MODELS, LABELS
 from tests.integration.helper import clear, check_output, add_file, entity_init, yaml_processor
 from tests.integration.output_messages import messages
 
@@ -19,39 +19,39 @@ from tests.integration.output_messages import messages
 class AddFilesAcceptanceTests(unittest.TestCase):
 
     def set_up_add(self):
-        init_repository('dataset', self)
-        workspace = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex')
+        init_repository(DATASETS, self)
+        workspace = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME)
         clear(workspace)
         os.makedirs(workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_add_files_to_dataset(self):
-        entity_init('dataset', self)
-        add_file(self, 'dataset', '', 'new')
+        entity_init(DATASETS, self)
+        add_file(self, DATASETS, '', 'new')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_add_files_to_model(self):
-        entity_init('model', self)
-        add_file(self, 'model', '', 'new')
+        entity_init(MODELS, self)
+        add_file(self, MODELS, '', 'new')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_add_files_to_labels(self):
-        entity_init('labels', self)
-        add_file(self, 'labels', '', 'new')
+        entity_init(LABELS, self)
+        add_file(self, LABELS, '', 'new')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_add_files_with_bumpversion(self):
-        entity_init('dataset', self)
-        add_file(self, 'dataset', '--bumpversion', 'new')
+        entity_init(DATASETS, self)
+        add_file(self, DATASETS, '--bumpversion', 'new')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_add_command_without_file_added(self):
         self.set_up_add()
 
-        create_spec(self, 'dataset', self.tmp_dir)
+        create_spec(self, DATASETS, self.tmp_dir)
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '')))
-        self.assertIn(messages[27], check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '')))
+        self.assertIn(messages[27], check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion')))
 
     def _check_index(self, index, files_in, files_not_in):
         with open(index, 'r') as file:
@@ -63,23 +63,23 @@ class AddFilesAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_06_add_command_with_corrupted_file_added(self):
-        entity_init('dataset', self)
+        entity_init(DATASETS, self)
 
-        add_file(self, 'dataset', '--bumpversion', 'new')
-        corrupted_file = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'newfile0')
+        add_file(self, DATASETS, '--bumpversion', 'new')
+        corrupted_file = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, 'newfile0')
 
         os.chmod(corrupted_file, S_IWUSR | S_IREAD)
         with open(corrupted_file, 'wb') as z:
             z.write(b'0' * 0)
 
-        self.assertIn(messages[67], check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion')))
+        self.assertIn(messages[67], check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion')))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_07_add_command_with_multiple_files(self):
         self.set_up_add()
 
-        create_spec(self, 'dataset', self.tmp_dir)
-        workspace = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex')
+        create_spec(self, DATASETS, self.tmp_dir)
+        workspace = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME)
 
         os.makedirs(os.path.join(workspace, 'data'))
 
@@ -87,12 +87,12 @@ class AddFilesAcceptanceTests(unittest.TestCase):
         create_file(workspace, 'file2', '1')
         create_file(workspace, 'file3', '1')
 
-        self.assertIn(messages[13] % 'dataset', check_output(MLGIT_ADD % ('dataset', 'dataset-ex',
-                                                                          os.path.join('data', 'file1'))))
-        index = os.path.join(ML_GIT_DIR, 'dataset', 'index', 'metadata', 'dataset-ex', 'INDEX.yaml')
+        self.assertIn(messages[13] % DATASETS, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME,
+                                                                         os.path.join('data', 'file1'))))
+        index = os.path.join(ML_GIT_DIR, DATASETS, 'index', 'metadata', DATASET_NAME, 'INDEX.yaml')
         self._check_index(index, ['data/file1'], ['data/file2', 'data/file3'])
-        self.assertIn(messages[13] % 'dataset', check_output(MLGIT_ADD % ('dataset', 'dataset-ex', 'data')))
+        self.assertIn(messages[13] % DATASETS, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, 'data')))
         self._check_index(index, ['data/file1', 'data/file2', 'data/file3'], [])
         create_file(workspace, 'file4', '0')
-        self.assertIn(messages[13] % 'dataset', check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '')))
+        self.assertIn(messages[13] % DATASETS, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '')))
         self._check_index(index, ['data/file1', 'data/file2', 'data/file3', 'data/file4'], [])

--- a/tests/integration/test_06_commit_files.py
+++ b/tests/integration/test_06_commit_files.py
@@ -10,7 +10,7 @@ import pytest
 
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_ADD
 from tests.integration.helper import check_output, add_file, ML_GIT_DIR, entity_init, create_spec, create_file, \
-    init_repository
+    init_repository, DATASETS, LABELS, MODELS, DATASET_NAME
 from tests.integration.output_messages import messages
 
 
@@ -28,79 +28,79 @@ class CommitFilesAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_commit_files_to_dataset(self):
-        self._commit_entity('dataset')
+        self._commit_entity(DATASETS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_commit_files_to_labels(self):
-        self._commit_entity('labels')
+        self._commit_entity(LABELS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_commit_files_to_model(self):
-        self._commit_entity('model')
+        self._commit_entity(MODELS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_commit_command_with_version(self):
-        init_repository('dataset', self)
-        create_spec(self, 'dataset', self.tmp_dir)
-        workspace = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex')
+        init_repository(DATASETS, self)
+        create_spec(self, DATASETS, self.tmp_dir)
+        workspace = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME)
 
         os.makedirs(os.path.join(workspace, 'data'))
 
         create_file(workspace, 'file1', '0')
-        self.assertIn(messages[13] % 'dataset',
-                      check_output(MLGIT_ADD % ('dataset', 'dataset-ex', "")))
-        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata'),
-                                      os.path.join('computer-vision', 'images', 'dataset' + '-ex')),
-                      check_output(MLGIT_COMMIT % ('dataset', 'dataset' + '-ex', '')))
+        self.assertIn(messages[13] % DATASETS,
+                      check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, "")))
+        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata'),
+                                      os.path.join('computer-vision', 'images', DATASET_NAME)),
+                      check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '')))
 
         create_file(workspace, 'file2', '1')
-        self.assertIn(messages[13] % 'dataset',
-                      check_output(MLGIT_ADD % ('dataset', 'dataset-ex', "")))
+        self.assertIn(messages[13] % DATASETS,
+                      check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, "")))
 
         self.assertIn(messages[96] % '-10',
-                      check_output(MLGIT_COMMIT % ('dataset', 'dataset' + '-ex', ' --version=-10')))
+                      check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, ' --version=-10')))
 
         self.assertIn(messages[96] % 'test',
-                      check_output(MLGIT_COMMIT % ('dataset', 'dataset' + '-ex', '--version=test')))
+                      check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '--version=test')))
 
-        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata'),
-                                      os.path.join('computer-vision', 'images', 'dataset' + '-ex')),
-                      check_output(MLGIT_COMMIT % ('dataset', 'dataset' + '-ex', '--version=2')))
+        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata'),
+                                      os.path.join('computer-vision', 'images', DATASET_NAME)),
+                      check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '--version=2')))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_commit_command_with_deprecated_version_number(self):
-        init_repository('dataset', self)
-        create_spec(self, 'dataset', self.tmp_dir)
-        workspace = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex')
+        init_repository(DATASETS, self)
+        create_spec(self, DATASETS, self.tmp_dir)
+        workspace = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME)
         os.makedirs(os.path.join(workspace, 'data'))
         create_file(workspace, 'file1', '0')
-        self.assertIn(messages[13] % 'dataset',
-                      check_output(MLGIT_ADD % ('dataset', 'dataset-ex', "")))
+        self.assertIn(messages[13] % DATASETS,
+                      check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, "")))
 
-        result = check_output(MLGIT_COMMIT % ('dataset', 'dataset' + '-ex', '--version-number=2'))
+        result = check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '--version-number=2'))
 
         self.assertIn(messages[106] % ('--version-number', '--version'), result)
-        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata'),
-                                      os.path.join('computer-vision', 'images', 'dataset' + '-ex')), result)
+        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata'),
+                                      os.path.join('computer-vision', 'images', DATASET_NAME)), result)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_06_commit_with_large_version_number(self):
-        init_repository('dataset', self)
-        create_spec(self, 'dataset', self.tmp_dir)
+        init_repository(DATASETS, self)
+        create_spec(self, DATASETS, self.tmp_dir)
         self.assertIn(messages[96] % '9999999999',
-                      check_output(MLGIT_COMMIT % ('dataset', 'dataset' + '-ex', ' --version=9999999999')))
+                      check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, ' --version=9999999999')))
         self.assertIn(messages[96] % '9999999999',
-                      check_output(MLGIT_COMMIT % ('model', 'model' + '-ex', ' --version=9999999999')))
+                      check_output(MLGIT_COMMIT % (MODELS, MODELS + '-ex', ' --version=9999999999')))
         self.assertIn(messages[96] % '9999999999',
-                      check_output(MLGIT_COMMIT % ('labels', 'labels' + '-ex', ' --version=9999999999')))
+                      check_output(MLGIT_COMMIT % (LABELS, LABELS + '-ex', ' --version=9999999999')))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_commit_tag_that_already_exists(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         self._commit_entity(entity_type)
         with open(os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'newfile5'), 'wt') as z:
             z.write(str('0' * 100))
-        self.assertIn(messages[13] % 'dataset', check_output(MLGIT_ADD % (entity_type, entity_type+'-ex', '')))
-        self.assertIn(messages[104] % 'computer-vision__images__dataset-ex__2', check_output(MLGIT_COMMIT % (entity_type, entity_type+'-ex', '')))
+        self.assertIn(messages[13] % DATASETS, check_output(MLGIT_ADD % (entity_type, entity_type+'-ex', '')))
+        self.assertIn(messages[104] % 'computer-vision__images__datasets-ex__2', check_output(MLGIT_COMMIT % (entity_type, entity_type+'-ex', '')))
         head_path = os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'refs', entity_type + '-ex', 'HEAD')
         self.assertTrue(os.path.exists(head_path))

--- a/tests/integration/test_07_push_files.py
+++ b/tests/integration/test_07_push_files.py
@@ -12,7 +12,7 @@ import pytest
 
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_PUSH
-from tests.integration.helper import ML_GIT_DIR, MINIO_BUCKET_PATH, GIT_PATH
+from tests.integration.helper import ML_GIT_DIR, MINIO_BUCKET_PATH, GIT_PATH, DATASETS, LABELS, MODELS, DATASET_NAME
 from tests.integration.helper import check_output, clear, init_repository, add_file, ERROR_MESSAGE
 from tests.integration.output_messages import messages
 
@@ -34,7 +34,7 @@ class PushFilesAcceptanceTests(unittest.TestCase):
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_PUSH % (entity_type, entity_type+'-ex')))
         self.check_metadata_after_push(entity_type)
 
-    def check_metadata_after_push(self, entity_type='dataset'):
+    def check_metadata_after_push(self, entity_type=DATASETS):
         metadata_path = os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'metadata')
         os.chdir(metadata_path)
         self.assertTrue(os.path.exists(
@@ -43,46 +43,46 @@ class PushFilesAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_push_files_to_dataset(self):
-        self._push_entity('dataset')
+        self._push_entity(DATASETS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_push_files_to_labels(self):
-        self._push_entity('labels')
+        self._push_entity(LABELS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_push_files_to_model(self):
-        self._push_entity('model')
+        self._push_entity(MODELS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_push_with_wrong_repository(self):
-        init_repository('dataset', self)
-        add_file(self, 'dataset', '--bumpversion', 'new')
-        metadata_path = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata')
-        self.assertIn(messages[17] % (metadata_path, os.path.join('computer-vision', 'images', 'dataset-ex')),
-                      check_output(MLGIT_COMMIT % ('dataset',  'dataset-ex', '')))
+        init_repository(DATASETS, self)
+        add_file(self, DATASETS, '--bumpversion', 'new')
+        metadata_path = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata')
+        self.assertIn(messages[17] % (metadata_path, os.path.join('computer-vision', 'images', DATASET_NAME)),
+                      check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '')))
 
-        HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'refs', 'dataset-ex', 'HEAD')
+        HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'refs', DATASET_NAME, 'HEAD')
         self.assertTrue(os.path.exists(HEAD))
 
         git_path = os.path.join(self.tmp_dir, GIT_PATH)
 
         clear(git_path)
 
-        output = check_output(MLGIT_PUSH % ('dataset', 'dataset-ex'))
+        output = check_output(MLGIT_PUSH % (DATASETS, DATASET_NAME))
 
         self.assertIn(ERROR_MESSAGE, output)
         self.assertIn(git_path, output)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_push_with_wrong_credentials_profile(self):
-        entity_type = 'dataset'
-        artifact_name = 'dataset-ex'
+        entity_type = DATASETS
+        artifact_name = DATASET_NAME
         init_repository(entity_type, self, profile='personal2')
         add_file(self, entity_type, '--bumpversion', 'new')
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (entity_type,  artifact_name, '')))
         self.assertIn(output_messages['ERROR_AWS_KEY_NOT_EXIST'], check_output(MLGIT_PUSH % (entity_type, artifact_name)))
 
-    def set_up_push_without_profile(self, entity_type='dataset', artifact_name='dataset-ex'):
+    def set_up_push_without_profile(self, entity_type=DATASETS, artifact_name=DATASET_NAME):
         init_repository(entity_type, self, profile=None)
         add_file(self, entity_type, '--bumpversion', 'new')
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (entity_type, artifact_name, '')))
@@ -91,8 +91,8 @@ class PushFilesAcceptanceTests(unittest.TestCase):
     @mock.patch.dict(os.environ, {'AWS_ACCESS_KEY_ID': 'fake_access_key'})
     @mock.patch.dict(os.environ, {'AWS_SECRET_ACCESS_KEY': 'fake_secret_key'})
     def test_06_push_with_environment_variables(self):
-        entity_type = 'dataset'
-        artifact_name = 'dataset-ex'
+        entity_type = DATASETS
+        artifact_name = DATASET_NAME
         self.set_up_push_without_profile()
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_PUSH % (entity_type, artifact_name)))
         self.check_metadata_after_push(entity_type)
@@ -100,16 +100,16 @@ class PushFilesAcceptanceTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     @mock.patch.dict(os.environ, {'AWS_SHARED_CREDENTIALS_FILE': os.path.join(Path('./tests/integration/.aws/credentials-default').resolve())})
     def test_07_push_with_default_aws_config(self):
-        entity_type = 'dataset'
-        artifact_name = 'dataset-ex'
+        entity_type = DATASETS
+        artifact_name = DATASET_NAME
         self.set_up_push_without_profile()
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_PUSH % (entity_type, artifact_name)))
         self.check_metadata_after_push(entity_type)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_08_push_without_default_config(self):
-        entity_type = 'dataset'
-        artifact_name = 'dataset-ex'
+        entity_type = DATASETS
+        artifact_name = DATASET_NAME
         init_repository(entity_type, self, profile=None)
         add_file(self, entity_type, '--bumpversion', 'new')
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (entity_type, artifact_name, '')))

--- a/tests/integration/test_08_checkout_tag.py
+++ b/tests/integration/test_08_checkout_tag.py
@@ -14,13 +14,14 @@ from tests.integration.commands import MLGIT_CHECKOUT, MLGIT_PUSH, MLGIT_COMMIT,
 from tests.integration.helper import ML_GIT_DIR, MLGIT_INIT, MLGIT_REMOTE_ADD, MLGIT_ENTITY_INIT, MLGIT_ADD, \
     recursive_write_read, ERROR_MESSAGE, \
     add_file, GIT_PATH, check_output, clear, init_repository, BUCKET_NAME, PROFILE, edit_config_yaml, \
-    create_spec, set_write_read, STORE_TYPE, create_file, populate_entity_with_new_data
+    create_spec, set_write_read, STORE_TYPE, create_file, populate_entity_with_new_data, DATASETS, DATASET_NAME, MODELS, \
+    LABELS
 from tests.integration.output_messages import messages
 
 
 @pytest.mark.usefixtures('tmp_dir', 'aws_session')
 class CheckoutTagAcceptanceTests(unittest.TestCase):
-    entity_path = os.path.join('dataset', 'computer_vision', 'images', 'dataset-ex')
+    entity_path = os.path.join(DATASETS, 'computer_vision', 'images', 'dataset-ex')
 
     def set_up_checkout(self, entity):
         init_repository(entity, self)
@@ -42,7 +43,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         entity_dir = os.path.join(self.tmp_dir, entity_type, 'computer-vision', 'images', entity_type+'-ex')
         if expected_files == 0:
             self.assertFalse(os.path.exists(entity_dir))
-            self.assertFalse(self.check_sampling_flag('dataset'))
+            self.assertFalse(self.check_sampling_flag(DATASETS))
             return
         self.assertTrue(os.path.exists(entity_dir))
         file_count = 0
@@ -51,7 +52,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
                 file_count += 1
         self.assertEqual(file_count, expected_files)
         if sampling:
-            self.assertTrue(self.check_sampling_flag('dataset'))
+            self.assertTrue(self.check_sampling_flag(DATASETS))
 
     def check_sampling_flag(self, entity):
         sampling = os.path.join(self.tmp_dir, ML_GIT_DIR, entity, 'index', 'metadata', entity+'-ex', 'sampling')
@@ -59,19 +60,19 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_checkout_tag(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 6
-        check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1'))
-        file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'newfile0')
+        check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1'))
+        file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile0')
         self.check_metadata()
-        self.check_amount_of_files('dataset', number_of_files_in_workspace, sampling=False)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace, sampling=False)
         self.assertTrue(os.path.exists(file))
 
     def check_metadata(self):
-        objects = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'objects')
-        refs = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'refs')
-        cache = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'cache')
-        spec_file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'dataset-ex.spec')
+        objects = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'objects')
+        refs = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'refs')
+        cache = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'cache')
+        spec_file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, DATASET_NAME+'.spec')
 
         self.assertTrue(os.path.exists(objects))
         self.assertTrue(os.path.exists(refs))
@@ -80,307 +81,305 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_checkout_with_group_sample(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 3
-        check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1 --sample-type=group '
-                                                  '--sampling=2:4 --seed=5'))
+        check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1 --sample-type=group '
+                                                 '--sampling=2:4 --seed=5'))
         self.check_metadata()
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
-        self.assertTrue(self.check_sampling_flag('dataset'))
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
+        self.assertTrue(self.check_sampling_flag(DATASETS))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_group_sample_with_amount_parameter_greater_than_group_size(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[21], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[21], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=group --sampling=4:2 --seed=5'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_group_sample_with_amount_parameter_equal_to_group_size(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[21], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[21], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=group --sampling=2:2 --seed=5'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_group_sample_with_group_size_parameter_greater_than_list_size(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[22], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[22], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=group --sampling=2:30 --seed=5'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_06_group_sample_with_group_size_parameter_less_than_zero(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[41], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[41], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=group --sampling=-2:3 --seed=5'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_07_checkout_with_range_sample(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 3
-        self.assertIn('', check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn('', check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                        + ' --sample-type=range --sampling=2:4:1'))
         self.check_metadata()
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_08_range_sample_with_start_parameter_greater_than_stop(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[23], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[23], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=range --sampling=4:2:1'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_09_range_sample_with_start_parameter_less_than_zero(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[23], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[23], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=range --sampling=3:2:1'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_10_range_sample_with_step_parameter_greater_than_stop_parameter(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[26], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[26], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=range --sampling=1:3:4'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_11_range_sample_with_start_parameter_equal_to_stop(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[23], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[23], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=range --sampling=2:2:1'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_12_range_sample_with_stop_parameter_greater_than_file_list_size(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[24], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[24], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=range --sampling=2:30:1'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_13_checkout_with_random_sample(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 4
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                      + ' --sample-type=random --sampling=2:3 --seed=3'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_14_random_sample_with_frequency_less_or_equal_zero(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
 
-        self.assertIn(messages[30], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[30], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=random --sampling=2:2 --seed=3'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_15_random_sample_with_amount_parameter_greater_than_frequency(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
 
-        self.assertIn(messages[30], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[30], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=random --sampling=4:2 --seed=3'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_16_random_sample_with_frequency_greater_or_equal_list_size(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
 
-        self.assertIn(messages[31], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[31], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=random --sampling=2:10 --seed=3'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_17_random_sample_with_frequency_equal_zero(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
 
-        self.assertIn(messages[29], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[29], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=random --sampling=2:0 --seed=3'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_18_group_sample_with_group_size_parameter_equal_zero(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
 
-        self.assertIn(messages[28], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[28], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=group --sampling=1:0 --seed=5'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_19_group_sample_with_amount_parameter_equal_zero(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
 
-        self.assertIn(messages[43], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[43], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=group --sampling=0:1 --seed=5'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_20_model_related(self):
-        model = 'model'
-        dataset = 'dataset'
-        labels = 'labels'
         git_server = os.path.join(self.tmp_dir, GIT_PATH)
 
         self.assertIn(messages[0], check_output(MLGIT_INIT))
-        self.assertIn(messages[2] % (git_server, model), check_output(MLGIT_REMOTE_ADD % (model, git_server)))
+        self.assertIn(messages[2] % (git_server, MODELS), check_output(MLGIT_REMOTE_ADD % (MODELS, git_server)))
         self.assertIn(messages[7] % (STORE_TYPE, BUCKET_NAME, PROFILE),
                       check_output(MLGIT_STORE_ADD % (BUCKET_NAME, PROFILE)))
-        self.assertIn(messages[8] % (git_server, os.path.join(self.tmp_dir, '.ml-git', model, 'metadata')),
-                      check_output(MLGIT_ENTITY_INIT % 'model'))
+        self.assertIn(messages[8] % (git_server, os.path.join(self.tmp_dir, '.ml-git', MODELS, 'metadata')),
+                      check_output(MLGIT_ENTITY_INIT % MODELS))
         edit_config_yaml(os.path.join(self.tmp_dir, '.ml-git'))
-        workspace_model = os.path.join(model, model + '-ex')
+        workspace_model = os.path.join(MODELS, MODELS + '-ex')
         os.makedirs(workspace_model)
         version = 1
-        create_spec(self, model, self.tmp_dir, version)
+        create_spec(self, MODELS, self.tmp_dir, version)
         with open(os.path.join(self.tmp_dir, workspace_model, 'file1'), 'wb') as z:
             z.write(b'0' * 1024)
 
-        self.assertIn(messages[2] % (git_server, dataset), check_output(MLGIT_REMOTE_ADD % (dataset, git_server)))
+        self.assertIn(messages[2] % (git_server, DATASETS), check_output(MLGIT_REMOTE_ADD % (DATASETS, git_server)))
         self.assertIn(messages[7] % (STORE_TYPE, BUCKET_NAME, PROFILE),
                       check_output(MLGIT_STORE_ADD % (BUCKET_NAME, PROFILE)))
-        self.assertIn(messages[8] % (git_server, os.path.join(self.tmp_dir, '.ml-git', dataset, 'metadata')),
-                      check_output(MLGIT_ENTITY_INIT % 'dataset'))
+        self.assertIn(messages[8] % (git_server, os.path.join(self.tmp_dir, '.ml-git', DATASETS, 'metadata')),
+                      check_output(MLGIT_ENTITY_INIT % DATASETS))
         edit_config_yaml(os.path.join(self.tmp_dir, '.ml-git'))
-        workspace_dataset = os.path.join(dataset, dataset + '-ex')
+        workspace_dataset = os.path.join(DATASETS, DATASETS + '-ex')
         os.makedirs(workspace_dataset)
         version = 1
-        create_spec(self, dataset, self.tmp_dir, version)
+        create_spec(self, DATASETS, self.tmp_dir, version)
         with open(os.path.join(self.tmp_dir, workspace_dataset, 'file1'), 'wb') as z:
             z.write(b'0' * 1024)
 
-        self.assertIn(messages[13] % 'dataset', check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion')))
-        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, '.ml-git', 'dataset', 'metadata'),
-                                      os.path.join('computer-vision', 'images', 'dataset-ex')),
-                      check_output(MLGIT_COMMIT % ('dataset', 'dataset-ex', '')))
-        self.assertIn(messages[47], check_output(MLGIT_PUSH % ('dataset', 'dataset-ex')))
+        self.assertIn(messages[13] % DATASETS, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion')))
+        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, '.ml-git', DATASETS, 'metadata'),
+                                      os.path.join('computer-vision', 'images', DATASET_NAME)),
+                      check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '')))
+        self.assertIn(messages[47], check_output(MLGIT_PUSH % (DATASETS, DATASET_NAME)))
 
-        self.assertIn(messages[2] % (git_server, labels), check_output(MLGIT_REMOTE_ADD % (labels, git_server)))
+        self.assertIn(messages[2] % (git_server, LABELS), check_output(MLGIT_REMOTE_ADD % (LABELS, git_server)))
         self.assertIn(messages[7] % (STORE_TYPE, BUCKET_NAME, PROFILE),
                       check_output(MLGIT_STORE_ADD % (BUCKET_NAME, PROFILE)))
-        self.assertIn(messages[8] % (git_server, os.path.join(self.tmp_dir, '.ml-git', labels, 'metadata')),
-                      check_output(MLGIT_ENTITY_INIT % labels))
+        self.assertIn(messages[8] % (git_server, os.path.join(self.tmp_dir, '.ml-git', LABELS, 'metadata')),
+                      check_output(MLGIT_ENTITY_INIT % LABELS))
         edit_config_yaml(os.path.join(self.tmp_dir, '.ml-git'))
-        workspace_labels = os.path.join(labels, labels + '-ex')
+        workspace_labels = os.path.join(LABELS, LABELS + '-ex')
         os.makedirs(workspace_labels)
         version = 1
-        create_spec(self, labels, self.tmp_dir, version)
+        create_spec(self, LABELS, self.tmp_dir, version)
         with open(os.path.join(self.tmp_dir, workspace_labels, 'file1'), 'wb') as z:
             z.write(b'0' * 1024)
 
-        self.assertIn(messages[15], check_output(MLGIT_ADD % ('labels', 'labels-ex', '--bumpversion')))
-        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, '.ml-git', 'labels', 'metadata'),
-                                      os.path.join('computer-vision', 'images', 'labels-ex')),
-                      check_output(MLGIT_COMMIT % ('labels', 'labels-ex', '')))
-        self.assertIn(messages[47], check_output(MLGIT_PUSH % ('labels', 'labels-ex')))
+        self.assertIn(messages[15], check_output(MLGIT_ADD % (LABELS, LABELS+'-ex', '--bumpversion')))
+        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, '.ml-git', LABELS, 'metadata'),
+                                      os.path.join('computer-vision', 'images', LABELS+'-ex')),
+                      check_output(MLGIT_COMMIT % (LABELS, LABELS+'-ex', '')))
+        self.assertIn(messages[47], check_output(MLGIT_PUSH % (LABELS, LABELS+'-ex')))
 
-        self.assertIn(messages[14], check_output(MLGIT_ADD % ('model', 'model-ex', '--bumpversion')))
-        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, '.ml-git', 'model', 'metadata'),
-                                      os.path.join('computer-vision', 'images', 'model-ex')),
-                      check_output(MLGIT_COMMIT % ('model', 'model-ex', '--dataset=dataset-ex') + ' --labels=labels-ex'))
-        self.assertIn(messages[47], check_output(MLGIT_PUSH % ('model', 'model-ex')))
+        self.assertIn(messages[14], check_output(MLGIT_ADD % (MODELS, MODELS+'-ex', '--bumpversion')))
+        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, '.ml-git', MODELS, 'metadata'),
+                                      os.path.join('computer-vision', 'images', MODELS+'-ex')),
+                      check_output(
+                          MLGIT_COMMIT % (MODELS, MODELS+'-ex', '--dataset=datasets-ex') + ' --labels=labels-ex'))
+        self.assertIn(messages[47], check_output(MLGIT_PUSH % (MODELS, MODELS+'-ex')))
         set_write_read(os.path.join(self.tmp_dir, workspace_model, 'file1'))
         set_write_read(os.path.join(self.tmp_dir, workspace_dataset, 'file1'))
         set_write_read(os.path.join(self.tmp_dir, workspace_labels, 'file1'))
         if not sys.platform.startswith('linux'):
             recursive_write_read(os.path.join(self.tmp_dir, '.ml-git'))
-        clear(os.path.join(self.tmp_dir, model))
-        clear(os.path.join(self.tmp_dir, dataset))
-        clear(os.path.join(self.tmp_dir, labels))
-        clear(os.path.join(self.tmp_dir, '.ml-git', model))
-        clear(os.path.join(self.tmp_dir, '.ml-git', dataset))
-        clear(os.path.join(self.tmp_dir, '.ml-git', labels))
-        self.assertIn(messages[8] % (git_server, os.path.join(self.tmp_dir, '.ml-git', model, 'metadata')),
-                      check_output(MLGIT_ENTITY_INIT % model))
-        self.assertIn('', check_output(MLGIT_CHECKOUT % ('model', 'computer-vision__images__model-ex__2')
-                                       + ' -d -l'))
-        self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, model)))
-        self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, dataset)))
-        self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, labels)))
+        clear(os.path.join(self.tmp_dir, MODELS))
+        clear(os.path.join(self.tmp_dir, DATASETS))
+        clear(os.path.join(self.tmp_dir, LABELS))
+        clear(os.path.join(self.tmp_dir, '.ml-git', MODELS))
+        clear(os.path.join(self.tmp_dir, '.ml-git', DATASETS))
+        clear(os.path.join(self.tmp_dir, '.ml-git', LABELS))
+        self.assertIn(messages[8] % (git_server, os.path.join(self.tmp_dir, '.ml-git', MODELS, 'metadata')),
+                      check_output(MLGIT_ENTITY_INIT % MODELS))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (MODELS, 'computer-vision__images__models-ex__2')
+                                                     + ' -d -l'))
+        self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, MODELS)))
+        self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, DATASETS)))
+        self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, LABELS)))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_21_check_error_for_checkout_sample_with_labels(self):
-        self.set_up_checkout('labels')
-        output = check_output(MLGIT_CHECKOUT % ('labels', 'computer-vision__images__labels-ex__1 --sample-type=group '
-                                                          '--sampling=2:4 --seed=5'))
+        self.set_up_checkout(LABELS)
+        output = check_output(MLGIT_CHECKOUT % (LABELS, 'computer-vision__images__labels-ex__1 --sample-type=group '
+                                                        '--sampling=2:4 --seed=5'))
 
         self.assertIn(messages[93], output)
-        self.assertFalse(os.path.exists(os.path.join(self.tmp_dir, 'labels')))
+        self.assertFalse(os.path.exists(os.path.join(self.tmp_dir, LABELS)))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_22_check_error_for_checkout_sample_with_model(self):
-        self.set_up_checkout('model')
-        output = check_output(MLGIT_CHECKOUT % ('model', 'computer-vision__images__model-ex__1 --sample-type=group '
-                                                         '--sampling=2:4 --seed=5'))
+        self.set_up_checkout(MODELS)
+        output = check_output(MLGIT_CHECKOUT % (MODELS, 'computer-vision__images__models-ex__1 --sample-type=group '
+                                                        '--sampling=2:4 --seed=5'))
 
         self.assertIn(messages[93], output)
-        self.assertFalse(os.path.exists(os.path.join(self.tmp_dir, 'model')))
+        self.assertFalse(os.path.exists(os.path.join(self.tmp_dir, MODELS)))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_23_add_after_checkout_with_sample(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 4
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                      + ' --sample-type=random --sampling=2:3 --seed=3'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
-        workspace = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex')
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
+        workspace = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME)
         create_file(workspace, 'new_file', '0', file_path='')
-        self.assertIn(messages[95], check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '')))
+        self.assertIn(messages[95], check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '')))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_24_check_sampling_flag_after_checkout(self):
-        entity = 'dataset'
+        entity = DATASETS
         self.set_up_checkout(entity)
         number_of_files_in_workspace = 4
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (entity, 'computer-vision__images__dataset-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (entity, 'computer-vision__images__datasets-ex__1')))
         workspace = os.path.join(self.tmp_dir, entity, 'computer-vision', 'images', entity+'-ex')
         create_file(workspace, 'new_file', '0', file_path='')
         populate_entity_with_new_data(self, entity)
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                      + ' --sample-type=random --sampling=2:3 --seed=3'))
-        self.check_amount_of_files('dataset', number_of_files_in_workspace)
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__2')))
-        self.assertFalse(self.check_sampling_flag('dataset'))
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__2')))
+        self.assertFalse(self.check_sampling_flag(DATASETS))
 
     @pytest.mark.usefixtures('start_local_git_server_with_main_branch', 'switch_to_tmp_dir')
     def test_25_checkout_tag_with_main_branch(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 6
-        check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1'))
-        file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'newfile0')
+        check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1'))
+        file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile0')
         self.check_metadata()
-        self.check_amount_of_files('dataset', number_of_files_in_workspace, sampling=False)
+        self.check_amount_of_files(DATASETS, number_of_files_in_workspace, sampling=False)
         self.assertTrue(os.path.exists(file))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_26_adding_data_based_in_older_tag(self):
-        entity = 'dataset'
+        entity = DATASETS
         self.set_up_checkout(entity)
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (entity, 'computer-vision__images__dataset-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (entity, 'computer-vision__images__datasets-ex__1')))
         workspace = os.path.join(self.tmp_dir, entity, 'computer-vision', 'images', entity+'-ex')
         create_file(workspace, 'newfile5', '0', file_path='')
         populate_entity_with_new_data(self, entity)
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')))
         expected_files_in_tag_1 = 6
         self.check_amount_of_files(entity, expected_files_in_tag_1, sampling=False)
         create_file(workspace, 'newfile6', '0', file_path='')
@@ -391,7 +390,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         self.assertIn(messages[8] % (
             os.path.join(self.tmp_dir, GIT_PATH), os.path.join(self.tmp_dir, ML_GIT_DIR, entity, 'metadata')),
                       check_output(MLGIT_ENTITY_INIT % entity))
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (entity, 'computer-vision__images__dataset-ex__3')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (entity, 'computer-vision__images__datasets-ex__3')))
 
         path_of_tag_2_file = os.path.join(self.tmp_dir, entity, 'computer-vision', 'images', entity+'-ex', 'newfile5')
         path_of_tag_3_file = os.path.join(self.tmp_dir, entity, 'computer-vision', 'images', entity+'-ex', 'newfile6')

--- a/tests/integration/test_08_checkout_tag.py
+++ b/tests/integration/test_08_checkout_tag.py
@@ -15,7 +15,7 @@ from tests.integration.helper import ML_GIT_DIR, MLGIT_INIT, MLGIT_REMOTE_ADD, M
     recursive_write_read, ERROR_MESSAGE, \
     add_file, GIT_PATH, check_output, clear, init_repository, BUCKET_NAME, PROFILE, edit_config_yaml, \
     create_spec, set_write_read, STORE_TYPE, create_file, populate_entity_with_new_data, DATASETS, DATASET_NAME, MODELS, \
-    LABELS
+    LABELS, DATASET_TAG
 from tests.integration.output_messages import messages
 
 
@@ -62,7 +62,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     def test_01_checkout_tag(self):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 6
-        check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1'))
+        check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG))
         file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile0')
         self.check_metadata()
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace, sampling=False)
@@ -83,8 +83,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     def test_02_checkout_with_group_sample(self):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 3
-        check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1 --sample-type=group '
-                                                 '--sampling=2:4 --seed=5'))
+        check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG + ' --sample-type=group --sampling=2:4 --seed=5'))
         self.check_metadata()
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
         self.assertTrue(self.check_sampling_flag(DATASETS))
@@ -93,7 +92,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     def test_03_group_sample_with_amount_parameter_greater_than_group_size(self):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[21], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[21], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=group --sampling=4:2 --seed=5'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -101,7 +100,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     def test_04_group_sample_with_amount_parameter_equal_to_group_size(self):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[21], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[21], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=group --sampling=2:2 --seed=5'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -109,7 +108,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     def test_05_group_sample_with_group_size_parameter_greater_than_list_size(self):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[22], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[22], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=group --sampling=2:30 --seed=5'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -117,7 +116,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     def test_06_group_sample_with_group_size_parameter_less_than_zero(self):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[41], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[41], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=group --sampling=-2:3 --seed=5'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -125,7 +124,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     def test_07_checkout_with_range_sample(self):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 3
-        self.assertIn('', check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn('', check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                        + ' --sample-type=range --sampling=2:4:1'))
         self.check_metadata()
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
@@ -134,7 +133,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     def test_08_range_sample_with_start_parameter_greater_than_stop(self):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[23], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[23], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=range --sampling=4:2:1'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -142,7 +141,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     def test_09_range_sample_with_start_parameter_less_than_zero(self):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[23], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[23], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=range --sampling=3:2:1'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -150,7 +149,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     def test_10_range_sample_with_step_parameter_greater_than_stop_parameter(self):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[26], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[26], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=range --sampling=1:3:4'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -158,7 +157,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     def test_11_range_sample_with_start_parameter_equal_to_stop(self):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[23], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[23], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=range --sampling=2:2:1'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -166,7 +165,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     def test_12_range_sample_with_stop_parameter_greater_than_file_list_size(self):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
-        self.assertIn(messages[24], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[24], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=range --sampling=2:30:1'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -175,7 +174,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 4
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                      + ' --sample-type=random --sampling=2:3 --seed=3'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -184,7 +183,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
 
-        self.assertIn(messages[30], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[30], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=random --sampling=2:2 --seed=3'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -193,7 +192,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
 
-        self.assertIn(messages[30], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[30], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=random --sampling=4:2 --seed=3'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -202,7 +201,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
 
-        self.assertIn(messages[31], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[31], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=random --sampling=2:10 --seed=3'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -211,7 +210,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
 
-        self.assertIn(messages[29], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[29], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=random --sampling=2:0 --seed=3'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -220,7 +219,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
 
-        self.assertIn(messages[28], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[28], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=group --sampling=1:0 --seed=5'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -229,7 +228,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 0
 
-        self.assertIn(messages[43], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[43], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=group --sampling=0:1 --seed=5'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
 
@@ -336,7 +335,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     def test_23_add_after_checkout_with_sample(self):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 4
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                      + ' --sample-type=random --sampling=2:3 --seed=3'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
         workspace = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME)
@@ -348,12 +347,12 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         entity = DATASETS
         self.set_up_checkout(entity)
         number_of_files_in_workspace = 4
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (entity, 'computer-vision__images__datasets-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (entity, DATASET_TAG)))
         workspace = os.path.join(self.tmp_dir, entity, 'computer-vision', 'images', entity+'-ex')
         create_file(workspace, 'new_file', '0', file_path='')
         populate_entity_with_new_data(self, entity)
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)
                                                      + ' --sample-type=random --sampling=2:3 --seed=3'))
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace)
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__2')))
@@ -363,7 +362,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     def test_25_checkout_tag_with_main_branch(self):
         self.set_up_checkout(DATASETS)
         number_of_files_in_workspace = 6
-        check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1'))
+        check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG))
         file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile0')
         self.check_metadata()
         self.check_amount_of_files(DATASETS, number_of_files_in_workspace, sampling=False)
@@ -374,12 +373,12 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         entity = DATASETS
         self.set_up_checkout(entity)
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (entity, 'computer-vision__images__datasets-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (entity, DATASET_TAG)))
         workspace = os.path.join(self.tmp_dir, entity, 'computer-vision', 'images', entity+'-ex')
         create_file(workspace, 'newfile5', '0', file_path='')
         populate_entity_with_new_data(self, entity)
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)))
         expected_files_in_tag_1 = 6
         self.check_amount_of_files(entity, expected_files_in_tag_1, sampling=False)
         create_file(workspace, 'newfile6', '0', file_path='')

--- a/tests/integration/test_09_status_command.py
+++ b/tests/integration/test_09_status_command.py
@@ -10,7 +10,7 @@ from stat import S_IWUSR, S_IREAD
 import pytest
 
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_PUSH, MLGIT_ENTITY_INIT, MLGIT_STATUS, MLGIT_ADD, MLGIT_CHECKOUT
-from tests.integration.helper import ML_GIT_DIR, GIT_PATH, ERROR_MESSAGE
+from tests.integration.helper import ML_GIT_DIR, GIT_PATH, ERROR_MESSAGE, DATASETS, DATASET_NAME
 from tests.integration.helper import check_output, clear, init_repository, add_file, create_file
 from tests.integration.output_messages import messages
 
@@ -39,74 +39,74 @@ class StatusAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_status_after_put_on_new_file_in_dataset(self):
-        self.set_up_status('dataset')
-        create_file(os.path.join(self.tmp_dir, 'dataset', 'dataset-ex'), 'file', '0', '')
-        self.assertRegex(check_output(MLGIT_STATUS % ('dataset', 'dataset-ex')),
-                         r'Changes to be committed:\s+Untracked files:\s+dataset-ex\.spec\s+file')
+        self.set_up_status(DATASETS)
+        create_file(os.path.join(self.tmp_dir, DATASETS, DATASET_NAME), 'file', '0', '')
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
+                         r'Changes to be committed:\s+Untracked files:\s+datasets-ex\.spec\s+file')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_status_after_add_command_in_dataset(self):
-        self.set_up_status('dataset')
-        create_file(os.path.join(self.tmp_dir, 'dataset', 'dataset-ex'), 'file0', '0', '')
-        self.assertIn(messages[13] % 'dataset', check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion')))
-        self.assertRegex(check_output(MLGIT_STATUS % ('dataset', 'dataset-ex')),
-                         r'Changes to be committed:\n\tNew file: dataset-ex.spec\n\tNew file: file0\n\nUntracked files:\n\nCorrupted files:')
+        self.set_up_status(DATASETS)
+        create_file(os.path.join(self.tmp_dir, DATASETS, DATASET_NAME), 'file0', '0', '')
+        self.assertIn(messages[13] % DATASETS, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion')))
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
+                         r'Changes to be committed:\n\tNew file: datasets-ex.spec\n\tNew file: file0\n\nUntracked files:\n\nCorrupted files:')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_status_after_commit_command_in_dataset(self):
-        self.set_up_status('dataset')
-        create_file(os.path.join(self.tmp_dir, 'dataset', 'dataset-ex'), 'file1', '0', '')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion')))
-        create_file(os.path.join(self.tmp_dir, 'dataset', 'dataset-ex'), 'file2', '0', '')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion')))
+        self.set_up_status(DATASETS)
+        create_file(os.path.join(self.tmp_dir, DATASETS, DATASET_NAME), 'file1', '0', '')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion')))
+        create_file(os.path.join(self.tmp_dir, DATASETS, DATASET_NAME), 'file2', '0', '')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion')))
 
-        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata'),
-                                      os.path.join('computer-vision', 'images', 'dataset-ex')),
-                      check_output(MLGIT_COMMIT % ('dataset', 'dataset-ex', '')))
-        self.assertRegex(check_output(MLGIT_STATUS % ('dataset', 'dataset-ex')),
+        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata'),
+                                      os.path.join('computer-vision', 'images', DATASET_NAME)),
+                      check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '')))
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
                          r'Changes to be committed:\s+Untracked files:')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_status_after_checkout_in_dataset(self):
-        self.set_up_checkout('dataset')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % ('dataset',
-                                                                       'computer-vision__images__dataset-ex__1')))
-        self.assertRegex(check_output(MLGIT_STATUS % ('dataset', 'dataset-ex')),
+        self.set_up_checkout(DATASETS)
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS,
+                                                                       'computer-vision__images__datasets-ex__1')))
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
                          r'Changes to be committed:\s+Untracked files')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_status_after_delete_file(self):
-        self.set_up_checkout('dataset')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % ('dataset',
-                                                                       'computer-vision__images__dataset-ex__1')))
-        new_file_path = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'newfile4')
+        self.set_up_checkout(DATASETS)
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS,
+                                                                       'computer-vision__images__datasets-ex__1')))
+        new_file_path = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile4')
         os.chmod(new_file_path, S_IWUSR | S_IREAD)
         os.remove(new_file_path)
-        self.assertRegex(check_output(MLGIT_STATUS % ('dataset', 'dataset-ex')),
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
                          r'Changes to be committed:\s+Deleted: newfile4\s+Untracked files:')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_06_status_after_rename_file(self):
-        self.set_up_checkout('dataset')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % ('dataset',
-                                                                       'computer-vision__images__dataset-ex__1')))
-        old_file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'newfile4')
-        new_file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'file4_renamed')
+        self.set_up_checkout(DATASETS)
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS,
+                                                                       'computer-vision__images__datasets-ex__1')))
+        old_file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile4')
+        new_file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'file4_renamed')
         os.rename(old_file, new_file)
-        self.assertRegex(check_output(MLGIT_STATUS % ('dataset', 'dataset-ex')),
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
                          r'Changes to be committed:\s+Deleted: newfile4\s+Untracked files:\s+file4_renamed')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_07_status_corrupted_files(self):
-        self.set_up_checkout('dataset')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % ('dataset',
-                                                                       'computer-vision__images__dataset-ex__1')))
-        corrupted_file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'newfile4')
+        self.set_up_checkout(DATASETS)
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS,
+                                                                       'computer-vision__images__datasets-ex__1')))
+        corrupted_file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile4')
 
         os.chmod(corrupted_file, S_IWUSR | S_IREAD)
         with open(corrupted_file, 'w') as file:
             file.write('modified')
-        create_file(os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex'), 'Ls87x', '0', '')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion')))
-        self.assertRegex(check_output(MLGIT_STATUS % ('dataset', 'dataset-ex')),
-                         r'Changes to be committed:\n\tNew file: Ls87x\n\tNew file: dataset-ex.spec\n\nUntracked files:\n\nCorrupted files:\n\tnewfile4\n')
+        create_file(os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME), 'Ls87x', '0', '')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion')))
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
+                         r'Changes to be committed:\n\tNew file: Ls87x\n\tNew file: datasets-ex.spec\n\nUntracked files:\n\nCorrupted files:\n\tnewfile4\n')

--- a/tests/integration/test_09_status_command.py
+++ b/tests/integration/test_09_status_command.py
@@ -10,7 +10,7 @@ from stat import S_IWUSR, S_IREAD
 import pytest
 
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_PUSH, MLGIT_ENTITY_INIT, MLGIT_STATUS, MLGIT_ADD, MLGIT_CHECKOUT
-from tests.integration.helper import ML_GIT_DIR, GIT_PATH, ERROR_MESSAGE, DATASETS, DATASET_NAME
+from tests.integration.helper import ML_GIT_DIR, GIT_PATH, ERROR_MESSAGE, DATASETS, DATASET_NAME, DATASET_TAG
 from tests.integration.helper import check_output, clear, init_repository, add_file, create_file
 from tests.integration.output_messages import messages
 
@@ -69,16 +69,14 @@ class StatusAcceptanceTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_status_after_checkout_in_dataset(self):
         self.set_up_checkout(DATASETS)
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS,
-                                                                       'computer-vision__images__datasets-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)))
         self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
                          r'Changes to be committed:\s+Untracked files')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_status_after_delete_file(self):
         self.set_up_checkout(DATASETS)
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS,
-                                                                       'computer-vision__images__datasets-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)))
         new_file_path = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile4')
         os.chmod(new_file_path, S_IWUSR | S_IREAD)
         os.remove(new_file_path)
@@ -88,8 +86,7 @@ class StatusAcceptanceTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_06_status_after_rename_file(self):
         self.set_up_checkout(DATASETS)
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS,
-                                                                       'computer-vision__images__datasets-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)))
         old_file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile4')
         new_file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'file4_renamed')
         os.rename(old_file, new_file)
@@ -99,8 +96,7 @@ class StatusAcceptanceTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_07_status_corrupted_files(self):
         self.set_up_checkout(DATASETS)
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS,
-                                                                       'computer-vision__images__datasets-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)))
         corrupted_file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile4')
 
         os.chmod(corrupted_file, S_IWUSR | S_IREAD)

--- a/tests/integration/test_10_fetch_command.py
+++ b/tests/integration/test_10_fetch_command.py
@@ -10,14 +10,14 @@ import pytest
 
 from tests.integration.commands import MLGIT_FETCH, MLGIT_PUSH, MLGIT_COMMIT
 from tests.integration.helper import ML_GIT_DIR, ERROR_MESSAGE, add_file, GIT_PATH, MLGIT_ENTITY_INIT, check_output, \
-    clear, init_repository, change_git_in_config
+    clear, init_repository, change_git_in_config, DATASETS
 from tests.integration.output_messages import messages
 
 
 @pytest.mark.usefixtures('tmp_dir', 'aws_session')
 class FetchAcceptanceTests(unittest.TestCase):
 
-    def set_up_fetch(self, entity='dataset'):
+    def set_up_fetch(self, entity=DATASETS):
         init_repository(entity, self)
         add_file(self, entity, '', 'new')
         metadata_path = os.path.join(self.tmp_dir, ML_GIT_DIR, entity, 'metadata')
@@ -36,10 +36,10 @@ class FetchAcceptanceTests(unittest.TestCase):
     def test_01_fetch_metadata_specific_tag(self):
         self.set_up_fetch()
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % ('dataset',
-                                                                    'computer-vision__images__dataset-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % (DATASETS,
+                                                                    'computer-vision__images__datasets-ex__1')))
 
-        hashfs = os.path.join(ML_GIT_DIR, 'dataset', 'objects', 'hashfs')
+        hashfs = os.path.join(ML_GIT_DIR, DATASETS, 'objects', 'hashfs')
 
         self.assertTrue(os.path.exists(hashfs))
 
@@ -47,97 +47,97 @@ class FetchAcceptanceTests(unittest.TestCase):
     def test_02_fetch_with_group_sample(self):
         self.set_up_fetch()
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % ('dataset',
-                                                                    'computer-vision__images__dataset-ex__1')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % (DATASETS,
+                                                                    'computer-vision__images__datasets-ex__1')
                                                      + ' --sample-type=group --sampling=1:3 --seed=4'))
 
-        hashfs = os.path.join(ML_GIT_DIR, 'dataset', 'objects', 'hashfs')
+        hashfs = os.path.join(ML_GIT_DIR, DATASETS, 'objects', 'hashfs')
         self.assertTrue(os.path.exists(hashfs))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_03_group_sample_with_amount_parameter_greater_than_frequency(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[21], check_output(MLGIT_FETCH % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[21], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=group --sampling=3:1 --seed=4'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_04_group_sample_with_seed_parameter_negative(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[41], check_output(MLGIT_FETCH % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[41], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=group --sampling=1:2 --seed=-4'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_05_fetch_with_range_sample(self):
         self.set_up_fetch()
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % ('dataset',
-                                                                    'computer-vision__images__dataset-ex__1')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % (DATASETS,
+                                                                    'computer-vision__images__datasets-ex__1')
                                                      + ' --sample-type=range --sampling=2:4:1'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_06_range_sample_with_start_parameter_greater_than_stop(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[23], check_output(MLGIT_FETCH % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[23], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=range --sampling=4:2:1'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_07_range_sample_with_start_parameter_less_than_zero(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[42], check_output(MLGIT_FETCH % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[42], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=range --sampling=-3:2:1'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_08_range_sample_with_step_parameter_greater_than_stop_parameter(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[26], check_output(MLGIT_FETCH % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[26], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=range --sampling=1:3:4'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_09_range_sample_with_start_parameter_equal_to_stop(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[23], check_output(MLGIT_FETCH % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[23], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=range --sampling=2:2:1'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_10_range_sample_with_stop_parameter_greater_than_file_list_size(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[24], check_output(MLGIT_FETCH % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[24], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=range --sampling=2:30:1'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_11_checkout_with_random_sample(self):
         self.set_up_fetch()
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % ('dataset',
-                                                                    'computer-vision__images__dataset-ex__1')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % (DATASETS,
+                                                                    'computer-vision__images__datasets-ex__1')
                                                      + ' --sample-type=random --sampling=2:3 --seed=3'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_12_random_sample_with_frequency_less_or_equal_zero(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[40], check_output(MLGIT_FETCH % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[40], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=random --sampling=2:-2 --seed=3'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_13_random_sample_with_amount_parameter_greater_than_frequency(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[30], check_output(MLGIT_FETCH % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[30], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=random --sampling=4:2 --seed=3'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_14_random_sample_with_frequency_greater_or_equal_list_size(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[31], check_output(MLGIT_FETCH % ('dataset', 'computer-vision__images__dataset-ex__1')
+        self.assertIn(messages[31], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
                                                  + ' --sample-type=random --sampling=2:10 --seed=3'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
@@ -145,10 +145,10 @@ class FetchAcceptanceTests(unittest.TestCase):
         self.set_up_fetch()
         change_git_in_config(os.path.join(self.tmp_dir, '.ml-git'), 'wrong-url')
 
-        self.assertIn(messages[100], check_output(MLGIT_FETCH % ('dataset', 'computer-vision__images__dataset-ex__1')))
+        self.assertIn(messages[100], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_16_fetch_with_wrong_tag(self):
         self.set_up_fetch()
-        wrong_tag = 'computer-vision__images__dataset-ex__10'
-        self.assertIn(messages[101] % wrong_tag, check_output(MLGIT_FETCH % ('dataset', wrong_tag)))
+        wrong_tag = 'computer-vision__images__datasets-ex__10'
+        self.assertIn(messages[101] % wrong_tag, check_output(MLGIT_FETCH % (DATASETS, wrong_tag)))

--- a/tests/integration/test_10_fetch_command.py
+++ b/tests/integration/test_10_fetch_command.py
@@ -10,7 +10,7 @@ import pytest
 
 from tests.integration.commands import MLGIT_FETCH, MLGIT_PUSH, MLGIT_COMMIT
 from tests.integration.helper import ML_GIT_DIR, ERROR_MESSAGE, add_file, GIT_PATH, MLGIT_ENTITY_INIT, check_output, \
-    clear, init_repository, change_git_in_config, DATASETS
+    clear, init_repository, change_git_in_config, DATASETS, DATASET_TAG
 from tests.integration.output_messages import messages
 
 
@@ -36,8 +36,7 @@ class FetchAcceptanceTests(unittest.TestCase):
     def test_01_fetch_metadata_specific_tag(self):
         self.set_up_fetch()
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % (DATASETS,
-                                                                    'computer-vision__images__datasets-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)))
 
         hashfs = os.path.join(ML_GIT_DIR, DATASETS, 'objects', 'hashfs')
 
@@ -47,8 +46,7 @@ class FetchAcceptanceTests(unittest.TestCase):
     def test_02_fetch_with_group_sample(self):
         self.set_up_fetch()
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % (DATASETS,
-                                                                    'computer-vision__images__datasets-ex__1')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)
                                                      + ' --sample-type=group --sampling=1:3 --seed=4'))
 
         hashfs = os.path.join(ML_GIT_DIR, DATASETS, 'objects', 'hashfs')
@@ -58,86 +56,84 @@ class FetchAcceptanceTests(unittest.TestCase):
     def test_03_group_sample_with_amount_parameter_greater_than_frequency(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[21], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[21], check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=group --sampling=3:1 --seed=4'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_04_group_sample_with_seed_parameter_negative(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[41], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[41], check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=group --sampling=1:2 --seed=-4'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_05_fetch_with_range_sample(self):
         self.set_up_fetch()
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % (DATASETS,
-                                                                    'computer-vision__images__datasets-ex__1')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)
                                                      + ' --sample-type=range --sampling=2:4:1'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_06_range_sample_with_start_parameter_greater_than_stop(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[23], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[23], check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=range --sampling=4:2:1'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_07_range_sample_with_start_parameter_less_than_zero(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[42], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[42], check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=range --sampling=-3:2:1'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_08_range_sample_with_step_parameter_greater_than_stop_parameter(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[26], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[26], check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=range --sampling=1:3:4'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_09_range_sample_with_start_parameter_equal_to_stop(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[23], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[23], check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=range --sampling=2:2:1'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_10_range_sample_with_stop_parameter_greater_than_file_list_size(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[24], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[24], check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=range --sampling=2:30:1'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_11_checkout_with_random_sample(self):
         self.set_up_fetch()
 
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % (DATASETS,
-                                                                    'computer-vision__images__datasets-ex__1')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)
                                                      + ' --sample-type=random --sampling=2:3 --seed=3'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_12_random_sample_with_frequency_less_or_equal_zero(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[40], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[40], check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=random --sampling=2:-2 --seed=3'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_13_random_sample_with_amount_parameter_greater_than_frequency(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[30], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[30], check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=random --sampling=4:2 --seed=3'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_14_random_sample_with_frequency_greater_or_equal_list_size(self):
         self.set_up_fetch()
 
-        self.assertIn(messages[31], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')
+        self.assertIn(messages[31], check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)
                                                  + ' --sample-type=random --sampling=2:10 --seed=3'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
@@ -145,7 +141,7 @@ class FetchAcceptanceTests(unittest.TestCase):
         self.set_up_fetch()
         change_git_in_config(os.path.join(self.tmp_dir, '.ml-git'), 'wrong-url')
 
-        self.assertIn(messages[100], check_output(MLGIT_FETCH % (DATASETS, 'computer-vision__images__datasets-ex__1')))
+        self.assertIn(messages[100], check_output(MLGIT_FETCH % (DATASETS, DATASET_TAG)))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_16_fetch_with_wrong_tag(self):

--- a/tests/integration/test_11_list_tag.py
+++ b/tests/integration/test_11_list_tag.py
@@ -9,7 +9,8 @@ import unittest
 import pytest
 
 from tests.integration.commands import MLGIT_PUSH, MLGIT_TAG_LIST, MLGIT_COMMIT
-from tests.integration.helper import check_output, init_repository, add_file, ML_GIT_DIR, create_spec
+from tests.integration.helper import check_output, init_repository, add_file, ML_GIT_DIR, create_spec, DATASETS, LABELS, \
+    MODELS
 from tests.integration.output_messages import messages
 
 
@@ -28,29 +29,29 @@ class ListTagAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_list_all_tag_dataset(self):
-        self._list_tag_entity('dataset')
+        self._list_tag_entity(DATASETS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_list_all_tag_labels(self):
-        self._list_tag_entity('labels')
+        self._list_tag_entity(LABELS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_list_all_tag_model(self):
-        self._list_tag_entity('model')
+        self._list_tag_entity(MODELS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_list_tags_without_similar_tags(self):
-        self._list_tag_entity('dataset')
-        entity_type = 'dataset'
-        similar_entity = 'dataset-ex2'
-        workspace = os.path.join('dataset', similar_entity)
+        self._list_tag_entity(DATASETS)
+        entity_type = DATASETS
+        similar_entity = 'datasets-ex2'
+        workspace = os.path.join(DATASETS, similar_entity)
         os.makedirs(workspace, exist_ok=True)
-        create_spec(self, 'dataset', self.tmp_dir, artifact_name=similar_entity)
-        add_file(self, 'dataset', '--bumpversion', 'new', artifact_name=similar_entity)
-        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata'),
+        create_spec(self, DATASETS, self.tmp_dir, artifact_name=similar_entity)
+        add_file(self, DATASETS, '--bumpversion', 'new', artifact_name=similar_entity)
+        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata'),
                                       os.path.join('computer-vision', 'images', similar_entity)),
-                      check_output(MLGIT_COMMIT % ('dataset', similar_entity, '')))
-        check_output(MLGIT_PUSH % ('dataset', similar_entity))
+                      check_output(MLGIT_COMMIT % (DATASETS, similar_entity, '')))
+        check_output(MLGIT_PUSH % (DATASETS, similar_entity))
         self.assertNotIn(similar_entity,
                          check_output(MLGIT_TAG_LIST % (entity_type, entity_type + '-ex')))
         self.assertIn(similar_entity,

--- a/tests/integration/test_12_reset_command.py
+++ b/tests/integration/test_12_reset_command.py
@@ -11,39 +11,39 @@ import pytest
 from ml_git.ml_git_message import output_messages
 from ml_git.utils import ensure_path_exists
 from tests.integration.commands import MLGIT_ADD, MLGIT_COMMIT, MLGIT_RESET, MLGIT_STATUS
-from tests.integration.helper import ML_GIT_DIR
+from tests.integration.helper import ML_GIT_DIR, DATASETS, DATASET_NAME
 from tests.integration.helper import check_output, init_repository, ERROR_MESSAGE, create_file
 from tests.integration.output_messages import messages
 
 
 @pytest.mark.usefixtures('tmp_dir')
 class ResetAcceptanceTests(unittest.TestCase):
-    dataset_tag = 'computer-vision__images__dataset-ex__2'
+    dataset_tag = 'computer-vision__images__datasets-ex__2'
 
     def set_up_reset(self):
-        init_repository('dataset', self)
-        create_file(os.path.join('dataset', 'dataset-ex'), 'file1', '0', '')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion')))
-        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata'),
-                                      os.path.join('computer-vision', 'images', 'dataset-ex')),
-                      check_output(MLGIT_COMMIT % ('dataset', 'dataset-ex', '')))
-        create_file(os.path.join('dataset', 'dataset-ex'), 'file2', '0', '')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion')))
-        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata'),
-                                      os.path.join('computer-vision', 'images', 'dataset-ex')),
-                      check_output(MLGIT_COMMIT % ('dataset', 'dataset-ex', '')))
+        init_repository(DATASETS, self)
+        create_file(os.path.join(DATASETS, DATASET_NAME), 'file1', '0', '')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion')))
+        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata'),
+                                      os.path.join('computer-vision', 'images', DATASET_NAME)),
+                      check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '')))
+        create_file(os.path.join(DATASETS, DATASET_NAME), 'file2', '0', '')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion')))
+        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata'),
+                                      os.path.join('computer-vision', 'images', DATASET_NAME)),
+                      check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '')))
 
     def _check_dir(self, tag):
-        os.chdir(os.path.join(ML_GIT_DIR, 'dataset', 'metadata'))
+        os.chdir(os.path.join(ML_GIT_DIR, DATASETS, 'metadata'))
         self.assertIn(tag, check_output('git describe --tags'))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_soft_with_HEAD1(self):
         self.set_up_reset()
         self.assertIn(output_messages['INFO_INITIALIZING_RESET'] % ('--soft', 'HEAD~1'),
-                      check_output(MLGIT_RESET % ('dataset', 'dataset-ex') + ' --soft --reference=head~1'))
-        self.assertRegex(check_output(MLGIT_STATUS % ('dataset', 'dataset-ex')),
-                         r'Changes to be committed:\n\tNew file: dataset-ex.spec\n\tNew file: file2\n\nUntracked files:\n\nCorrupted files:')
+                      check_output(MLGIT_RESET % (DATASETS, DATASET_NAME) + ' --soft --reference=head~1'))
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
+                         r'Changes to be committed:\n\tNew file: datasets-ex.spec\n\tNew file: file2\n\nUntracked files:\n\nCorrupted files:')
 
         self._check_dir(self.dataset_tag)
 
@@ -51,34 +51,34 @@ class ResetAcceptanceTests(unittest.TestCase):
     def test_02_mixed_with_HEAD1(self):
         self.set_up_reset()
         self.assertIn(output_messages['INFO_INITIALIZING_RESET'] % ('--mixed', 'HEAD~1'),
-                      check_output(MLGIT_RESET % ('dataset', 'dataset-ex') + ' --mixed --reference=head~1'))
-        self.assertRegex(check_output(MLGIT_STATUS % ('dataset', 'dataset-ex')),
-                         r'Changes to be committed:\n\tNew file: dataset-ex.spec\n\nUntracked files:\n\tfile2\n\nCorrupted files:')
+                      check_output(MLGIT_RESET % (DATASETS, DATASET_NAME) + ' --mixed --reference=head~1'))
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
+                         r'Changes to be committed:\n\tNew file: datasets-ex.spec\n\nUntracked files:\n\tfile2\n\nCorrupted files:')
         self._check_dir(self.dataset_tag)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_hard_with_HEAD(self):
         self.set_up_reset()
-        create_file(os.path.join('dataset', 'dataset-ex'), 'file3', '0', '')
-        check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion'))
+        create_file(os.path.join(DATASETS, DATASET_NAME), 'file3', '0', '')
+        check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion'))
         self.assertIn(output_messages['INFO_INITIALIZING_RESET'] % ('--hard', 'HEAD'),
-                      check_output(MLGIT_RESET % ('dataset', 'dataset-ex') + ' --hard --reference=head'))
-        self.assertRegex(check_output(MLGIT_STATUS % ('dataset', 'dataset-ex')),
-                         r'Changes to be committed:\n\tNew file: dataset-ex.spec\n\nUntracked files:\n\nCorrupted files:')
-        self._check_dir('computer-vision__images__dataset-ex__3')
+                      check_output(MLGIT_RESET % (DATASETS, DATASET_NAME) + ' --hard --reference=head'))
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
+                         r'Changes to be committed:\n\tNew file: datasets-ex.spec\n\nUntracked files:\n\nCorrupted files:')
+        self._check_dir('computer-vision__images__datasets-ex__3')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_hard_with_HEAD1(self):
         self.set_up_reset()
         self.assertIn(output_messages['INFO_INITIALIZING_RESET'] % ('--hard', 'HEAD~1'),
-                      check_output(MLGIT_RESET % ('dataset', 'dataset-ex') + ' --hard --reference=head~1'))
-        self.assertRegex(check_output(MLGIT_STATUS % ('dataset', 'dataset-ex')),
-                         r'Changes to be committed:\n\tNew file: dataset-ex.spec\n\nUntracked files:\n\nCorrupted files')
+                      check_output(MLGIT_RESET % (DATASETS, DATASET_NAME) + ' --hard --reference=head~1'))
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
+                         r'Changes to be committed:\n\tNew file: datasets-ex.spec\n\nUntracked files:\n\nCorrupted files')
         self._check_dir(self.dataset_tag)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_hard_with_data_in_subpath(self):
-        entity = 'dataset'
+        entity = DATASETS
         subpath = 'data'
 
         init_repository(entity, self)
@@ -101,5 +101,5 @@ class ResetAcceptanceTests(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(data_path, first_commit_file_name)))
         self.assertFalse(os.path.exists(os.path.join(data_path, second_commit_file_name)))
         self.assertRegex(check_output(MLGIT_STATUS % (entity, entity+'-ex')),
-                         r'Changes to be committed:\n\tNew file: dataset-ex.spec\n\nUntracked files:\n\nCorrupted files')
+                         r'Changes to be committed:\n\tNew file: datasets-ex.spec\n\nUntracked files:\n\nCorrupted files')
         self._check_dir(self.dataset_tag)

--- a/tests/integration/test_13_remote_fsck.py
+++ b/tests/integration/test_13_remote_fsck.py
@@ -9,7 +9,7 @@ import unittest
 import pytest
 
 from tests.integration.commands import MLGIT_REMOTE_FSCK, MLGIT_PUSH, MLGIT_COMMIT
-from tests.integration.helper import ML_GIT_DIR, ERROR_MESSAGE, MLGIT_ADD
+from tests.integration.helper import ML_GIT_DIR, ERROR_MESSAGE, MLGIT_ADD, DATASETS, DATASET_NAME
 from tests.integration.helper import check_output, init_repository, MINIO_BUCKET_PATH
 from tests.integration.output_messages import messages
 
@@ -18,7 +18,7 @@ from tests.integration.output_messages import messages
 class RemoteFsckAcceptanceTests(unittest.TestCase):
     file = 'zdj7WWzF6t7MVbteB97N39oFQjP9TTYdHKgS2wetdFWuj1ZP1'
 
-    def setup_remote_fsck(self, entity='dataset'):
+    def setup_remote_fsck(self, entity=DATASETS):
         init_repository(entity, self)
 
         with open(os.path.join(entity, entity+'-ex', 'remote'), 'wt') as z:
@@ -29,7 +29,7 @@ class RemoteFsckAcceptanceTests(unittest.TestCase):
                                       os.path.join('computer-vision', 'images', entity+'-ex')),
                       check_output(MLGIT_COMMIT % (entity, entity+'-ex', '')))
 
-        HEAD = os.path.join(ML_GIT_DIR, entity, 'refs', 'dataset-ex', 'HEAD')
+        HEAD = os.path.join(ML_GIT_DIR, entity, 'refs', DATASET_NAME, 'HEAD')
         self.assertTrue(os.path.exists(HEAD))
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_PUSH % (entity, entity+'-ex')))
 
@@ -37,11 +37,11 @@ class RemoteFsckAcceptanceTests(unittest.TestCase):
     def test_01_remote_fsck(self):
         self.setup_remote_fsck()
         os.unlink(os.path.join(MINIO_BUCKET_PATH, 'zdj7Wi996ViPiddvDGvzjBBACZzw6YfPujBCaPHunVoyiTUCj'))
-        self.assertIn(messages[35] % (0, 1), check_output(MLGIT_REMOTE_FSCK % ('dataset', 'dataset-ex')))
+        self.assertIn(messages[35] % (0, 1), check_output(MLGIT_REMOTE_FSCK % (DATASETS, DATASET_NAME)))
         self.assertTrue(os.path.exists(os.path.join(MINIO_BUCKET_PATH, 'zdj7Wi996ViPiddvDGvzjBBACZzw6YfPujBCaPHunVoyiTUCj')))
 
     def _get_file_path(self):
-        hash_path = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'objects', 'hashfs')
+        hash_path = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'objects', 'hashfs')
         file_path = ''
 
         for root, _, files in os.walk(hash_path):
@@ -59,11 +59,11 @@ class RemoteFsckAcceptanceTests(unittest.TestCase):
 
         os.remove(file_path)
 
-        self.assertIn(messages[58] % 1, check_output(MLGIT_REMOTE_FSCK % ('dataset', 'dataset-ex')))
+        self.assertIn(messages[58] % 1, check_output(MLGIT_REMOTE_FSCK % (DATASETS, DATASET_NAME)))
 
         self.assertFalse(os.path.exists(file_path))
 
-        self.assertIn(messages[59] % 1, check_output(MLGIT_REMOTE_FSCK % ('dataset', 'dataset-ex') + ' --thorough'))
+        self.assertIn(messages[59] % 1, check_output(MLGIT_REMOTE_FSCK % (DATASETS, DATASET_NAME) + ' --thorough'))
 
         self.assertTrue(os.path.exists(file_path))
 
@@ -77,10 +77,10 @@ class RemoteFsckAcceptanceTests(unittest.TestCase):
         with open(os.path.join(MINIO_BUCKET_PATH, self.file), 'wt') as z:
             z.write(str('1' * 10011))
 
-        output = check_output(MLGIT_REMOTE_FSCK % ('dataset', 'dataset-ex') + ' --paranoid')
+        output = check_output(MLGIT_REMOTE_FSCK % (DATASETS, DATASET_NAME) + ' --paranoid')
 
         self.assertIn(messages[60] % self.file, output)
         self.assertIn(messages[35] % (1, 0), output)
 
-        self.assertNotIn(messages[60], check_output(MLGIT_REMOTE_FSCK % ('dataset', 'dataset-ex') + ' --paranoid'))
+        self.assertNotIn(messages[60], check_output(MLGIT_REMOTE_FSCK % (DATASETS, DATASET_NAME) + ' --paranoid'))
         self.assertTrue(os.path.exists(os.path.join(MINIO_BUCKET_PATH, self.file)))

--- a/tests/integration/test_14_fsck.py
+++ b/tests/integration/test_14_fsck.py
@@ -9,7 +9,7 @@ import unittest
 import pytest
 
 from tests.integration.commands import MLGIT_FSCK
-from tests.integration.helper import check_output, init_repository, add_file, ML_GIT_DIR
+from tests.integration.helper import check_output, init_repository, add_file, ML_GIT_DIR, DATASETS, LABELS, MODELS
 from tests.integration.output_messages import messages
 
 
@@ -27,12 +27,12 @@ class FsckAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_fsck_dataset(self):
-        self._fsck('dataset')
+        self._fsck(DATASETS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_fsck_labels(self):
-        self._fsck('labels')
+        self._fsck(LABELS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_fsck_model(self):
-        self._fsck('model')
+        self._fsck(MODELS)

--- a/tests/integration/test_15_update.py
+++ b/tests/integration/test_15_update.py
@@ -10,7 +10,7 @@ import pytest
 
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_UPDATE, MLGIT_PUSH, MLGIT_REPOSITORY_UPDATE, MLGIT_INIT
-from tests.integration.helper import ML_GIT_DIR, init_repository, add_file, ERROR_MESSAGE
+from tests.integration.helper import ML_GIT_DIR, init_repository, add_file, ERROR_MESSAGE, DATASETS, MODELS, LABELS
 from tests.integration.helper import check_output
 from tests.integration.output_messages import messages
 
@@ -38,31 +38,31 @@ class UpdateAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_update_dataset(self):
-        self._setup_update_entity('dataset')
-        self._check_update_entity('dataset')
+        self._setup_update_entity(DATASETS)
+        self._check_update_entity(DATASETS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_update_model(self):
-        self._setup_update_entity('model')
-        self._check_update_entity('model')
+        self._setup_update_entity(MODELS)
+        self._check_update_entity(MODELS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_update_labels(self):
-        self._setup_update_entity('labels')
-        self._check_update_entity('labels')
+        self._setup_update_entity(LABELS)
+        self._check_update_entity(LABELS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_update_with_git_error(self):
-        init_repository('dataset', self)
-        self.assertTrue(messages[105], check_output(MLGIT_UPDATE % 'dataset'))
+        init_repository(DATASETS, self)
+        self.assertTrue(messages[105], check_output(MLGIT_UPDATE % DATASETS))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_update_all_entities(self):
-        self._setup_update_entity('dataset')
-        self._setup_update_entity('labels')
-        self._setup_update_entity('model')
+        self._setup_update_entity(DATASETS)
+        self._setup_update_entity(LABELS)
+        self._setup_update_entity(MODELS)
         response = check_output(MLGIT_REPOSITORY_UPDATE)
-        self._check_update_output(response, 'dataset', 'model', 'labels')
+        self._check_update_output(response, DATASETS, MODELS, LABELS)
         self.assertNotIn(ERROR_MESSAGE, response)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
@@ -73,9 +73,8 @@ class UpdateAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_07_update_some_entities(self):
-        self._setup_update_entity('dataset')
-        self._setup_update_entity('model')
+        self._setup_update_entity(DATASETS)
+        self._setup_update_entity(MODELS)
         response = check_output(MLGIT_REPOSITORY_UPDATE)
-        self._check_update_output(response, 'dataset', 'model')
-        self.assertNotIn(messages[37] % os.path.join(self.tmp_dir, ML_GIT_DIR, 'labels', 'metadata'),
-                         response)
+        self._check_update_output(response, DATASETS, MODELS)
+        self.assertNotIn(messages[37] % os.path.join(self.tmp_dir, ML_GIT_DIR, LABELS, 'metadata'), response)

--- a/tests/integration/test_16_show.py
+++ b/tests/integration/test_16_show.py
@@ -9,7 +9,7 @@ import unittest
 import pytest
 
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_SHOW
-from tests.integration.helper import check_output, init_repository, add_file, ML_GIT_DIR
+from tests.integration.helper import check_output, init_repository, add_file, ML_GIT_DIR, DATASETS, LABELS, MODELS
 from tests.integration.output_messages import messages
 
 
@@ -27,12 +27,12 @@ class ShowAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_01_show_dataset(self):
-        self._show_entity('dataset')
+        self._show_entity(DATASETS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_02_show_labels(self):
-        self._show_entity('labels')
+        self._show_entity(LABELS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_03_show_model(self):
-        self._show_entity('model')
+        self._show_entity(MODELS)

--- a/tests/integration/test_17_list.py
+++ b/tests/integration/test_17_list.py
@@ -10,7 +10,7 @@ import pytest
 
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_LIST, MLGIT_INIT, MLGIT_REMOTE_ADD, MLGIT_ENTITY_INIT
 from tests.integration.helper import check_output, init_repository, add_file, GIT_PATH, \
-    ERROR_MESSAGE, ML_GIT_DIR
+    ERROR_MESSAGE, ML_GIT_DIR, DATASETS, LABELS, MODELS
 from tests.integration.output_messages import messages
 
 
@@ -29,24 +29,24 @@ class ListAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_list_dataset(self):
-        self._list_entity('dataset')
+        self._list_entity(DATASETS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_list_without_any_entity(self):
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_INIT))
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_REMOTE_ADD % ('dataset', GIT_PATH)))
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ENTITY_INIT % 'dataset'))
-        self.assertIn(messages[86], check_output(MLGIT_LIST % 'dataset'))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_REMOTE_ADD % (DATASETS, GIT_PATH)))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ENTITY_INIT % DATASETS))
+        self.assertIn(messages[86], check_output(MLGIT_LIST % DATASETS))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_list_without_initialize(self):
         check_output(MLGIT_INIT)
-        self.assertIn(messages[85] % 'dataset', check_output(MLGIT_LIST % 'dataset'))
+        self.assertIn(messages[85] % DATASETS, check_output(MLGIT_LIST % DATASETS))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_list_labels(self):
-        self._list_entity('labels')
+        self._list_entity(LABELS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_list_model(self):
-        self._list_entity('model')
+        self._list_entity(MODELS)

--- a/tests/integration/test_18_branch.py
+++ b/tests/integration/test_18_branch.py
@@ -10,7 +10,7 @@ import unittest
 import pytest
 
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_BRANCH
-from tests.integration.helper import ML_GIT_DIR
+from tests.integration.helper import ML_GIT_DIR, DATASETS, LABELS, MODELS
 from tests.integration.helper import check_output, init_repository, add_file
 from tests.integration.output_messages import messages
 
@@ -32,12 +32,12 @@ class BranchAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_01_branch_dataset(self):
-        self._branch_entity('dataset')
+        self._branch_entity(DATASETS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_02_branch_labels(self):
-        self._branch_entity('labels')
+        self._branch_entity(LABELS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_03_branch_model(self):
-        self._branch_entity('model')
+        self._branch_entity(MODELS)

--- a/tests/integration/test_19_create.py
+++ b/tests/integration/test_19_create.py
@@ -12,7 +12,7 @@ from ml_git.ml_git_message import output_messages
 
 from tests.integration.commands import MLGIT_CREATE, MLGIT_INIT
 from tests.integration.helper import check_output, ML_GIT_DIR, IMPORT_PATH, create_file, ERROR_MESSAGE, yaml_processor, \
-    create_zip_file
+    create_zip_file, DATASETS, DATASET_NAME, MODELS, LABELS
 from tests.integration.output_messages import messages
 
 
@@ -54,24 +54,24 @@ class CreateAcceptanceTests(unittest.TestCase):
         self.assertIn(messages[38], check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
                                                  + ' --category=img --version-number=1 '
                                                    '--credentials-path=test --mutability=' + mutability))
-        spec = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'dataset-ex.spec')
+        spec = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, DATASET_NAME+'.spec')
         with open(spec, 'r') as s:
             spec_file = yaml_processor.load(s)
-            self.assertEqual(spec_file['dataset']['mutability'], mutability)
-            self.assertEqual(spec_file['dataset']['name'], 'dataset-ex')
-            self.assertEqual(spec_file['dataset']['version'], 1)
+            self.assertEqual(spec_file[DATASETS]['mutability'], mutability)
+            self.assertEqual(spec_file[DATASETS]['name'], DATASET_NAME)
+            self.assertEqual(spec_file[DATASETS]['version'], 1)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_01_create_dataset(self):
-        self._create_entity('dataset')
+        self._create_entity(DATASETS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_02_create_model(self):
-        self._create_entity('model')
+        self._create_entity(MODELS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_03_create_labels(self):
-        self._create_entity('labels')
+        self._create_entity(LABELS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_04_create_import_with_subdir(self):
@@ -80,20 +80,20 @@ class CreateAcceptanceTests(unittest.TestCase):
         os.makedirs(os.path.join(self.tmp_dir, IMPORT_PATH, sub_dir))
 
         self.assertIn(messages[38], check_output(
-            'ml-git dataset create dataset-ex --category=imgs --store-type=s3h --bucket-name=minio '
+            'ml-git datasets create datasets-ex --category=imgs --store-type=s3h --bucket-name=minio '
             '--version=1 --import="%s" --mutability=strict' % os.path.join(self.tmp_dir, IMPORT_PATH)))
 
-        folder_data = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'data')
-        spec = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'dataset-ex.spec')
-        readme = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'README.md')
+        folder_data = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, 'data')
+        spec = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, DATASET_NAME+'.spec')
+        readme = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, 'README.md')
         with open(spec, 'r') as s:
             spec_file = yaml_processor.load(s)
-            self.assertEqual(spec_file['dataset']['manifest']['store'], 's3h://minio')
-            self.assertEqual(spec_file['dataset']['name'], 'dataset-ex')
-            self.assertEqual(spec_file['dataset']['version'], 1)
+            self.assertEqual(spec_file[DATASETS]['manifest']['store'], 's3h://minio')
+            self.assertEqual(spec_file[DATASETS]['name'], DATASET_NAME)
+            self.assertEqual(spec_file[DATASETS]['version'], 1)
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as y:
             config = yaml_processor.load(y)
-            self.assertIn('dataset', config)
+            self.assertIn(DATASETS, config)
 
         self.assertTrue(os.path.exists(folder_data))
         self.assertTrue(os.path.exists(spec))
@@ -102,7 +102,7 @@ class CreateAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_05_create_command_wrong_import_path(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         os.makedirs(IMPORT_PATH)
         create_file(IMPORT_PATH, 'teste1', '0', '')
         dataset_path = os.path.join(self.tmp_dir, entity_type, entity_type + 'ex')
@@ -115,9 +115,9 @@ class CreateAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_06_create_with_the_name_of_an_existing_entity(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
 
-        self._create_entity('dataset')
+        self._create_entity(DATASETS)
 
         self.assertIn(messages[88], check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
                                                  + ' --category=imgs --store-type=s3h --bucket-name=minio'
@@ -126,15 +126,15 @@ class CreateAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_07_create_entity_with_gdriveh_storage(self):
-        self._create_entity('dataset', StoreType.GDRIVEH.value)
+        self._create_entity(DATASETS, StoreType.GDRIVEH.value)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_08_create_entity_with_azure_storage(self):
-        self._create_entity('dataset', StoreType.AZUREBLOBH.value)
+        self._create_entity(DATASETS, StoreType.AZUREBLOBH.value)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_09_create_with_import_and_import_url_options(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         self.assertIn(messages[0], check_output(MLGIT_INIT))
         self.assertIn(messages[89], check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
                                                  + ' --category=img --version=1 --import="import_path" --import-url="import_url"'
@@ -142,7 +142,7 @@ class CreateAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_10_create_with_import_url_without_credentials_path(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         self.assertIn(messages[0], check_output(MLGIT_INIT))
         self.assertIn(messages[90], check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
                                                  + ' --category=img --version=1 --import-url="import_url"'
@@ -150,7 +150,7 @@ class CreateAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_11_create_with_wrong_import_url(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         self.assertIn(messages[0], check_output(MLGIT_INIT))
         self.assertIn(messages[91] % 'import_url', check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
                                                                 + ' --category=img --version=1 --import-url="import_url" '
@@ -158,7 +158,7 @@ class CreateAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_12_create_with_unzip_option(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         self.assertIn(messages[0], check_output(MLGIT_INIT))
         import_path = os.path.join(self.tmp_dir, IMPORT_PATH)
         os.makedirs(import_path)
@@ -177,7 +177,7 @@ class CreateAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_12_create_with_deprecated_version_number(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         self.assertIn(messages[0], check_output(MLGIT_INIT))
         os.makedirs(os.path.join(self.tmp_dir, IMPORT_PATH))
         result = check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex') + ' --category=imgs --store-type=s3h --bucket-name=minio'
@@ -190,25 +190,25 @@ class CreateAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_13_create_with_mutability_mutable(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         mutability = 'mutable'
         self.create_with_mutability(entity_type, mutability)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_14_create_with_mutability_flexible(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         mutability = 'flexible'
         self.create_with_mutability(entity_type, mutability)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_15_create_with_mutability_strict(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         mutability = 'strict'
         self.create_with_mutability(entity_type, mutability)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_15_create_without_mutability_option(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         self.assertIn(messages[0], check_output(MLGIT_INIT))
         self.assertIn(output_messages['ERROR_MISSING_MUTABILITY'], check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
                                                                                 + ' --category=img --version-number=1'))

--- a/tests/integration/test_20_clone.py
+++ b/tests/integration/test_20_clone.py
@@ -9,73 +9,73 @@ import unittest
 import pytest
 
 from tests.integration.commands import MLGIT_CLONE
-from tests.integration.helper import check_output, PATH_TEST, CLONE_FOLDER, create_git_clone_repo
+from tests.integration.helper import check_output, PATH_TEST, CLONE_FOLDER, create_git_clone_repo, DATASETS
 from tests.integration.output_messages import messages
 
 
-@pytest.mark.usefixtures("tmp_dir")
+@pytest.mark.usefixtures('tmp_dir')
 class CloneTest(unittest.TestCase):
-    GIT_CLONE = os.path.join(PATH_TEST, "git_clone.git")
+    GIT_CLONE = os.path.join(PATH_TEST, 'git_clone.git')
 
     def set_up_clone(self):
         os.makedirs(self.GIT_CLONE, exist_ok=True)
         create_git_clone_repo(self.GIT_CLONE, self.tmp_dir)
 
     def check_metadata_entity(self, clone_dir):
-        config = os.path.join(clone_dir, "config.yaml")
-        dataset_metadata = os.path.join(self.tmp_dir, clone_dir, "dataset", "metadata", ".git")
+        config = os.path.join(clone_dir, 'config.yaml')
+        dataset_metadata = os.path.join(self.tmp_dir, clone_dir, DATASETS, 'metadata', '.git')
         self.assertTrue(os.path.exists(config))
         self.assertTrue(os.path.exists(dataset_metadata))
 
-    @pytest.mark.usefixtures("start_local_git_server", "switch_to_tmp_dir")
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_clone(self):
         self.set_up_clone()
-        self.assertIn(messages[39], check_output(MLGIT_CLONE % (self.GIT_CLONE, "--folder=" + CLONE_FOLDER)))
-        clone_dir = os.path.join(CLONE_FOLDER, ".ml-git")
+        self.assertIn(messages[39], check_output(MLGIT_CLONE % (self.GIT_CLONE, '--folder=' + CLONE_FOLDER)))
+        clone_dir = os.path.join(CLONE_FOLDER, '.ml-git')
         self.check_metadata_entity(clone_dir)
 
-    @pytest.mark.usefixtures("start_local_git_server", "switch_to_tmp_dir")
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_clone_folder_non_empty(self):
         os.mkdir(CLONE_FOLDER)
-        with open(os.path.join(CLONE_FOLDER, "file"), "wt") as file:
-            file.write("0" * 2048)
+        with open(os.path.join(CLONE_FOLDER, 'file'), 'wt') as file:
+            file.write('0' * 2048)
 
         self.assertIn(messages[45] % (os.path.join(self.tmp_dir, CLONE_FOLDER)),
-                      check_output(MLGIT_CLONE % (self.GIT_CLONE, "--folder=" + CLONE_FOLDER)))
+                      check_output(MLGIT_CLONE % (self.GIT_CLONE, '--folder=' + CLONE_FOLDER)))
 
-    @pytest.mark.usefixtures("start_local_git_server", "switch_to_tmp_dir")
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_clone_wrong_url(self):
-        self.assertIn(messages[44], check_output(MLGIT_CLONE % (self.GIT_CLONE+"wrong", "--folder=" + CLONE_FOLDER)))
+        self.assertIn(messages[44], check_output(MLGIT_CLONE % (self.GIT_CLONE+'wrong', '--folder=' + CLONE_FOLDER)))
         self.assertFalse(os.path.exists(os.path.join(PATH_TEST, CLONE_FOLDER)))
 
-    @pytest.mark.usefixtures("start_local_git_server", "switch_to_folder_without_permissions")
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_folder_without_permissions')
     def test_04_clone_inside_folder_without_permission(self):
         self.set_up_clone()
-        self.assertIn(messages[46], check_output(MLGIT_CLONE % (self.GIT_CLONE, "--folder=" + CLONE_FOLDER)))
+        self.assertIn(messages[46], check_output(MLGIT_CLONE % (self.GIT_CLONE, '--folder=' + CLONE_FOLDER)))
 
-    @pytest.mark.usefixtures("start_local_git_server", "switch_to_tmp_dir")
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_clone_folder_with_track(self):
         self.set_up_clone()
         self.assertIn(messages[39], check_output((MLGIT_CLONE + ' --track') % (self.GIT_CLONE,
-                                                                               "--folder=" + CLONE_FOLDER)))
+                                                                               '--folder=' + CLONE_FOLDER)))
         os.chdir(CLONE_FOLDER)
         assert (os.path.isdir('.git'))
 
-    @pytest.mark.usefixtures("start_local_git_server", "switch_to_tmp_dir")
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_06_clone_without_folder_option(self):
         self.set_up_clone()
         os.mkdir(CLONE_FOLDER)
         os.chdir(CLONE_FOLDER)
-        self.assertIn(messages[39], check_output(MLGIT_CLONE % (self.GIT_CLONE, "")))
+        self.assertIn(messages[39], check_output(MLGIT_CLONE % (self.GIT_CLONE, '')))
 
-    @pytest.mark.usefixtures("start_local_git_server")
+    @pytest.mark.usefixtures('start_local_git_server')
     def test_07_clone_to_folder_without_permission(self):
         self.set_up_clone()
         os.chdir(PATH_TEST)
-        self.assertIn(messages[46], check_output(MLGIT_CLONE % (self.GIT_CLONE, "--folder=test_permission")))
+        self.assertIn(messages[46], check_output(MLGIT_CLONE % (self.GIT_CLONE, '--folder=test_permission')))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_08_clone_repository_with_wrong_configurations(self):
         os.makedirs(self.GIT_CLONE, exist_ok=True)
         create_git_clone_repo(self.GIT_CLONE, self.tmp_dir, 'wrong_git_path')
-        self.assertIn(messages[94] % 'dataset', check_output(MLGIT_CLONE % (self.GIT_CLONE, '--folder=' + CLONE_FOLDER)))
+        self.assertIn(messages[94] % DATASETS, check_output(MLGIT_CLONE % (self.GIT_CLONE, '--folder=' + CLONE_FOLDER)))

--- a/tests/integration/test_21_tag.py
+++ b/tests/integration/test_21_tag.py
@@ -9,7 +9,7 @@ import unittest
 import pytest
 
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_PUSH, MLGIT_TAG_ADD
-from tests.integration.helper import PATH_TEST, ML_GIT_DIR, create_file, ERROR_MESSAGE
+from tests.integration.helper import PATH_TEST, ML_GIT_DIR, create_file, ERROR_MESSAGE, DATASETS, DATASET_NAME
 from tests.integration.helper import check_output, init_repository, add_file
 from tests.integration.output_messages import messages
 
@@ -40,39 +40,39 @@ class TagAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_01_add_tag(self):
-        self._add_tag_entity('dataset')
+        self._add_tag_entity(DATASETS)
 
         tag_file = os.path.join(self.tmp_dir, 'local_git_server.git', 'refs', 'tags', 'test-tag')
         self.assertTrue(os.path.exists(tag_file))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_02_add_tag_wrong_entity(self):
-        self.set_up_tag('dataset')
+        self.set_up_tag(DATASETS)
 
         self.assertIn(messages[55] % 'dataset-wrong', check_output(MLGIT_TAG_ADD
-                                                                   % ('dataset', 'dataset-wrong', 'test-tag')))
+                                                                   % (DATASETS, 'dataset-wrong', 'test-tag')))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_03_add_tag_without_previous_commit(self):
-        self.set_up_tag('dataset')
+        self.set_up_tag(DATASETS)
 
-        self.assertIn(messages[48] % 'dataset-ex', check_output(MLGIT_TAG_ADD % ('dataset', 'dataset-ex', 'test-tag')))
+        self.assertIn(messages[48] % DATASET_NAME, check_output(MLGIT_TAG_ADD % (DATASETS, DATASET_NAME, 'test-tag')))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_04_add_existing_tag(self):
-        self._add_tag_entity('dataset')
+        self._add_tag_entity(DATASETS)
 
-        create_file(os.path.join('dataset', 'dataset' + '-ex'), 'file2', '0', '')
+        create_file(os.path.join(DATASETS, DATASET_NAME), 'file2', '0', '')
 
         tag_file = os.path.join(self.tmp_dir, 'local_git_server.git', 'refs', 'tags', 'test-tag')
         self.assertTrue(os.path.exists(tag_file))
 
-        self.assertIn(messages[49] % 'test-tag', check_output(MLGIT_TAG_ADD % ('dataset', 'dataset-ex', 'test-tag')))
+        self.assertIn(messages[49] % 'test-tag', check_output(MLGIT_TAG_ADD % (DATASETS, DATASET_NAME, 'test-tag')))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_05_add_tag_and_push(self):
-        self._add_tag_entity('dataset')
-        metadata_path = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata')
+        self._add_tag_entity(DATASETS)
+        metadata_path = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata')
         os.chdir(metadata_path)
 
         self.assertTrue(os.path.exists(os.path.join(PATH_TEST, 'data', 'mlgit',

--- a/tests/integration/test_22_import.py
+++ b/tests/integration/test_22_import.py
@@ -10,7 +10,7 @@ import unittest
 import pytest
 
 from tests.integration.commands import MLGIT_IMPORT
-from tests.integration.helper import check_output, init_repository, PROFILE
+from tests.integration.helper import check_output, init_repository, PROFILE, DATASETS, DATASET_NAME
 from tests.integration.output_messages import messages
 
 
@@ -28,24 +28,24 @@ class ImportAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_01_import_with_wrong_credentials(self):
-        init_repository('dataset', self)
+        init_repository(DATASETS, self)
 
-        self.assertIn(messages[54], check_output(MLGIT_IMPORT % ('dataset', 'bucket', 'dataset-ex')
+        self.assertIn(messages[54], check_output(MLGIT_IMPORT % (DATASETS, 'bucket', DATASET_NAME)
                                                  + ' --credentials=personal2'))
-        self.check_amount_of_files('dataset', 1)
+        self.check_amount_of_files(DATASETS, 1)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_02_import_with_wrong_bucket(self):
-        init_repository('dataset', self)
+        init_repository(DATASETS, self)
 
-        self.assertIn(messages[51], check_output(MLGIT_IMPORT % ('dataset', 'wrong-bucket', 'dataset-ex')
+        self.assertIn(messages[51], check_output(MLGIT_IMPORT % (DATASETS, 'wrong-bucket', DATASET_NAME)
                                                  + ' --object=test  --credentials='+PROFILE))
-        self.check_amount_of_files('dataset', 1)
+        self.check_amount_of_files(DATASETS, 1)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_03_import_when_credentials_does_not_exist(self):
-        init_repository('dataset', self)
+        init_repository(DATASETS, self)
 
-        self.assertIn(messages[52] % 'anyone', check_output(MLGIT_IMPORT % ('dataset', 'bucket', 'dataset-ex')
+        self.assertIn(messages[52] % 'anyone', check_output(MLGIT_IMPORT % (DATASETS, 'bucket', DATASET_NAME)
                                                             + ' --credentials=anyone'))
-        self.check_amount_of_files('dataset', 1)
+        self.check_amount_of_files(DATASETS, 1)

--- a/tests/integration/test_23_metadata_persistence.py
+++ b/tests/integration/test_23_metadata_persistence.py
@@ -10,7 +10,7 @@ import pytest
 
 from tests.integration.commands import MLGIT_STATUS, MLGIT_ADD, MLGIT_PUSH, MLGIT_COMMIT, MLGIT_INIT, \
     MLGIT_REMOTE_ADD, MLGIT_ENTITY_INIT, MLGIT_CHECKOUT, MLGIT_STORE_ADD_WITH_TYPE
-from tests.integration.helper import ML_GIT_DIR, GIT_PATH, BUCKET_NAME, PROFILE, STORE_TYPE
+from tests.integration.helper import ML_GIT_DIR, GIT_PATH, BUCKET_NAME, PROFILE, STORE_TYPE, DATASETS, DATASET_NAME
 from tests.integration.helper import check_output, clear, init_repository, yaml_processor
 from tests.integration.output_messages import messages
 
@@ -20,83 +20,83 @@ class MetadataPersistenceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_change_metadata(self):
-        init_repository('dataset', self)
-        self.assertRegex(check_output(MLGIT_STATUS % ('dataset', 'dataset-ex')),
-                         r'Changes to be committed:\n\nUntracked files:\n\tdataset-ex.spec\n\nCorrupted files')
+        init_repository(DATASETS, self)
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
+                         r'Changes to be committed:\n\nUntracked files:\n\tdatasets-ex.spec\n\nCorrupted files')
 
-        self.assertIn(messages[13] % 'dataset', check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '')))
+        self.assertIn(messages[13] % DATASETS, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '')))
 
-        readme = os.path.join('dataset', 'dataset-ex', 'README.md')
+        readme = os.path.join(DATASETS, DATASET_NAME, 'README.md')
 
         with open(readme, 'w') as file:
             file.write('NEW')
 
-        self.assertRegex(check_output(MLGIT_STATUS % ('dataset', 'dataset-ex')),
-                         r'Changes to be committed:\n\tNew file: dataset-ex.spec\n\nUntracked files:\n\tREADME.md\n\nCorrupted files')
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
+                         r'Changes to be committed:\n\tNew file: datasets-ex.spec\n\nUntracked files:\n\tREADME.md\n\nCorrupted files')
 
-        self.assertIn(messages[13] % 'dataset', check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '')))
+        self.assertIn(messages[13] % DATASETS, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '')))
 
-        status = check_output(MLGIT_STATUS % ('dataset', 'dataset-ex'))
+        status = check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME))
 
-        self.assertIn('New file: dataset-ex.spec', status)
+        self.assertIn('New file: datasets-ex.spec', status)
         self.assertIn('New file: README.md', status)
 
         with open(readme, 'w') as file:
             file.write('NEW2')
 
         spec = {
-            'dataset': {
+            'datasets': {
                 'categories': ['computer-vision', 'images'],
                 'manifest': {
                     'files': 'MANIFEST.yaml',
                     'store': 's3h://mlgit'
                 },
                 'mutability': 'strict',
-                'name': 'dataset-ex',
+                'name': 'datasets-ex',
                 'version': 16
             }
         }
 
-        with open(os.path.join('dataset', 'dataset-ex', 'dataset-ex.spec'), 'w') as y:
-            spec['dataset']['version'] = 17
+        with open(os.path.join(DATASETS, DATASET_NAME, 'datasets-ex.spec'), 'w') as y:
+            spec[DATASETS]['version'] = 17
             yaml_processor.dump(spec, y)
 
-        status = check_output(MLGIT_STATUS % ('dataset', 'dataset-ex'))
+        status = check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME))
 
         self.assertNotIn('new file: README.md', status)
         self.assertIn('README.md', status)
-        self.assertNotIn('new file: dataset-ex.spec', status)
-        self.assertIn('dataset-ex.spec', status)
+        self.assertNotIn('new file: datasets-ex.spec', status)
+        self.assertIn('datasets-ex.spec', status)
 
-        self.assertIn(messages[13] % 'dataset', check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '')))
+        self.assertIn(messages[13] % DATASETS, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '')))
 
-        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata'),
-                                      os.path.join('computer-vision', 'images', 'dataset-ex')),
-                      check_output(MLGIT_COMMIT % ('dataset', 'dataset-ex', '')))
+        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata'),
+                                      os.path.join('computer-vision', 'images', DATASET_NAME)),
+                      check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '')))
 
-        self.assertIn('No blobs', check_output(MLGIT_PUSH % ('dataset', 'dataset-ex')))
+        self.assertIn('No blobs', check_output(MLGIT_PUSH % (DATASETS, DATASET_NAME)))
 
-        self.assertRegex(check_output(MLGIT_STATUS % ('dataset', 'dataset-ex')),
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
                          r'Changes to be committed:\n\nUntracked files:\n\nCorrupted files')
 
         clear(ML_GIT_DIR)
-        clear('dataset')
+        clear(DATASETS)
 
         self.assertIn(messages[0], check_output(MLGIT_INIT))
-        self.assertIn(messages[2] % (GIT_PATH, 'dataset'), check_output(MLGIT_REMOTE_ADD % ('dataset', GIT_PATH)))
+        self.assertIn(messages[2] % (GIT_PATH, DATASETS), check_output(MLGIT_REMOTE_ADD % (DATASETS, GIT_PATH)))
         self.assertIn(messages[7] % (STORE_TYPE, BUCKET_NAME, PROFILE),
                       check_output(MLGIT_STORE_ADD_WITH_TYPE % (BUCKET_NAME, PROFILE, STORE_TYPE)))
-        self.assertIn(messages[8] % (GIT_PATH, os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata')),
-                      check_output(MLGIT_ENTITY_INIT % 'dataset'))
+        self.assertIn(messages[8] % (GIT_PATH, os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata')),
+                      check_output(MLGIT_ENTITY_INIT % DATASETS))
 
-        check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__17'))
+        check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__17'))
 
-        spec_file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'dataset-ex.spec')
-        readme = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'README.md')
+        spec_file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'datasets-ex.spec')
+        readme = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'README.md')
 
         with open(spec_file, 'r') as f:
             spec = yaml_processor.load(f)
-            self.assertEqual(spec['dataset']['version'], 17)
+            self.assertEqual(spec[DATASETS]['version'], 17)
 
         with open(readme, 'r') as f:
             self.assertEqual(f.read(), 'NEW2')

--- a/tests/integration/test_24_api.py
+++ b/tests/integration/test_24_api.py
@@ -13,23 +13,24 @@ from ml_git.constants import Mutability, StoreType
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_INIT
 from tests.integration.helper import ML_GIT_DIR, check_output, init_repository, create_git_clone_repo, \
-    clear, yaml_processor, create_zip_file, CLONE_FOLDER, GIT_PATH, BUCKET_NAME, PROFILE, STORE_TYPE
+    clear, yaml_processor, create_zip_file, CLONE_FOLDER, GIT_PATH, BUCKET_NAME, PROFILE, STORE_TYPE, DATASETS, \
+    DATASET_NAME, LABELS, MODELS
 
 
 @pytest.mark.usefixtures('tmp_dir', 'aws_session')
 class APIAcceptanceTests(unittest.TestCase):
 
-    objects = os.path.join(ML_GIT_DIR, 'dataset', 'objects')
-    refs = os.path.join(ML_GIT_DIR, 'dataset', 'refs')
-    cache = os.path.join(ML_GIT_DIR, 'dataset', 'cache')
-    metadata = os.path.join(ML_GIT_DIR, 'dataset', 'metadata')
-    spec_file = os.path.join('dataset', 'computer-vision', 'images', 'dataset-ex', 'dataset-ex.spec')
-    file1 = os.path.join('dataset', 'computer-vision', 'images', 'dataset-ex', 'data', 'file1')
-    file2 = os.path.join('dataset', 'computer-vision', 'images', 'dataset-ex', 'data', 'file2')
-    file3 = os.path.join('dataset', 'computer-vision', 'images', 'dataset-ex', 'data', 'file3')
-    file4 = os.path.join('dataset', 'computer-vision', 'images', 'dataset-ex', 'data', 'file4')
-    dataset_tag = 'computer-vision__images__dataset-ex__10'
-    data_path = os.path.join('dataset', 'computer-vision', 'images', 'dataset-ex')
+    objects = os.path.join(ML_GIT_DIR, DATASETS, 'objects')
+    refs = os.path.join(ML_GIT_DIR, DATASETS, 'refs')
+    cache = os.path.join(ML_GIT_DIR, DATASETS, 'cache')
+    metadata = os.path.join(ML_GIT_DIR, DATASETS, 'metadata')
+    spec_file = os.path.join(DATASETS, 'computer-vision', 'images', DATASET_NAME, 'datasets-ex.spec')
+    file1 = os.path.join(DATASETS, 'computer-vision', 'images', DATASET_NAME, 'data', 'file1')
+    file2 = os.path.join(DATASETS, 'computer-vision', 'images', DATASET_NAME, 'data', 'file2')
+    file3 = os.path.join(DATASETS, 'computer-vision', 'images', DATASET_NAME, 'data', 'file3')
+    file4 = os.path.join(DATASETS, 'computer-vision', 'images', DATASET_NAME, 'data', 'file4')
+    dataset_tag = 'computer-vision__images__datasets-ex__10'
+    data_path = os.path.join(DATASETS, 'computer-vision', 'images', DATASET_NAME)
     GIT_CLONE = 'git_clone.git'
 
     def create_file(self, path, file_name, code):
@@ -38,26 +39,26 @@ class APIAcceptanceTests(unittest.TestCase):
             file.write(code * 2048)
 
     def set_up_test(self):
-        init_repository('dataset', self)
+        init_repository(DATASETS, self)
 
-        workspace = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex')
+        workspace = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME)
 
         os.makedirs(workspace, exist_ok=True)
 
         spec = {
-            'dataset': {
+            DATASETS: {
                 'categories': ['computer-vision', 'images'],
                 'manifest': {
                     'files': 'MANIFEST.yaml',
                     'store': 's3h://mlgit'
                 },
                 'mutability': Mutability.STRICT.value,
-                'name': 'dataset-ex',
+                'name': DATASET_NAME,
                 'version': 9
             }
         }
 
-        with open(os.path.join(workspace, 'dataset-ex.spec'), 'w') as y:
+        with open(os.path.join(workspace, 'datasets-ex.spec'), 'w') as y:
             yaml_processor.dump(spec, y)
 
         os.makedirs(os.path.join(workspace, 'data'), exist_ok=True)
@@ -67,15 +68,15 @@ class APIAcceptanceTests(unittest.TestCase):
         self.create_file(workspace, 'file3', 'a')
         self.create_file(workspace, 'file4', 'b')
 
-        api.add('dataset', 'dataset-ex', bumpversion=True)
-        api.commit('dataset', 'dataset-ex')
-        api.push('dataset', 'dataset-ex')
+        api.add(DATASETS, DATASET_NAME, bumpversion=True)
+        api.commit(DATASETS, DATASET_NAME)
+        api.push(DATASETS, DATASET_NAME)
 
         self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, self.metadata)))
 
         clear(os.path.join(self.tmp_dir, ML_GIT_DIR))
         clear(workspace)
-        init_repository('dataset', self)
+        init_repository(DATASETS, self)
 
     def check_metadata(self):
         self.assertTrue(os.path.exists(self.objects))
@@ -100,7 +101,7 @@ class APIAcceptanceTests(unittest.TestCase):
     def test_01_checkout_tag(self):
         self.set_up_test()
 
-        data_path = api.checkout('dataset', self.dataset_tag)
+        data_path = api.checkout(DATASETS, self.dataset_tag)
 
         self.assertEqual(self.data_path, data_path)
         self.check_metadata()
@@ -114,7 +115,7 @@ class APIAcceptanceTests(unittest.TestCase):
     def test_02_checkout_with_group_sample(self):
         self.set_up_test()
 
-        data_path = api.checkout('dataset', self.dataset_tag, {'group': '1:2', 'seed': '10'})
+        data_path = api.checkout(DATASETS, self.dataset_tag, {'group': '1:2', 'seed': '10'})
 
         self.assertEqual(self.data_path, data_path)
         self.check_metadata()
@@ -128,7 +129,7 @@ class APIAcceptanceTests(unittest.TestCase):
     def test_03_checkout_with_range_sample(self):
         self.set_up_test()
 
-        data_path = api.checkout('dataset', self.dataset_tag, {'range': '0:4:3'})
+        data_path = api.checkout(DATASETS, self.dataset_tag, {'range': '0:4:3'})
 
         self.assertEqual(self.data_path, data_path)
         self.check_metadata()
@@ -142,7 +143,7 @@ class APIAcceptanceTests(unittest.TestCase):
     def test_04_checkout_with_random_sample(self):
         self.set_up_test()
 
-        data_path = api.checkout('dataset', self.dataset_tag, {'random': '1:2', 'seed': '1'})
+        data_path = api.checkout(DATASETS, self.dataset_tag, {'random': '1:2', 'seed': '1'})
 
         self.assertEqual(self.data_path, data_path)
         self.check_metadata()
@@ -156,7 +157,7 @@ class APIAcceptanceTests(unittest.TestCase):
     def test_05_checkout_with_group_sample_without_group(self):
         self.set_up_test()
 
-        data_path = api.checkout('dataset', self.dataset_tag, {'seed': '10'})
+        data_path = api.checkout(DATASETS, self.dataset_tag, {'seed': '10'})
 
         self._checkout_fail(data_path)
 
@@ -164,7 +165,7 @@ class APIAcceptanceTests(unittest.TestCase):
     def test_06_checkout_with_range_sample_without_range(self):
         self.set_up_test()
 
-        data_path = api.checkout('dataset', self.dataset_tag, {'seed': '10'})
+        data_path = api.checkout(DATASETS, self.dataset_tag, {'seed': '10'})
 
         self._checkout_fail(data_path)
 
@@ -172,7 +173,7 @@ class APIAcceptanceTests(unittest.TestCase):
     def test_07_checkout_with_random_sample_without_seed(self):
         self.set_up_test()
 
-        data_path = api.checkout('dataset', self.dataset_tag, {'random': '1:2'})
+        data_path = api.checkout(DATASETS, self.dataset_tag, {'random': '1:2'})
 
         self._checkout_fail(data_path)
 
@@ -201,7 +202,7 @@ class APIAcceptanceTests(unittest.TestCase):
         with open(os.path.join(entity, entity + '-ex', name), 'wt') as z:
             z.write(value * 100)
 
-    def set_up_add_test(self, entity='dataset'):
+    def set_up_add_test(self, entity=DATASETS):
         clear(os.path.join(self.tmp_dir, ML_GIT_DIR))
         clear(os.path.join(self.tmp_dir, entity))
         init_repository(entity, self)
@@ -209,7 +210,7 @@ class APIAcceptanceTests(unittest.TestCase):
         self.create_file_in_ws(entity, 'file', '0')
         self.create_file_in_ws(entity, 'file2', '1')
 
-    def check_add(self, entity='dataset', files=['file', 'file2'], files_not_in=[]):
+    def check_add(self, entity=DATASETS, files=['file', 'file2'], files_not_in=[]):
         metadata = os.path.join(self.tmp_dir, ML_GIT_DIR, entity, 'index', 'metadata', entity + '-ex')
         metadata_file = os.path.join(metadata, 'MANIFEST.yaml')
         index_file = os.path.join(metadata, 'INDEX.yaml')
@@ -224,7 +225,7 @@ class APIAcceptanceTests(unittest.TestCase):
             for file in files_not_in:
                 self.assertNotIn({file}, manifest.values())
 
-    def check_entity_version(self, version, entity='dataset'):
+    def check_entity_version(self, version, entity=DATASETS):
         spec_path = os.path.join(entity, entity+'-ex', entity+'-ex.spec')
         with open(spec_path) as y:
             ws_spec = yaml_processor.load(y)
@@ -233,7 +234,7 @@ class APIAcceptanceTests(unittest.TestCase):
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_10_add_files(self):
         self.set_up_add_test()
-        api.add('dataset', 'dataset-ex', bumpversion=False, fsck=False, file_path=[])
+        api.add(DATASETS, DATASET_NAME, bumpversion=False, fsck=False, file_path=[])
         self.check_add()
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
@@ -241,7 +242,7 @@ class APIAcceptanceTests(unittest.TestCase):
         self.set_up_add_test()
         self.check_entity_version(1)
 
-        api.add('dataset', 'dataset-ex', bumpversion=True, fsck=False, file_path=[])
+        api.add(DATASETS, DATASET_NAME, bumpversion=True, fsck=False, file_path=[])
 
         self.check_add()
         self.check_entity_version(2)
@@ -250,7 +251,7 @@ class APIAcceptanceTests(unittest.TestCase):
     def test_12_add_one_file(self):
         self.set_up_add_test()
 
-        api.add('dataset', 'dataset-ex', bumpversion=False, fsck=False, file_path=['file'])
+        api.add(DATASETS, DATASET_NAME, bumpversion=False, fsck=False, file_path=['file'])
 
         self.check_add(files=['file'], files_not_in=['file2'])
 
@@ -258,25 +259,25 @@ class APIAcceptanceTests(unittest.TestCase):
     def test_13_commit_files(self):
         self.set_up_test()
         self.set_up_add_test()
-        api.add('dataset', 'dataset-ex', bumpversion=True, fsck=False, file_path=['file'])
-        api.commit('dataset', 'dataset-ex')
-        HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'refs', 'dataset-ex', 'HEAD')
+        api.add(DATASETS, DATASET_NAME, bumpversion=True, fsck=False, file_path=['file'])
+        api.commit(DATASETS, DATASET_NAME)
+        HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'refs', DATASET_NAME, 'HEAD')
         self.assertTrue(os.path.exists(HEAD))
 
-        init_repository('labels', self)
-        self.create_file_in_ws('labels', 'file', '0')
-        api.add('labels', 'labels-ex', bumpversion=True, fsck=False, file_path=['file'])
-        api.commit('labels', 'labels-ex', related_dataset='dataset-ex')
+        init_repository(LABELS, self)
+        self.create_file_in_ws(LABELS, 'file', '0')
+        api.add(LABELS, 'labels-ex', bumpversion=True, fsck=False, file_path=['file'])
+        api.commit(LABELS, 'labels-ex', related_dataset=DATASET_NAME)
 
-        labels_metadata = os.path.join(self.tmp_dir, ML_GIT_DIR, 'labels', 'metadata')
+        labels_metadata = os.path.join(self.tmp_dir, ML_GIT_DIR, LABELS, 'metadata')
 
-        with open(os.path.join(labels_metadata, "computer-vision", "images", "labels-ex", "labels-ex.spec")) as y:
+        with open(os.path.join(labels_metadata, 'computer-vision', 'images', 'labels-ex', 'labels-ex.spec')) as y:
             spec = yaml_processor.load(y)
 
-        HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, 'labels', 'refs', 'labels-ex', 'HEAD')
+        HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, LABELS, 'refs', 'labels-ex', 'HEAD')
         self.assertTrue(os.path.exists(HEAD))
 
-        self.assertEqual('computer-vision__images__dataset-ex__2', spec['labels']['dataset']['tag'])
+        self.assertEqual('computer-vision__images__datasets-ex__2', spec[LABELS][DATASETS]['tag'])
 
     def check_created_folders(self, entity_type, store_type=StoreType.S3H.value, version=1, bucket_name='fake_store'):
         folder_data = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'data')
@@ -297,23 +298,23 @@ class APIAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_14_create_entity(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         store_type = StoreType.S3H.value
         self.assertIn(output_messages['INFO_INITIALIZED_PROJECT'] % self.tmp_dir, check_output(MLGIT_INIT))
-        api.create('dataset', 'dataset-ex', categories=['computer-vision', 'images'], mutability='strict')
+        api.create(DATASETS, DATASET_NAME, categories=['computer-vision', 'images'], mutability='strict')
         self.check_created_folders(entity_type, store_type)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_15_create_entity_with_optional_arguments(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         store_type = StoreType.AZUREBLOBH.value
         self.assertIn(output_messages['INFO_INITIALIZED_PROJECT'] % self.tmp_dir, check_output(MLGIT_INIT))
-        api.create('dataset', 'dataset-ex', categories=['computer-vision', 'images'], version=5, store_type=store_type, bucket_name='test', mutability='strict')
+        api.create(DATASETS, DATASET_NAME, categories=['computer-vision', 'images'], version=5, store_type=store_type, bucket_name='test', mutability='strict')
         self.check_created_folders(entity_type, store_type, version=5, bucket_name='test')
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_16_create_entity_with_import(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         IMPORT_PATH = 'src'
         self.assertIn(output_messages['INFO_INITIALIZED_PROJECT'] % self.tmp_dir, check_output(MLGIT_INIT))
         import_path = os.path.join(self.tmp_dir, IMPORT_PATH)
@@ -346,15 +347,15 @@ class APIAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_18_add_remote_dataset(self):
-        self._add_remote(entity_type='dataset')
+        self._add_remote(entity_type=DATASETS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_19_add_remote_laebls(self):
-        self._add_remote(entity_type='labels')
+        self._add_remote(entity_type=LABELS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_20_add_remote_model(self):
-        self._add_remote(entity_type='model')
+        self._add_remote(entity_type=MODELS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_21_add_store(self):
@@ -404,15 +405,15 @@ class APIAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_24_init_dataset(self):
-        self._initialize_entity('dataset')
+        self._initialize_entity(DATASETS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_25_init_labels(self):
-        self._initialize_entity('labels')
+        self._initialize_entity(LABELS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_26_init_model(self):
-        self._initialize_entity('model')
+        self._initialize_entity(MODELS)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_27_create_with_invalid_entity(self):
@@ -420,7 +421,7 @@ class APIAcceptanceTests(unittest.TestCase):
             entity_type = 'dataset_invalid'
             store_type = StoreType.S3H.value
             self.assertIn(output_messages['INFO_INITIALIZED_PROJECT'] % self.tmp_dir, check_output(MLGIT_INIT))
-            api.create('dataset_invalid', 'dataset-ex', categories=['computer-vision', 'images'], mutability='strict')
+            api.create('dataset_invalid', DATASET_NAME, categories=['computer-vision', 'images'], mutability='strict')
             self.check_created_folders(entity_type, store_type)
             self.assertTrue(False)
         except Exception as e:

--- a/tests/integration/test_25_export.py
+++ b/tests/integration/test_25_export.py
@@ -10,7 +10,7 @@ import pytest
 
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_PUSH, MLGIT_EXPORT
 from tests.integration.helper import ML_GIT_DIR, PROFILE, BUCKET_NAME, \
-    check_output, init_repository, add_file, PATH_TEST
+    check_output, init_repository, add_file, PATH_TEST, DATASETS, DATASET_NAME, MODELS, LABELS
 from tests.integration.output_messages import messages
 
 
@@ -38,13 +38,13 @@ class ExportTagAcceptanceTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_export_dataset_tag(self):
 
-        self.export('dataset', 'dataset-ex')
+        self.export(DATASETS, DATASET_NAME)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_export_model_tag(self):
 
-        self.export('model', 'model-ex')
+        self.export(MODELS, 'models-ex')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_export_labels_tag(self):
-        self.export('labels', 'labels-ex')
+        self.export(LABELS, 'labels-ex')

--- a/tests/integration/test_26_mutability.py
+++ b/tests/integration/test_26_mutability.py
@@ -9,7 +9,7 @@ import unittest
 import pytest
 
 from tests.integration.commands import MLGIT_ADD, MLGIT_COMMIT, MLGIT_PUSH, MLGIT_UPDATE, MLGIT_CHECKOUT
-from tests.integration.helper import ML_GIT_DIR, create_spec, create_file, DATASETS, MODELS, LABELS
+from tests.integration.helper import ML_GIT_DIR, create_spec, create_file, DATASETS, MODELS, LABELS, DATASET_TAG
 from tests.integration.helper import check_output, clear, init_repository, ERROR_MESSAGE, yaml_processor
 from tests.integration.output_messages import messages
 
@@ -35,7 +35,7 @@ class MutabilityAcceptanceTests(unittest.TestCase):
         clear(workspace)
         clear(os.path.join(self.tmp_dir, entity_type))
 
-    def _checkout_entity(self, entity_type, tag='computer-vision__images__datasets-ex__1'):
+    def _checkout_entity(self, entity_type, tag=DATASET_TAG):
         init_repository(entity_type, self)
         self.assertIn(messages[20] % (os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'metadata')),
                       check_output(MLGIT_UPDATE % entity_type))

--- a/tests/integration/test_26_mutability.py
+++ b/tests/integration/test_26_mutability.py
@@ -9,7 +9,7 @@ import unittest
 import pytest
 
 from tests.integration.commands import MLGIT_ADD, MLGIT_COMMIT, MLGIT_PUSH, MLGIT_UPDATE, MLGIT_CHECKOUT
-from tests.integration.helper import ML_GIT_DIR, create_spec, create_file
+from tests.integration.helper import ML_GIT_DIR, create_spec, create_file, DATASETS, MODELS, LABELS
 from tests.integration.helper import check_output, clear, init_repository, ERROR_MESSAGE, yaml_processor
 from tests.integration.output_messages import messages
 
@@ -35,7 +35,7 @@ class MutabilityAcceptanceTests(unittest.TestCase):
         clear(workspace)
         clear(os.path.join(self.tmp_dir, entity_type))
 
-    def _checkout_entity(self, entity_type, tag='computer-vision__images__dataset-ex__1'):
+    def _checkout_entity(self, entity_type, tag='computer-vision__images__datasets-ex__1'):
         init_repository(entity_type, self)
         self.assertIn(messages[20] % (os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'metadata')),
                       check_output(MLGIT_UPDATE % entity_type))
@@ -56,7 +56,7 @@ class MutabilityAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_mutability_strict_push(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         self._create_entity_with_mutability(entity_type, 'strict')
         self._checkout_entity(entity_type)
 
@@ -72,9 +72,9 @@ class MutabilityAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_mutability_flexible_push(self):
-        entity_type = 'model'
+        entity_type = MODELS
         self._create_entity_with_mutability(entity_type, 'flexible')
-        self._checkout_entity(entity_type, 'computer-vision__images__model-ex__1')
+        self._checkout_entity(entity_type, 'computer-vision__images__models-ex__1')
 
         spec_with_categories = os.path.join(self.tmp_dir, entity_type, 'computer-vision', 'images', entity_type + '-ex',
                                             entity_type + '-ex.spec')
@@ -88,7 +88,7 @@ class MutabilityAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_mutability_mutable_push(self):
-        entity_type = 'labels'
+        entity_type = LABELS
         self._create_entity_with_mutability(entity_type, 'mutable')
         self._checkout_entity(entity_type, 'computer-vision__images__labels-ex__1')
 

--- a/tests/integration/test_27_unlock.py
+++ b/tests/integration/test_27_unlock.py
@@ -10,7 +10,7 @@ from stat import S_IREAD, S_IRGRP, S_IROTH
 import pytest
 
 from tests.integration.commands import MLGIT_ADD, MLGIT_UNLOCK
-from tests.integration.helper import check_output, ERROR_MESSAGE
+from tests.integration.helper import check_output, ERROR_MESSAGE, DATASETS, DATASET_NAME
 from tests.integration.helper import create_spec, init_repository
 from tests.integration.output_messages import messages
 
@@ -18,7 +18,7 @@ from tests.integration.output_messages import messages
 @pytest.mark.usefixtures('tmp_dir')
 class UnlockAcceptanceTests(unittest.TestCase):
     file = os.path.join('data', 'file1')
-    workspace = os.path.join('dataset', 'dataset-ex')
+    workspace = os.path.join(DATASETS, DATASET_NAME)
     file_path = os.path.join(workspace, file)
 
     def set_up_unlock(self, entity_type, mutability_type):
@@ -35,35 +35,35 @@ class UnlockAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_unlock_in_strict_mode(self):
-        self.set_up_unlock('dataset', 'strict')
+        self.set_up_unlock(DATASETS, 'strict')
 
         self.assertEqual(2, os.stat(self.file_path).st_nlink)
-        self.assertIn(messages[71], check_output(MLGIT_UNLOCK % ('dataset', 'dataset-ex', 'data/file1')))
+        self.assertIn(messages[71], check_output(MLGIT_UNLOCK % (DATASETS, DATASET_NAME, 'data/file1')))
         self.assertEqual(2, os.stat(self.file_path).st_nlink)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_unlock_wrong_file(self):
-        self.set_up_unlock('dataset', 'flexible')
+        self.set_up_unlock(DATASETS, 'flexible')
 
         self.assertEqual(2, os.stat(self.file_path).st_nlink)
         self.assertIn(messages[73] % 'data/file10', check_output(MLGIT_UNLOCK %
-                                                                 ('dataset', 'dataset-ex', 'data/file10')))
+                                                                 (DATASETS, DATASET_NAME, 'data/file10')))
         self.assertEqual(2, os.stat(self.file_path).st_nlink)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_unlock_flexible_mode(self):
-        self.set_up_unlock('dataset', 'flexible')
+        self.set_up_unlock(DATASETS, 'flexible')
 
         self.assertEqual(2, os.stat(self.file_path).st_nlink)
-        self.assertIn(messages[72] % 'data/file1', check_output(MLGIT_UNLOCK % ('dataset', 'dataset-ex', 'data/file1')))
+        self.assertIn(messages[72] % 'data/file1', check_output(MLGIT_UNLOCK % (DATASETS, DATASET_NAME, 'data/file1')))
         self.assertTrue(os.access(self.file_path, os.W_OK))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_unlock_mutable_mode(self):
-        self.set_up_unlock('dataset', 'mutable')
+        self.set_up_unlock(DATASETS, 'mutable')
 
         os.chmod(self.file_path, S_IREAD | S_IRGRP | S_IROTH)
         self.assertEqual(1, os.stat(self.file_path).st_nlink)
-        self.assertIn(messages[72] % 'data/file1', check_output(MLGIT_UNLOCK % ('dataset', 'dataset-ex', 'data/file1')))
+        self.assertIn(messages[72] % 'data/file1', check_output(MLGIT_UNLOCK % (DATASETS, DATASET_NAME, 'data/file1')))
         self.assertEqual(1, os.stat(self.file_path).st_nlink)
         self.assertTrue(os.access(self.file_path, os.W_OK))

--- a/tests/integration/test_28_checkout_bare.py
+++ b/tests/integration/test_28_checkout_bare.py
@@ -9,7 +9,7 @@ import unittest
 import pytest
 
 from tests.integration.commands import MLGIT_ADD, MLGIT_COMMIT, MLGIT_PUSH, MLGIT_UPDATE, MLGIT_CHECKOUT
-from tests.integration.helper import ML_GIT_DIR, ERROR_MESSAGE, DATASETS, DATASET_NAME
+from tests.integration.helper import ML_GIT_DIR, ERROR_MESSAGE, DATASETS, DATASET_NAME, DATASET_TAG
 from tests.integration.helper import check_output, clear, init_repository, create_spec, create_file, yaml_processor
 from tests.integration.output_messages import messages
 
@@ -38,7 +38,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         self._push_files(entity_type, '')
         self._clear_path()
 
-    def _checkout_entity(self, entity_type, tag='computer-vision__images__datasets-ex__1', bare=True):
+    def _checkout_entity(self, entity_type, tag=DATASET_TAG, bare=True):
         init_repository(entity_type, self)
         self.assertIn(messages[20] % (os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'metadata')),
                       check_output(MLGIT_UPDATE % entity_type))

--- a/tests/integration/test_28_checkout_bare.py
+++ b/tests/integration/test_28_checkout_bare.py
@@ -9,7 +9,7 @@ import unittest
 import pytest
 
 from tests.integration.commands import MLGIT_ADD, MLGIT_COMMIT, MLGIT_PUSH, MLGIT_UPDATE, MLGIT_CHECKOUT
-from tests.integration.helper import ML_GIT_DIR, ERROR_MESSAGE
+from tests.integration.helper import ML_GIT_DIR, ERROR_MESSAGE, DATASETS, DATASET_NAME
 from tests.integration.helper import check_output, clear, init_repository, create_spec, create_file, yaml_processor
 from tests.integration.output_messages import messages
 
@@ -22,7 +22,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (entity_type, entity_type + '-ex', '')))
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_PUSH % (entity_type, entity_type+'-ex')))
 
-    def _clear_path(self, entity_type='dataset'):
+    def _clear_path(self, entity_type=DATASETS):
         clear(os.path.join(self.tmp_dir, ML_GIT_DIR))
         workspace = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex')
         clear(os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'cache'))
@@ -38,7 +38,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         self._push_files(entity_type, '')
         self._clear_path()
 
-    def _checkout_entity(self, entity_type, tag='computer-vision__images__dataset-ex__1', bare=True):
+    def _checkout_entity(self, entity_type, tag='computer-vision__images__datasets-ex__1', bare=True):
         init_repository(entity_type, self)
         self.assertIn(messages[20] % (os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'metadata')),
                       check_output(MLGIT_UPDATE % entity_type))
@@ -46,7 +46,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
             self.assertIn(messages[68], check_output(MLGIT_CHECKOUT % (entity_type, tag + ' --bare')))
         else:
             self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (entity_type, tag)))
-            self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'data', 'file1')))
+            self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'data', 'file1')))
 
     def check_bare_checkout(self, entity):
         objects = os.path.join(self.tmp_dir, ML_GIT_DIR, entity, 'objects')
@@ -63,18 +63,18 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_checkout_bare(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         self._create_entity_with_mutability(entity_type, 'strict')
         self._checkout_entity(entity_type)
-        self.assertFalse(os.path.exists(os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'data', 'file1')))
+        self.assertFalse(os.path.exists(os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'data', 'file1')))
         self.check_bare_checkout(entity_type)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_push_file(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         self._create_entity_with_mutability(entity_type, 'strict')
         self._checkout_entity(entity_type)
-        self.assertFalse(os.path.exists(os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'data', 'file1')))
+        self.assertFalse(os.path.exists(os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'data', 'file1')))
         self.check_bare_checkout(entity_type)
 
         data_path = os.path.join(self.tmp_dir, entity_type, 'computer-vision', 'images', entity_type+'-ex')
@@ -87,10 +87,10 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         self._checkout_entity(entity_type, tag='computer-vision__images__'+entity_type+'-ex__2', bare=False)
 
         file2 = os.path.join(self.tmp_dir, entity_type, 'computer-vision', 'images', entity_type+'-ex', 'data', 'file2')
-        self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'data', 'file1')))
+        self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'data', 'file1')))
         self.assertTrue(os.path.exists(file2))
 
-    def _create_file_with_same_path(self, entity_type='dataset'):
+    def _create_file_with_same_path(self, entity_type=DATASETS):
         entity_path = os.path.join(self.tmp_dir, entity_type, 'computer-vision', 'images', entity_type+'-ex')
 
         file = os.path.join(self.tmp_dir, entity_path, 'data', 'file1')
@@ -102,7 +102,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_push_file_with_same_path_strict(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         self._create_entity_with_mutability(entity_type, 'strict')
         self._checkout_entity(entity_type)
         self.check_bare_checkout(entity_type)
@@ -112,17 +112,17 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
 
         self._clear_path()
 
-        self.assertFalse(os.path.exists(os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'data', 'file1')))
+        self.assertFalse(os.path.exists(os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'data', 'file1')))
         self._checkout_entity(entity_type, tag='computer-vision__images__'+entity_type+'-ex__1', bare=False)
 
-        with open(os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'data', 'file1')) as f:
+        with open(os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'data', 'file1')) as f:
             file_text = f.read()
             self.assertNotIn('1', file_text)
             self.assertIn('0', file_text)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_push_file_with_same_path_mutable(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         self._create_entity_with_mutability(entity_type, 'mutable')
         self._checkout_entity(entity_type)
 
@@ -139,14 +139,14 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
 
         self._checkout_entity(entity_type, tag='computer-vision__images__'+entity_type+'-ex__2', bare=False)
 
-        with open(os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'data', 'file1')) as f:
+        with open(os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'data', 'file1')) as f:
             file_text = f.read()
             self.assertNotIn('0', file_text)
             self.assertIn('1', file_text)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_checkout_bare_in_older_tag(self):
-        entity_type = 'dataset'
+        entity_type = DATASETS
         self._create_entity_with_mutability(entity_type, 'strict')
         data_path = os.path.join(self.tmp_dir, entity_type, 'computer-vision', 'images', entity_type+'-ex')
         self._clear_path()
@@ -154,12 +154,12 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         os.mkdir(os.path.join(data_path, 'data'))
         create_file(data_path, 'file3', '1')
 
-        spec_path = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'dataset-ex.spec')
+        spec_path = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'datasets-ex.spec')
         with open(spec_path, 'r') as y:
             spec = yaml_processor.load(y)
 
         with open(spec_path, 'w') as y:
-            spec['dataset']['version'] = 2
+            spec[DATASETS]['version'] = 2
             yaml_processor.dump(spec, y)
 
         self._push_files(entity_type)

--- a/tests/integration/test_29_log.py
+++ b/tests/integration/test_29_log.py
@@ -10,7 +10,7 @@ import pytest
 
 from tests.integration.commands import MLGIT_ADD, MLGIT_COMMIT, MLGIT_LOG
 from tests.integration.helper import ML_GIT_DIR, add_file, create_spec, delete_file, ERROR_MESSAGE, DATASETS, \
-    DATASET_NAME
+    DATASET_NAME, DATASET_TAG
 from tests.integration.helper import check_output, init_repository
 from tests.integration.output_messages import messages
 
@@ -18,7 +18,6 @@ from tests.integration.output_messages import messages
 @pytest.mark.usefixtures('tmp_dir')
 class LogTests(unittest.TestCase):
     COMMIT_MESSAGE = 'test_message'
-    TAG = 'computer-vision__images__datasets-ex__1'
 
     def setUp_test(self):
         init_repository(DATASETS, self)
@@ -32,7 +31,7 @@ class LogTests(unittest.TestCase):
     def test_01_log(self):
         self.setUp_test()
         output = check_output(MLGIT_LOG % (DATASETS, DATASET_NAME, ''))
-        self.assertIn(messages[77] % self.TAG, output)
+        self.assertIn(messages[77] % DATASET_TAG, output)
         self.assertIn(messages[78] % self.COMMIT_MESSAGE, output)
         self.assertNotIn(messages[79] % 0, output)
         self.assertNotIn(messages[80] % 0, output)

--- a/tests/integration/test_29_log.py
+++ b/tests/integration/test_29_log.py
@@ -9,7 +9,8 @@ import unittest
 import pytest
 
 from tests.integration.commands import MLGIT_ADD, MLGIT_COMMIT, MLGIT_LOG
-from tests.integration.helper import ML_GIT_DIR, add_file, create_spec, delete_file, ERROR_MESSAGE
+from tests.integration.helper import ML_GIT_DIR, add_file, create_spec, delete_file, ERROR_MESSAGE, DATASETS, \
+    DATASET_NAME
 from tests.integration.helper import check_output, init_repository
 from tests.integration.output_messages import messages
 
@@ -17,20 +18,20 @@ from tests.integration.output_messages import messages
 @pytest.mark.usefixtures('tmp_dir')
 class LogTests(unittest.TestCase):
     COMMIT_MESSAGE = 'test_message'
-    TAG = 'computer-vision__images__dataset-ex__1'
+    TAG = 'computer-vision__images__datasets-ex__1'
 
     def setUp_test(self):
-        init_repository('dataset', self)
-        create_spec(self, 'dataset', self.tmp_dir)
-        self.assertIn(messages[13] % 'dataset', check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '')))
-        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata'),
-                                      os.path.join('computer-vision', 'images', 'dataset-ex')),
-                      check_output(MLGIT_COMMIT % ('dataset', 'dataset-ex', '-m ' + self.COMMIT_MESSAGE)))
+        init_repository(DATASETS, self)
+        create_spec(self, DATASETS, self.tmp_dir)
+        self.assertIn(messages[13] % DATASETS, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '')))
+        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata'),
+                                      os.path.join('computer-vision', 'images', DATASET_NAME)),
+                      check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '-m ' + self.COMMIT_MESSAGE)))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_log(self):
         self.setUp_test()
-        output = check_output(MLGIT_LOG % ('dataset', 'dataset-ex', ''))
+        output = check_output(MLGIT_LOG % (DATASETS, DATASET_NAME, ''))
         self.assertIn(messages[77] % self.TAG, output)
         self.assertIn(messages[78] % self.COMMIT_MESSAGE, output)
         self.assertNotIn(messages[79] % 0, output)
@@ -41,7 +42,7 @@ class LogTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_log_with_stat(self):
         self.setUp_test()
-        output = check_output(MLGIT_LOG % ('dataset', 'dataset-ex', '--stat'))
+        output = check_output(MLGIT_LOG % (DATASETS, DATASET_NAME, '--stat'))
         self.assertIn(messages[79] % 0, output)
         self.assertIn(messages[80] % 0, output)
         self.assertNotIn(messages[81] % 0, output)
@@ -52,12 +53,12 @@ class LogTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_log_with_fullstat(self):
         self.setUp_test()
-        add_file(self, 'dataset', '--bumpversion')
-        check_output(MLGIT_COMMIT % ('dataset', 'dataset-ex', ''))
+        add_file(self, DATASETS, '--bumpversion')
+        check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, ''))
         amount_files = 5
         workspace_size = 14
 
-        output = check_output(MLGIT_LOG % ('dataset', 'dataset-ex', '--fullstat'))
+        output = check_output(MLGIT_LOG % (DATASETS, DATASET_NAME, '--fullstat'))
 
         files = ['newfile4', 'file2', 'file0', 'file3']
 
@@ -70,15 +71,15 @@ class LogTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_log_with_fullstat_files_added_and_deleted(self):
         self.setUp_test()
-        add_file(self, 'dataset', '--bumpversion')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % ('dataset', 'dataset-ex', '')))
+        add_file(self, DATASETS, '--bumpversion')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '')))
         added = 4
         deleted = 1
-        workspace_path = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex')
+        workspace_path = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME)
         files = ['file2', 'newfile4']
         delete_file(workspace_path, files)
-        add_file(self, 'dataset', '--bumpversion', 'img')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % ('dataset', 'dataset-ex', '')))
-        output = check_output(MLGIT_LOG % ('dataset', 'dataset-ex', '--fullstat'))
+        add_file(self, DATASETS, '--bumpversion', 'img')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '')))
+        output = check_output(MLGIT_LOG % (DATASETS, DATASET_NAME, '--fullstat'))
         self.assertIn(messages[81] % added, output)
         self.assertIn(messages[82] % deleted, output)

--- a/tests/integration/test_30_azure_storage.py
+++ b/tests/integration/test_30_azure_storage.py
@@ -12,14 +12,14 @@ from azure.storage.blob import BlobServiceClient, ContainerClient
 
 from tests.integration.commands import MLGIT_INIT, MLGIT_REMOTE_ADD, MLGIT_ENTITY_INIT, MLGIT_COMMIT, MLGIT_PUSH, \
     MLGIT_CHECKOUT
-from tests.integration.helper import ML_GIT_DIR, ERROR_MESSAGE
+from tests.integration.helper import ML_GIT_DIR, ERROR_MESSAGE, DATASETS, DATASET_NAME
 from tests.integration.helper import check_output, clear, GIT_PATH, create_spec, add_file
 from tests.integration.output_messages import messages
 
 
 @pytest.mark.usefixtures('tmp_dir', 'start_local_git_server', 'switch_to_tmp_dir')
 class AzureAcceptanceTests(unittest.TestCase):
-    repo_type = 'dataset'
+    repo_type = DATASETS
     store_type = 'azureblobh'
     bucket = 'mlgit'
     workspace = os.path.join(repo_type, repo_type + '-ex')
@@ -37,14 +37,14 @@ class AzureAcceptanceTests(unittest.TestCase):
         self.assertIn(messages[87] % (self.store_type, self.bucket),
                       check_output('ml-git repository store add %s --type=%s' %
                                    (self.bucket, self.store_type)))
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ENTITY_INIT % 'dataset'))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ENTITY_INIT % DATASETS))
 
         add_file(self, self.repo_type, '', 'new')
-        metadata_path = os.path.join(ML_GIT_DIR, 'dataset', 'metadata')
+        metadata_path = os.path.join(ML_GIT_DIR, DATASETS, 'metadata')
         self.assertIn(messages[17] % (os.path.join(self.tmp_dir, metadata_path),
-                                      os.path.join('computer-vision', 'images', 'dataset-ex')),
-                      check_output(MLGIT_COMMIT % (self.repo_type, 'dataset-ex', '')))
-        HEAD = os.path.join(ML_GIT_DIR, 'dataset', 'refs', 'dataset-ex', 'HEAD')
+                                      os.path.join('computer-vision', 'images', DATASET_NAME)),
+                      check_output(MLGIT_COMMIT % (self.repo_type, DATASET_NAME, '')))
+        HEAD = os.path.join(ML_GIT_DIR, DATASETS, 'refs', DATASET_NAME, 'HEAD')
         self.assertTrue(os.path.exists(HEAD))
 
     def create_bucket(self, connection_string, container):
@@ -65,14 +65,14 @@ class AzureAcceptanceTests(unittest.TestCase):
         self.assertIn(messages[87] % (self.store_type, self.bucket),
                       check_output('ml-git repository store add %s --type=%s' %
                                    (self.bucket, self.store_type)))
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ENTITY_INIT % 'dataset'))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ENTITY_INIT % DATASETS))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     @mock.patch.dict(os.environ, {'AZURE_STORAGE_CONNECTION_STRING': dev_store_account_})
     def test_02_push_file(self):
         self.set_up_push()
         self.assertEqual(os.getenv('AZURE_STORAGE_CONNECTION_STRING'), self.dev_store_account_)
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_PUSH % (self.repo_type, 'dataset-ex')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_PUSH % (self.repo_type, DATASET_NAME)))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     @mock.patch.dict(os.environ, {'AZURE_STORAGE_CONNECTION_STRING': dev_store_account_})
@@ -86,26 +86,26 @@ class AzureAcceptanceTests(unittest.TestCase):
         self.assertIn(messages[87] % (self.store_type, self.bucket),
                       check_output('ml-git repository store add %s --type=%s' %
                                    (self.bucket, self.store_type)))
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ENTITY_INIT % 'dataset'))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ENTITY_INIT % DATASETS))
 
         add_file(self, self.repo_type, '', 'new')
-        metadata_path = os.path.join(ML_GIT_DIR, 'dataset', 'metadata')
+        metadata_path = os.path.join(ML_GIT_DIR, DATASETS, 'metadata')
         self.assertIn(messages[17] %
                       (os.path.join(self.tmp_dir, metadata_path),
-                       os.path.join('computer-vision', 'images', 'dataset-ex')),
-                      check_output(MLGIT_COMMIT % (self.repo_type, 'dataset-ex', '')))
-        HEAD = os.path.join(ML_GIT_DIR, 'dataset', 'refs', 'dataset-ex', 'HEAD')
+                       os.path.join('computer-vision', 'images', DATASET_NAME)),
+                      check_output(MLGIT_COMMIT % (self.repo_type, DATASET_NAME, '')))
+        HEAD = os.path.join(ML_GIT_DIR, DATASETS, 'refs', DATASET_NAME, 'HEAD')
         self.assertTrue(os.path.exists(HEAD))
         self.assertEqual(os.getenv('AZURE_STORAGE_CONNECTION_STRING'), self.dev_store_account_)
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_PUSH % (self.repo_type, 'dataset-ex')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_PUSH % (self.repo_type, DATASET_NAME)))
 
         clear(self.workspace)
-        clear(os.path.join(ML_GIT_DIR, 'dataset'))
+        clear(os.path.join(ML_GIT_DIR, DATASETS))
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ENTITY_INIT % self.repo_type))
         self.assertEqual(os.getenv('AZURE_STORAGE_CONNECTION_STRING'), self.dev_store_account_)
         self.assertNotIn(ERROR_MESSAGE,
-                         check_output(MLGIT_CHECKOUT % (self.repo_type, 'computer-vision__images__dataset-ex__1')))
-        ws_path = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex')
+                         check_output(MLGIT_CHECKOUT % (self.repo_type, 'computer-vision__images__datasets-ex__1')))
+        ws_path = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME)
 
         self.assertTrue(os.path.isfile(os.path.join(ws_path, 'newfile0')))
         self.assertTrue(os.path.isfile(os.path.join(ws_path, 'newfile1')))
@@ -116,11 +116,10 @@ class AzureAcceptanceTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_push_without_credentials(self):
         self.set_up_push()
-
-        self.assertIn(messages[102], check_output(MLGIT_PUSH % (self.repo_type, 'dataset-ex')))
+        self.assertIn(messages[102], check_output(MLGIT_PUSH % (self.repo_type, DATASET_NAME)))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     @mock.patch.dict(os.environ, {'AZURE_STORAGE_CONNECTION_STRING': 'wrong_connection_string'})
     def test_05_push_with_wrong_connection_credential(self):
         self.set_up_push()
-        self.assertIn(messages[103], check_output(MLGIT_PUSH % (self.repo_type, 'dataset-ex')))
+        self.assertIn(messages[103], check_output(MLGIT_PUSH % (self.repo_type, DATASET_NAME)))

--- a/tests/integration/test_30_azure_storage.py
+++ b/tests/integration/test_30_azure_storage.py
@@ -12,7 +12,7 @@ from azure.storage.blob import BlobServiceClient, ContainerClient
 
 from tests.integration.commands import MLGIT_INIT, MLGIT_REMOTE_ADD, MLGIT_ENTITY_INIT, MLGIT_COMMIT, MLGIT_PUSH, \
     MLGIT_CHECKOUT
-from tests.integration.helper import ML_GIT_DIR, ERROR_MESSAGE, DATASETS, DATASET_NAME
+from tests.integration.helper import ML_GIT_DIR, ERROR_MESSAGE, DATASETS, DATASET_NAME, DATASET_TAG
 from tests.integration.helper import check_output, clear, GIT_PATH, create_spec, add_file
 from tests.integration.output_messages import messages
 
@@ -104,7 +104,7 @@ class AzureAcceptanceTests(unittest.TestCase):
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ENTITY_INIT % self.repo_type))
         self.assertEqual(os.getenv('AZURE_STORAGE_CONNECTION_STRING'), self.dev_store_account_)
         self.assertNotIn(ERROR_MESSAGE,
-                         check_output(MLGIT_CHECKOUT % (self.repo_type, 'computer-vision__images__datasets-ex__1')))
+                         check_output(MLGIT_CHECKOUT % (self.repo_type, DATASET_TAG)))
         ws_path = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME)
 
         self.assertTrue(os.path.isfile(os.path.join(ws_path, 'newfile0')))

--- a/tests/integration/test_31_push_api.py
+++ b/tests/integration/test_31_push_api.py
@@ -9,7 +9,7 @@ import unittest
 import pytest
 
 from ml_git import api
-from tests.integration.helper import ML_GIT_DIR, create_spec
+from tests.integration.helper import ML_GIT_DIR, create_spec, DATASETS, DATASET_NAME, MODELS, LABELS
 from tests.integration.helper import init_repository
 
 
@@ -38,23 +38,23 @@ class APIAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_01_dataset_push(self):
-        self.set_up_test('dataset')
-        cache = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'cache')
-        api.push('dataset', 'dataset-ex', 2, False)
+        self.set_up_test(DATASETS)
+        cache = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'cache')
+        api.push(DATASETS, DATASET_NAME, 2, False)
         self.assertTrue(os.path.exists(cache))
         self.assertFalse(os.path.isfile(os.path.join(cache, 'store.log')))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_02_model_push(self):
-        self.set_up_test('model')
-        cache = os.path.join(self.tmp_dir, ML_GIT_DIR, 'model', 'cache')
-        api.push('model', 'model-ex', 2, False)
+        self.set_up_test(MODELS)
+        cache = os.path.join(self.tmp_dir, ML_GIT_DIR, MODELS, 'cache')
+        api.push(MODELS, 'models-ex', 2, False)
         self.assertTrue(os.path.exists(cache))
         self.assertFalse(os.path.isfile(os.path.join(cache, 'store.log')))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_03_labels_push(self):
-        self.set_up_test('labels')
+        self.set_up_test(LABELS)
         cache = os.path.join(self.tmp_dir, ML_GIT_DIR, 'labels', 'cache')
         api.push('labels', 'labels-ex', 2, False)
         self.assertTrue(os.path.exists(cache))

--- a/tests/integration/test_32_checkout_otf.py
+++ b/tests/integration/test_32_checkout_otf.py
@@ -14,7 +14,7 @@ from tests.integration.commands import MLGIT_INIT, MLGIT_STORE_ADD, MLGIT_COMMIT
     MLGIT_CHECKOUT, MLGIT_ENTITY_INIT
 from tests.integration.helper import check_output, BUCKET_NAME, PROFILE, ERROR_MESSAGE, init_repository, add_file, \
     ML_GIT_DIR, clear, GLOBAL_CONFIG_PATH, delete_global_config, \
-    configure_global, DATASETS, DATASET_NAME
+    configure_global, DATASETS, DATASET_NAME, DATASET_TAG
 from tests.integration.output_messages import messages
 
 
@@ -55,7 +55,7 @@ class APIAcceptanceTests(unittest.TestCase):
     @mock.patch.dict(os.environ, {'HOME': GLOBAL_CONFIG_PATH})
     def test_01_checkout_with_otf_option(self):
         self.set_up_checkout(DATASETS)
-        self.assertIn(messages[0], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')))
+        self.assertIn(messages[0], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)))
         self.check_metadata()
         self.check_amount_of_files(DATASETS, 6)
 
@@ -66,7 +66,7 @@ class APIAcceptanceTests(unittest.TestCase):
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_INIT))
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_STORE_ADD % (BUCKET_NAME, PROFILE)))
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ENTITY_INIT % DATASETS))
-        self.assertNotIn(messages[98], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')))
+        self.assertNotIn(messages[98], check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)))
         self.check_metadata()
         self.check_amount_of_files(DATASETS, 6)
 

--- a/tests/integration/test_32_checkout_otf.py
+++ b/tests/integration/test_32_checkout_otf.py
@@ -14,7 +14,7 @@ from tests.integration.commands import MLGIT_INIT, MLGIT_STORE_ADD, MLGIT_COMMIT
     MLGIT_CHECKOUT, MLGIT_ENTITY_INIT
 from tests.integration.helper import check_output, BUCKET_NAME, PROFILE, ERROR_MESSAGE, init_repository, add_file, \
     ML_GIT_DIR, clear, GLOBAL_CONFIG_PATH, delete_global_config, \
-    configure_global
+    configure_global, DATASETS, DATASET_NAME
 from tests.integration.output_messages import messages
 
 
@@ -22,7 +22,7 @@ from tests.integration.output_messages import messages
 class APIAcceptanceTests(unittest.TestCase):
 
     def set_up_checkout(self, entity):
-        configure_global(self, 'dataset')
+        configure_global(self, DATASETS)
         init_repository(entity, self)
         add_file(self, entity, '', 'new')
         workspace = os.path.join(self.tmp_dir, entity)
@@ -32,10 +32,10 @@ class APIAcceptanceTests(unittest.TestCase):
         clear(workspace)
 
     def check_metadata(self):
-        objects = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'objects')
-        refs = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'refs')
-        cache = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'cache')
-        spec_file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'dataset-ex.spec')
+        objects = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'objects')
+        refs = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'refs')
+        cache = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'cache')
+        spec_file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'datasets-ex.spec')
 
         self.assertTrue(os.path.exists(objects))
         self.assertTrue(os.path.exists(refs))
@@ -54,35 +54,35 @@ class APIAcceptanceTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     @mock.patch.dict(os.environ, {'HOME': GLOBAL_CONFIG_PATH})
     def test_01_checkout_with_otf_option(self):
-        self.set_up_checkout('dataset')
-        self.assertIn(messages[0], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')))
+        self.set_up_checkout(DATASETS)
+        self.assertIn(messages[0], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')))
         self.check_metadata()
-        self.check_amount_of_files('dataset', 6)
+        self.check_amount_of_files(DATASETS, 6)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     @mock.patch.dict(os.environ, {'HOME': GLOBAL_CONFIG_PATH})
     def test_02_checkout_with_otf_in_already_initialized_repository(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_INIT))
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_STORE_ADD % (BUCKET_NAME, PROFILE)))
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ENTITY_INIT % 'dataset'))
-        self.assertNotIn(messages[98], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ENTITY_INIT % DATASETS))
+        self.assertNotIn(messages[98], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__1')))
         self.check_metadata()
-        self.check_amount_of_files('dataset', 6)
+        self.check_amount_of_files(DATASETS, 6)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     @mock.patch.dict(os.environ, {'HOME': GLOBAL_CONFIG_PATH})
     def test_03_checkout_with_otf_fail(self):
-        self.set_up_checkout('dataset')
-        self.assertIn(messages[98], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__2')))
-        entity_dir = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex')
+        self.set_up_checkout(DATASETS)
+        self.assertIn(messages[98], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__2')))
+        entity_dir = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME)
         self.assertFalse(os.path.exists(entity_dir))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     @mock.patch.dict(os.environ, {'HOME': GLOBAL_CONFIG_PATH})
     def test_04_checkout_with_otf_without_global(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         delete_global_config()
-        self.assertIn(messages[99], check_output(MLGIT_CHECKOUT % ('dataset', 'computer-vision__images__dataset-ex__2')))
-        entity_dir = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex')
+        self.assertIn(messages[99], check_output(MLGIT_CHECKOUT % (DATASETS, 'computer-vision__images__datasets-ex__2')))
+        entity_dir = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME)
         self.assertFalse(os.path.exists(entity_dir))

--- a/tests/integration/test_33_checkout_entity.py
+++ b/tests/integration/test_33_checkout_entity.py
@@ -12,7 +12,7 @@ import pytest
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_CHECKOUT, MLGIT_PUSH, MLGIT_COMMIT, MLGIT_ADD
 from tests.integration.helper import ML_GIT_DIR, MLGIT_ENTITY_INIT, ERROR_MESSAGE, \
-    add_file, GIT_PATH, check_output, clear, init_repository
+    add_file, GIT_PATH, check_output, clear, init_repository, DATASETS, DATASET_NAME
 
 
 @pytest.mark.usefixtures('tmp_dir', 'aws_session')
@@ -39,10 +39,10 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         self.assertEqual(file_count, expected_files)
 
     def check_metadata(self):
-        objects = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'objects')
-        refs = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'refs')
-        cache = os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'cache')
-        spec_file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'dataset-ex.spec')
+        objects = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'objects')
+        refs = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'refs')
+        cache = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'cache')
+        spec_file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'datasets-ex.spec')
 
         self.assertTrue(os.path.exists(objects))
         self.assertTrue(os.path.exists(refs))
@@ -69,28 +69,28 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_checkout_with_entity_name(self):
-        entity = 'dataset'
+        entity = DATASETS
         init_repository(entity, self)
         self._create_new_tag(entity, 'new')
         self._clear_workspace(entity)
-        self.assertIn(output_messages['INFO_CHECKOUT_LATEST_TAG'] % 'computer-vision__images__dataset-ex__2',
-                      check_output(MLGIT_CHECKOUT % ('dataset', 'dataset-ex')))
-        file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'newfile0')
+        self.assertIn(output_messages['INFO_CHECKOUT_LATEST_TAG'] % 'computer-vision__images__datasets-ex__2',
+                      check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_NAME)))
+        file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile0')
         self.check_metadata()
-        self.check_amount_of_files('dataset', 6)
+        self.check_amount_of_files(DATASETS, 6)
         self.assertTrue(os.path.exists(file))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_checkout_with_wrong_entity_name(self):
-        self.set_up_checkout('dataset')
+        self.set_up_checkout(DATASETS)
         self.assertIn(output_messages['ERROR_WITHOUT_TAG_FOR_THIS_ENTITY'],
-                      check_output(MLGIT_CHECKOUT % ('dataset', 'dataset-wrong')))
-        file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'newfile0')
+                      check_output(MLGIT_CHECKOUT % (DATASETS, 'dataset-wrong')))
+        file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile0')
         self.assertFalse(os.path.exists(file))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_checkout_with_two_entities_wit_same_name(self):
-        entity = 'dataset'
+        entity = DATASETS
         self._create_entity(entity, 'images')
         clear(os.path.join(self.tmp_dir, '.ml-git'))
         self._create_entity(entity, 'video')
@@ -98,30 +98,30 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
             os.path.join(self.tmp_dir, GIT_PATH), os.path.join(self.tmp_dir, ML_GIT_DIR, entity, 'metadata')),
                       check_output(MLGIT_ENTITY_INIT % entity))
         self.assertIn(output_messages['ERROR_MULTIPLES_ENTITIES_WITH_SAME_NAME'] +
-                      '\tcomputer-vision__images__dataset-ex__2\n\tcomputer-vision__video__dataset-ex__2',
-                      check_output(MLGIT_CHECKOUT % ('dataset', 'dataset-ex')))
+                      '\tcomputer-vision__images__datasets-ex__2\n\tcomputer-vision__video__datasets-ex__2',
+                      check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_NAME)))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_checkout_with_version_number(self):
-        self.set_up_checkout('dataset')
-        self.assertIn(output_messages['INFO_CHECKOUT_TAG'] % 'computer-vision__images__dataset-ex__1',
-                      check_output(MLGIT_CHECKOUT % ('dataset', 'dataset-ex --version=1')))
-        file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'newfile0')
+        self.set_up_checkout(DATASETS)
+        self.assertIn(output_messages['INFO_CHECKOUT_TAG'] % 'computer-vision__images__datasets-ex__1',
+                      check_output(MLGIT_CHECKOUT % (DATASETS, 'datasets-ex --version=1')))
+        file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile0')
         self.check_metadata()
-        self.check_amount_of_files('dataset', 6)
+        self.check_amount_of_files(DATASETS, 6)
         self.assertTrue(os.path.exists(file))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_checkout_with_wrong_version_number(self):
-        self.set_up_checkout('dataset')
-        self.assertIn(output_messages['ERROR_WRONG_VERSION_NUMBER_TO_CHECKOUT'] % ('computer-vision__images__dataset-ex__1'),
-                      check_output(MLGIT_CHECKOUT % ('dataset', 'dataset-ex --version=10')))
-        file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'newfile0')
+        self.set_up_checkout(DATASETS)
+        self.assertIn(output_messages['ERROR_WRONG_VERSION_NUMBER_TO_CHECKOUT'] % ('computer-vision__images__datasets-ex__1'),
+                      check_output(MLGIT_CHECKOUT % (DATASETS, 'datasets-ex --version=10')))
+        file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile0')
         self.assertFalse(os.path.exists(file))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_06_checkout_with_two_entities_wit_same_name_and_version(self):
-        entity = 'dataset'
+        entity = DATASETS
         self._create_entity(entity, 'images')
         clear(os.path.join(self.tmp_dir, '.ml-git'))
         self._create_entity(entity, 'video')
@@ -129,12 +129,12 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
             os.path.join(self.tmp_dir, GIT_PATH), os.path.join(self.tmp_dir, ML_GIT_DIR, entity, 'metadata')),
                       check_output(MLGIT_ENTITY_INIT % entity))
         self.assertIn(output_messages['ERROR_MULTIPLES_ENTITIES_WITH_SAME_NAME'] +
-                      '\tcomputer-vision__images__dataset-ex__2\n\tcomputer-vision__video__dataset-ex__2',
-                      check_output(MLGIT_CHECKOUT % ('dataset', 'dataset-ex --version=2')))
+                      '\tcomputer-vision__images__datasets-ex__2\n\tcomputer-vision__video__datasets-ex__2',
+                      check_output(MLGIT_CHECKOUT % (DATASETS, 'datasets-ex --version=2')))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_07_checkout_without_clear_workspace(self):
-        entity = 'dataset'
+        entity = DATASETS
         init_repository(entity, self)
         self._create_new_tag(entity, 'new')
         with open(os.path.join(self.tmp_dir, entity, entity+'-ex', 'newfile-tag2'), 'wt') as z:
@@ -142,8 +142,8 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % (entity, entity + '-ex', '--bumpversion')))
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (entity, entity + '-ex', '')))
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_PUSH % (entity, entity + '-ex')))
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (entity, 'computer-vision__images__dataset-ex__2')))
-        file = os.path.join(self.tmp_dir, entity, 'computer-vision', 'images', 'dataset-ex', 'newfile0')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (entity, 'computer-vision__images__datasets-ex__2')))
+        file = os.path.join(self.tmp_dir, entity, 'computer-vision', 'images', DATASET_NAME, 'newfile0')
         self.check_metadata()
         self.check_amount_of_files(entity, 6)
         self.assertTrue(os.path.exists(file))

--- a/tests/integration/test_33_checkout_entity.py
+++ b/tests/integration/test_33_checkout_entity.py
@@ -12,7 +12,7 @@ import pytest
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_CHECKOUT, MLGIT_PUSH, MLGIT_COMMIT, MLGIT_ADD
 from tests.integration.helper import ML_GIT_DIR, MLGIT_ENTITY_INIT, ERROR_MESSAGE, \
-    add_file, GIT_PATH, check_output, clear, init_repository, DATASETS, DATASET_NAME
+    add_file, GIT_PATH, check_output, clear, init_repository, DATASETS, DATASET_NAME, DATASET_TAG
 
 
 @pytest.mark.usefixtures('tmp_dir', 'aws_session')
@@ -104,7 +104,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_checkout_with_version_number(self):
         self.set_up_checkout(DATASETS)
-        self.assertIn(output_messages['INFO_CHECKOUT_TAG'] % 'computer-vision__images__datasets-ex__1',
+        self.assertIn(output_messages['INFO_CHECKOUT_TAG'] % DATASET_TAG,
                       check_output(MLGIT_CHECKOUT % (DATASETS, 'datasets-ex --version=1')))
         file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile0')
         self.check_metadata()
@@ -114,7 +114,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_checkout_with_wrong_version_number(self):
         self.set_up_checkout(DATASETS)
-        self.assertIn(output_messages['ERROR_WRONG_VERSION_NUMBER_TO_CHECKOUT'] % ('computer-vision__images__datasets-ex__1'),
+        self.assertIn(output_messages['ERROR_WRONG_VERSION_NUMBER_TO_CHECKOUT'] % (DATASET_TAG),
                       check_output(MLGIT_CHECKOUT % (DATASETS, 'datasets-ex --version=10')))
         file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'newfile0')
         self.assertFalse(os.path.exists(file))

--- a/tests/integration/test_33_config.py
+++ b/tests/integration/test_33_config.py
@@ -16,9 +16,9 @@ from tests.integration.output_messages import messages
 class ConfigAcceptanceTests(unittest.TestCase):
     threads_per_core = 5
     push_threads_count = os.cpu_count() * threads_per_core
-    expected_result = "config:\n{'batch_size': 20,\n 'cache_path': '',\n 'dataset': {'git': ''}," \
+    expected_result = "config:\n{'batch_size': 20,\n 'cache_path': '',\n 'datasets': {'git': ''}," \
                       "\n 'index_path': '',\n 'labels': {'git': ''},\n 'metadata_path': '',\n 'mlgit_conf': 'config.yaml'," \
-                      "\n 'mlgit_path': '.ml-git',\n 'model': {'git': ''},\n 'object_path': ''," \
+                      "\n 'mlgit_path': '.ml-git',\n 'models': {'git': ''},\n 'object_path': ''," \
                       "\n 'push_threads_count': "+str(push_threads_count)+",\n 'refs_path': ''," \
                       "\n 'store': {'s3': {'mlgit-datasets': {'aws-credentials': {'profile': 'default'}," \
                       "\n                                     'region': 'us-east-1'}}},\n 'verbose': 'info'}"

--- a/tests/integration/test_34_remote_del.py
+++ b/tests/integration/test_34_remote_del.py
@@ -12,7 +12,8 @@ from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_PUSH, MLGIT_COMMIT, MLGIT_INIT, MLGIT_REMOTE_ADD, \
     MLGIT_REMOTE_DEL, MLGIT_UPDATE
 from tests.integration.helper import ML_GIT_DIR, MLGIT_ENTITY_INIT, ERROR_MESSAGE, \
-    add_file, GIT_PATH, check_output, clear, init_repository, yaml_processor, MINIO_BUCKET_PATH
+    add_file, GIT_PATH, check_output, clear, init_repository, yaml_processor, MINIO_BUCKET_PATH, DATASETS, MODELS, \
+    LABELS
 from tests.integration.output_messages import messages
 
 
@@ -75,28 +76,28 @@ class RemoteDelAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_01_remote_del_for_dataset(self):
-        entity = 'dataset'
+        entity = DATASETS
         self._add_remote(entity)
         self._remote_del(entity)
         self._remote_del_without_remote(entity)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_03_remote_del_for_model(self):
-        entity = 'model'
+        entity = MODELS
         self._add_remote(entity)
         self._remote_del(entity)
         self._remote_del_without_remote(entity)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_04_remote_del_for_labels(self):
-        entity = 'labels'
+        entity = LABELS
         self._add_remote(entity)
         self._remote_del(entity)
         self._remote_del_without_remote(entity)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_update_dataset_after_remote_del(self):
-        entity = 'dataset'
+        entity = DATASETS
         self._setup_update_entity(entity)
         self._check_update_entity(entity)
         self._remote_del(entity)
@@ -105,7 +106,7 @@ class RemoteDelAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_06_update_model_after_remote_del(self):
-        entity = 'model'
+        entity = MODELS
         self._setup_update_entity(entity)
         self._check_update_entity(entity)
         self._remote_del(entity)
@@ -114,7 +115,7 @@ class RemoteDelAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_07_update_labels_after_remote_del(self):
-        entity = 'labels'
+        entity = LABELS
         self._setup_update_entity(entity)
         self._check_update_entity(entity)
         self._remote_del(entity)
@@ -124,7 +125,7 @@ class RemoteDelAcceptanceTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_08_push_after_remote_del(self):
         clear(os.path.join(MINIO_BUCKET_PATH, 'zdj7WWjGAAJ8gdky5FKcVLfd63aiRUGb8fkc8We2bvsp9WW12'))
-        entity_type = 'dataset'
+        entity_type = DATASETS
         init_repository(entity_type, self)
         add_file(self, entity_type, '--bumpversion', 'new', file_content='0')
         metadata_path = os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'metadata')

--- a/tests/integration/test_35_status_short_mode.py
+++ b/tests/integration/test_35_status_short_mode.py
@@ -10,7 +10,7 @@ import pytest
 
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_PUSH, MLGIT_ENTITY_INIT, MLGIT_STATUS_SHORT, MLGIT_ADD, \
     MLGIT_CHECKOUT
-from tests.integration.helper import ML_GIT_DIR, GIT_PATH, ERROR_MESSAGE
+from tests.integration.helper import ML_GIT_DIR, GIT_PATH, ERROR_MESSAGE, DATASETS, DATASET_NAME
 from tests.integration.helper import check_output, clear, init_repository, create_file
 from tests.integration.output_messages import messages
 
@@ -24,12 +24,12 @@ class StatusShortModeAcceptanceTests(unittest.TestCase):
     def set_up_checkout(self, entity):
         metadata_path = os.path.join(self.tmp_dir, ML_GIT_DIR, entity, 'metadata')
         workspace = os.path.join(self.tmp_dir, entity)
-        self.set_up_status('dataset')
-        data_path = os.path.join(workspace, 'dataset-ex', 'data')
+        self.set_up_status(DATASETS)
+        data_path = os.path.join(workspace, DATASET_NAME, 'data')
         os.makedirs(data_path, exist_ok=True)
         create_file(data_path, 'file', '0', '')
         create_file(data_path, 'file2', '0', '')
-        self.assertIn(messages[13] % 'dataset', check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '')))
+        self.assertIn(messages[13] % DATASETS, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '')))
         self.assertIn(messages[17] % (metadata_path, os.path.join('computer-vision', 'images', entity + '-ex')),
                       check_output(MLGIT_COMMIT % (entity, entity + '-ex', '')))
         HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, entity, 'refs', entity + '-ex', 'HEAD')
@@ -43,67 +43,67 @@ class StatusShortModeAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_status_after_put_on_new_file_in_dataset(self):
-        self.set_up_status('dataset')
-        data_path = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'data')
+        self.set_up_status(DATASETS)
+        data_path = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, 'data')
         os.makedirs(data_path, exist_ok=True)
         create_file(data_path, 'file', '0', '')
-        self.assertRegex(check_output(MLGIT_STATUS_SHORT % ('dataset', 'dataset-ex')),
+        self.assertRegex(check_output(MLGIT_STATUS_SHORT % (DATASETS, DATASET_NAME)),
                          r'Changes to be committed:\s+Untracked files:(\s|.)*data/file(\s|.)*')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_status_after_put_more_than_one_file_in_dataset(self):
-        self.set_up_status('dataset')
-        data_path = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'data')
+        self.set_up_status(DATASETS)
+        data_path = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, 'data')
         os.makedirs(data_path, exist_ok=True)
         create_file(data_path, 'file', '0', '')
         create_file(data_path, 'file2', '0', '')
-        self.assertRegex(check_output(MLGIT_STATUS_SHORT % ('dataset', 'dataset-ex')),
+        self.assertRegex(check_output(MLGIT_STATUS_SHORT % (DATASETS, DATASET_NAME)),
                          r'Changes to be committed:\s+Untracked files:(\s|.)*data/\t->\t2 FILES(\s|.)*')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_status_after_add_command_in_dataset(self):
-        self.set_up_status('dataset')
-        data_path = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'data')
+        self.set_up_status(DATASETS)
+        data_path = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, 'data')
         os.makedirs(data_path, exist_ok=True)
         create_file(data_path, 'file0', '0', '')
-        self.assertIn(messages[13] % 'dataset', check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion')))
-        self.assertRegex(check_output(MLGIT_STATUS_SHORT % ('dataset', 'dataset-ex')),
+        self.assertIn(messages[13] % DATASETS, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion')))
+        self.assertRegex(check_output(MLGIT_STATUS_SHORT % (DATASETS, DATASET_NAME)),
                          r'Changes to be committed:(\s|.)*New file: data/file0(\s|.)*'
                          r'Untracked files:\n\nCorrupted files:')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_status_after_commit_command_in_dataset(self):
-        self.set_up_status('dataset')
-        data_path = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'data')
+        self.set_up_status(DATASETS)
+        data_path = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, 'data')
         os.makedirs(data_path, exist_ok=True)
         create_file(data_path, 'file0', '0', '')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion')))
         create_file(data_path, 'file2', '0', '')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion')))
 
-        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, 'dataset', 'metadata'),
-                                      os.path.join('computer-vision', 'images', 'dataset-ex')),
-                      check_output(MLGIT_COMMIT % ('dataset', 'dataset-ex', '')))
-        self.assertRegex(check_output(MLGIT_STATUS_SHORT % ('dataset', 'dataset-ex')),
+        self.assertIn(messages[17] % (os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'metadata'),
+                                      os.path.join('computer-vision', 'images', DATASET_NAME)),
+                      check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '')))
+        self.assertRegex(check_output(MLGIT_STATUS_SHORT % (DATASETS, DATASET_NAME)),
                          r'Changes to be committed:\s+Untracked files:')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_status_after_checkout_in_dataset(self):
-        self.set_up_checkout('dataset')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % ('dataset',
-                                                                       'computer-vision__images__dataset-ex__1')))
-        self.assertRegex(check_output(MLGIT_STATUS_SHORT % ('dataset', 'dataset-ex')),
+        self.set_up_checkout(DATASETS)
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS,
+                                                                       'computer-vision__images__datasets-ex__1')))
+        self.assertRegex(check_output(MLGIT_STATUS_SHORT % (DATASETS, DATASET_NAME)),
                          r'Changes to be committed:\s+Untracked files')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_06_status_after_delete_file(self):
-        self.set_up_checkout('dataset')
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % ('dataset',
-                                                                       'computer-vision__images__dataset-ex__1')))
-        data_path = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'data')
+        self.set_up_checkout(DATASETS)
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS,
+                                                                       'computer-vision__images__datasets-ex__1')))
+        data_path = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'data')
         file_to_be_deleted = os.path.join(data_path, 'file')
         file_to_be_deleted2 = os.path.join(data_path, 'file2')
         clear(file_to_be_deleted)
         clear(file_to_be_deleted2)
-        self.assertRegex(check_output(MLGIT_STATUS_SHORT % ('dataset', 'dataset-ex')),
+        self.assertRegex(check_output(MLGIT_STATUS_SHORT % (DATASETS, DATASET_NAME)),
                          r'Changes to be committed:\s+Deleted: (\s|.)*data/\t->\t2 FILES(\s|.)*')

--- a/tests/integration/test_35_status_short_mode.py
+++ b/tests/integration/test_35_status_short_mode.py
@@ -10,7 +10,7 @@ import pytest
 
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_PUSH, MLGIT_ENTITY_INIT, MLGIT_STATUS_SHORT, MLGIT_ADD, \
     MLGIT_CHECKOUT
-from tests.integration.helper import ML_GIT_DIR, GIT_PATH, ERROR_MESSAGE, DATASETS, DATASET_NAME
+from tests.integration.helper import ML_GIT_DIR, GIT_PATH, ERROR_MESSAGE, DATASETS, DATASET_NAME, DATASET_TAG
 from tests.integration.helper import check_output, clear, init_repository, create_file
 from tests.integration.output_messages import messages
 
@@ -90,16 +90,14 @@ class StatusShortModeAcceptanceTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_status_after_checkout_in_dataset(self):
         self.set_up_checkout(DATASETS)
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS,
-                                                                       'computer-vision__images__datasets-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)))
         self.assertRegex(check_output(MLGIT_STATUS_SHORT % (DATASETS, DATASET_NAME)),
                          r'Changes to be committed:\s+Untracked files')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_06_status_after_delete_file(self):
         self.set_up_checkout(DATASETS)
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS,
-                                                                       'computer-vision__images__datasets-ex__1')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_TAG)))
         data_path = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'data')
         file_to_be_deleted = os.path.join(data_path, 'file')
         file_to_be_deleted2 = os.path.join(data_path, 'file2')

--- a/tests/integration/test_36_gc.py
+++ b/tests/integration/test_36_gc.py
@@ -12,7 +12,8 @@ import pytest
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_PUSH, MLGIT_REPOSITORY_GC, MLGIT_CHECKOUT, MLGIT_ADD, \
     MLGIT_INIT, MLGIT_ENTITY_INIT
-from tests.integration.helper import init_repository, add_file, check_output, ERROR_MESSAGE, clear, ML_GIT_DIR
+from tests.integration.helper import init_repository, add_file, check_output, ERROR_MESSAGE, clear, ML_GIT_DIR, \
+    DATASETS, LABELS, MODELS, DATASET_NAME
 
 
 @pytest.mark.usefixtures('tmp_dir', 'aws_session')
@@ -52,7 +53,7 @@ class GcAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_gc_dataset_entity(self):
-        entity = 'dataset'
+        entity = DATASETS
         self.set_up_gc(entity)
         original_size, number_of_files = self._get_metadata_info()
         result = check_output(MLGIT_REPOSITORY_GC)
@@ -61,7 +62,7 @@ class GcAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_gc_labels_entity(self):
-        entity = 'labels'
+        entity = LABELS
         self.set_up_gc(entity)
         original_size, number_of_files = self._get_metadata_info()
         result = check_output(MLGIT_REPOSITORY_GC)
@@ -70,7 +71,7 @@ class GcAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_gc_model_entity(self):
-        entity = 'model'
+        entity = MODELS
         self.set_up_gc(entity)
         original_size, number_of_files = self._get_metadata_info()
         result = check_output(MLGIT_REPOSITORY_GC)
@@ -79,25 +80,25 @@ class GcAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_gc_repository(self):
-        self.set_up_gc('dataset')
-        self.set_up_gc('model')
-        self.set_up_gc('labels')
+        self.set_up_gc(DATASETS)
+        self.set_up_gc(MODELS)
+        self.set_up_gc(LABELS)
         original_size, number_of_files = self._get_metadata_info()
         result = check_output(MLGIT_REPOSITORY_GC)
-        self.assertIn(output_messages['INFO_STARTING_GC'] % 'labels', result)
-        self.assertIn(output_messages['INFO_STARTING_GC'] % 'model', result)
-        self._check_result(result, 'dataset', original_size, number_of_files,
+        self.assertIn(output_messages['INFO_STARTING_GC'] % LABELS, result)
+        self.assertIn(output_messages['INFO_STARTING_GC'] % MODELS, result)
+        self._check_result(result, DATASETS, original_size, number_of_files,
                            expected_removed_files=9, expected_reclaimed_space='6.4 kB')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_gc_deleted_entity(self):
-        self.set_up_gc('dataset')
-        self.set_up_gc('labels')
+        self.set_up_gc(DATASETS)
+        self.set_up_gc(LABELS)
         original_size, number_of_files = self._get_metadata_info()
-        clear(os.path.join(self.tmp_dir, 'labels'))
+        clear(os.path.join(self.tmp_dir, LABELS))
         result = check_output(MLGIT_REPOSITORY_GC)
-        self.assertIn(output_messages['INFO_STARTING_GC'] % 'labels', result)
-        self._check_result(result, 'dataset', original_size, number_of_files,
+        self.assertIn(output_messages['INFO_STARTING_GC'] % LABELS, result)
+        self._check_result(result, DATASETS, original_size, number_of_files,
                            expected_removed_files=21, expected_reclaimed_space='33.7 kB')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
@@ -107,13 +108,13 @@ class GcAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_07_gc_basic_flow(self):
-        entity = 'dataset'
+        entity = DATASETS
         self.set_up_gc(entity)
         original_size, number_of_files = self._get_metadata_info()
         result = check_output(MLGIT_REPOSITORY_GC)
         self._check_result(result, entity, original_size, number_of_files,
                            expected_removed_files=3, expected_reclaimed_space='2.1 kB')
-        file = os.path.join(self.tmp_dir, 'dataset', 'computer-vision', 'images', 'dataset-ex', 'file-after-gc')
+        file = os.path.join(self.tmp_dir, DATASETS, 'computer-vision', 'images', DATASET_NAME, 'file-after-gc')
         with open(file, 'wb') as z:
             z.write(b'1' * 1024)
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % (entity, entity + '-ex', '')))

--- a/tests/integration/test_36_status_path_directory.py
+++ b/tests/integration/test_36_status_path_directory.py
@@ -8,9 +8,9 @@ import unittest
 
 import pytest
 
-from tests.integration.commands import MLGIT_STATUS_DIRECTORY, MLGIT_ADD
-from tests.integration.helper import check_output, init_repository, create_file
 from ml_git.ml_git_message import output_messages
+from tests.integration.commands import MLGIT_STATUS_DIRECTORY, MLGIT_ADD
+from tests.integration.helper import check_output, init_repository, create_file, DATASET_NAME, DATASETS
 
 
 @pytest.mark.usefixtures('tmp_dir')
@@ -21,51 +21,51 @@ class StatusPathDirectoryAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_status_after_put_on_new_file_in_dataset_without_directory(self):
-        self.set_up_status('dataset')
-        data_path = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', '')
+        self.set_up_status(DATASETS)
+        data_path = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, '')
         os.makedirs(data_path, exist_ok=True)
         create_file(data_path, 'file1', '0', '')
 
-        self.assertRegex(check_output(MLGIT_STATUS_DIRECTORY % ('dataset', 'dataset-ex', '')),
+        self.assertRegex(check_output(MLGIT_STATUS_DIRECTORY % (DATASETS, DATASET_NAME, '')),
                          r'Changes to be committed:\s+Untracked files:(\s|.)*file1(\s|.)*')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_status_after_put_on_new_file_in_dataset_with_directory(self):
-        self.set_up_status('dataset')
-        data_path = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'data')
+        self.set_up_status(DATASETS)
+        data_path = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, 'data')
         os.makedirs(data_path, exist_ok=True)
         create_file(data_path, 'file2', '0', '')
-        self.assertRegex(check_output(MLGIT_STATUS_DIRECTORY % ('dataset', 'dataset-ex', 'data')),
+        self.assertRegex(check_output(MLGIT_STATUS_DIRECTORY % (DATASETS, DATASET_NAME, 'data')),
                          r'Changes to be committed:\s+Untracked files:(\s|.)*file2(\s|.)*')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_status_after_put_more_than_one_file_in_dataset_with_directory(self):
-        self.set_up_status('dataset')
-        data_path = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'data')
+        self.set_up_status(DATASETS)
+        data_path = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, 'data')
         os.makedirs(data_path, exist_ok=True)
         create_file(data_path, 'file3', '0', '')
         create_file(data_path, 'file4', '0', '')
-        self.assertRegex(check_output(MLGIT_STATUS_DIRECTORY % ('dataset', 'dataset-ex', 'data')),
+        self.assertRegex(check_output(MLGIT_STATUS_DIRECTORY % (DATASETS, DATASET_NAME, 'data')),
                          r'Changes to be committed:\s+Untracked files:(\s|.)*data/\t->\t2 FILES(\s|.)*')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_status_after_put_more_than_one_file_in_dataset_with_invalid_directory(self):
-        self.set_up_status('dataset')
-        data_path = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'data')
+        self.set_up_status(DATASETS)
+        data_path = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, 'data')
         os.makedirs(data_path, exist_ok=True)
         create_file(data_path, 'file5', '0', '')
         create_file(data_path, 'file6', '0', '')
-        self.assertIn(output_messages['ERROR_INVALID_STATUS_DIRECTORY'], check_output(MLGIT_STATUS_DIRECTORY % ('dataset', 'dataset-ex', 'invalid')))
+        self.assertIn(output_messages['ERROR_INVALID_STATUS_DIRECTORY'], check_output(MLGIT_STATUS_DIRECTORY % (DATASETS, DATASET_NAME, 'invalid')))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_status_after_put_on_new_file_in_dataset_with_directory_and_add_command(self):
-        self.set_up_status('dataset')
-        data_path = os.path.join(self.tmp_dir, 'dataset', 'dataset-ex', 'data')
+        self.set_up_status(DATASETS)
+        data_path = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, 'data')
         os.makedirs(data_path, exist_ok=True)
         create_file(data_path, 'file7', '0', '')
 
-        check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion'))
+        check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion'))
 
-        self.assertRegex(check_output(MLGIT_STATUS_DIRECTORY % ('dataset', 'dataset-ex', 'data')),
+        self.assertRegex(check_output(MLGIT_STATUS_DIRECTORY % (DATASETS, DATASET_NAME, 'data')),
                          r'Changes to be committed:(\s|.)*New file: data(/|\\)file7(\s|.)*'
                          r'Untracked files:\n\nCorrupted files:')


### PR DESCRIPTION
Depends on PR #69 .

Updating integration tests to use plural entity names and adding new tests for the project update scenario.