### PR TITLE
Fixing create command when used with entity_dir and wizard-config options

### DIFF
--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -997,7 +997,7 @@ class Repository(object):
                 has_new_store, store_type, bucket, profile, endpoint_url, git_repo = start_wizard_questions(repo_type)
                 if has_new_store:
                     store_add(store_type, bucket, profile, endpoint_url)
-                update_store_spec(repo_type, artifact_name, store_type, bucket)
+                update_store_spec(repo_type, artifact_name, store_type, bucket, kwargs['entity_dir'])
                 remote_add(repo_type, git_repo)
             if import_url:
                 self.create_config_store('gdrive', credentials_path)

--- a/ml_git/spec.py
+++ b/ml_git/spec.py
@@ -135,14 +135,13 @@ def get_entity_tag(specpath, repotype, entity):
     return entity_tag
 
 
-def update_store_spec(repotype, artefact_name, store_type, bucket):
+def update_store_spec(repotype, artifact_name, store_type, bucket, entity_dir=''):
     path = None
     try:
         path = get_root_path()
     except Exception as e:
         log.error(e, CLASS_NAME=ML_GIT_PROJECT_NAME)
-
-    spec_path = os.path.join(path, repotype, artefact_name, artefact_name + SPEC_EXTENSION)
+    spec_path = os.path.join(path, repotype, entity_dir, artifact_name, artifact_name + SPEC_EXTENSION)
     spec_hash = utils.yaml_load(spec_path)
     spec_hash[repotype]['manifest']['store'] = store_type + '://' + bucket
     utils.yaml_save(spec_hash, spec_path)

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -9,10 +9,11 @@ import unittest
 import pytest
 import os
 
+from ml_git.constants import EntityType, StoreType, SPEC_EXTENSION
 from ml_git.spec import yaml_load, incr_version, is_valid_version, search_spec_file, SearchSpecException, spec_parse, \
     get_spec_file_dir, increment_version_in_spec, get_root_path, get_version, update_store_spec, validate_bucket_name, \
     set_version_in_spec, get_entity_dir
-from ml_git.utils import yaml_save
+from ml_git.utils import yaml_save, ensure_path_exists
 
 testdir = 'specdata'
 
@@ -154,3 +155,21 @@ class SpecTestCases(unittest.TestCase):
         set_version_in_spec(3, tmpfile, 'dataset')
         spec_hash = yaml_load(tmpfile)
         self.assertEqual(spec_hash['dataset']['version'], 3)
+
+    def test_update_store_spec_with_entity_dir(self):
+        entity_name = 'dataex'
+        entity_type = EntityType.DATASET.value
+        dataset_without_dir_path = os.path.join(os.getcwd(), os.sep.join([entity_type, entity_name]))
+        dataset_path = os.path.join(os.getcwd(), os.sep.join([entity_type, 'folderA', 'folderB']))
+        ensure_path_exists(dataset_path)
+        shutil.move(dataset_without_dir_path, dataset_path)
+        spec_path = os.path.join(dataset_path, entity_name, entity_name + SPEC_EXTENSION)
+        entity_dir = os.sep.join(['folderA', 'folderB'])
+
+        update_store_spec(entity_type, entity_name, StoreType.S3H.value, 'fakestore', entity_dir)
+        spec = yaml_load(spec_path)
+        self.assertEqual(spec[entity_type]['manifest']['store'], 's3h://fakestore')
+
+        update_store_spec(entity_type, entity_name, StoreType.S3H.value, 'some-bucket-name', entity_dir)
+        spec = yaml_load(spec_path)
+        self.assertEqual(spec[entity_type]['manifest']['store'], 's3h://some-bucket-name')


### PR DESCRIPTION
Fixing an error that occurs when the user tries to use the create command with the `entity-dir` and `wizard-config` options together.

Observed behavior:
```
$ ml-git dataset create dataset-ex --mutability=strict --category=images --entity-dir=folderA/folderB --wizard-config
_ Current configured stores _

1 - s3 - mlgit-datasets
X = New Data Store

_Which store do you want to use (a number or new data store)? _ 1
ERROR - MLGit: 'dataset'
```

Fixed behavior:
```
$ ml-git dataset create dataset-ex --mutability=strict --category=images --entity-dir=folderA/folderB --wizard-config
_ Current configured stores _

1 - s3 - mlgit-datasets
X = New Data Store

_Which store do you want to use (a number or new data store)? _ 1
INFO - MLGit: Project Created.
```

