### PR TITLE
Fixing tests that fail when run in a Windows environment

### DIFF
--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -20,7 +20,7 @@ from ml_git.manifest import Manifest
 from ml_git.ml_git_message import output_messages
 from ml_git.spec import get_entity_dir
 from ml_git.utils import get_root_path, ensure_path_exists, yaml_load, RootPathException, get_yaml_str, yaml_load_str, \
-    clear
+    clear, posix_path
 
 
 class MetadataRepo(object):
@@ -348,14 +348,14 @@ class MetadataRepo(object):
     def __sort_tag_by_date(elem):
         return elem.commit.authored_date
 
-    def _get_spec_content(self, spec, tag, sha):
+    def _get_spec_content(self, spec, sha):
         entity_dir = get_entity_dir(self.__repo_type, spec, root_path=self.__path)
-        spec_path = '/'.join([entity_dir, spec + SPEC_EXTENSION])
+        spec_path = '/'.join([posix_path(entity_dir), spec + SPEC_EXTENSION])
 
         return yaml_load_str(self._get_spec_content_from_ref(sha, spec_path))
 
     def _get_metrics(self, spec, tag, sha):
-        spec_file = self._get_spec_content(spec, tag, sha)
+        spec_file = self._get_spec_content(spec, sha)
         metrics = spec_file[self.__repo_type].get(PERFORMANCE_KEY, {})
         metrics_table = PrettyTable()
         if not metrics:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -106,7 +106,7 @@ def start_local_git_server_with_main_branch(tmp_path):
 def create_csv_file(request):
 
     def _create_csv_file(_, path, table):
-        with open(path, 'w') as file:
+        with open(path, 'w', newline='') as file:
             writer = csv.writer(file)
             row_list = list()
             row_list.append(table.keys())

--- a/tests/integration/test_05_add_files.py
+++ b/tests/integration/test_05_add_files.py
@@ -161,7 +161,7 @@ class AddFilesAcceptanceTests(unittest.TestCase):
 
         self.create_csv_file(csv_file, {'Accuracy': 1, 'Recall': 2})
 
-        metrics_options = '--metrics-file={}'.format(csv_file)
+        metrics_options = '--metrics-file="{}"'.format(csv_file)
 
         self.assertIn(messages[13] % repo_type, check_output(MLGIT_ADD % (repo_type, 'model-ex', metrics_options)))
         index = os.path.join(ML_GIT_DIR, repo_type, 'index', 'metadata', 'model-ex', 'INDEX.yaml')

--- a/tests/integration/test_07_push_files.py
+++ b/tests/integration/test_07_push_files.py
@@ -73,7 +73,7 @@ class PushFilesAcceptanceTests(unittest.TestCase):
         output = check_output(MLGIT_PUSH % ('dataset', 'dataset-ex'))
 
         self.assertIn(ERROR_MESSAGE, output)
-        self.assertIn(git_path, output)
+        self.assertIn(GIT_PATH, output)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_push_with_wrong_credentials_profile(self):

--- a/tests/integration/test_35_status_short_mode.py
+++ b/tests/integration/test_35_status_short_mode.py
@@ -48,7 +48,7 @@ class StatusShortModeAcceptanceTests(unittest.TestCase):
         os.makedirs(data_path, exist_ok=True)
         create_file(data_path, 'file', '0', '')
         self.assertRegex(check_output(MLGIT_STATUS_SHORT % ('dataset', 'dataset-ex')),
-                         r'Changes to be committed:\s+Untracked files:(\s|.)*data/file(\s|.)*')
+                         r'Changes to be committed:\s+Untracked files:(\s|.)*data(\\|/)file(\s|.)*')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_status_after_put_more_than_one_file_in_dataset(self):
@@ -68,7 +68,7 @@ class StatusShortModeAcceptanceTests(unittest.TestCase):
         create_file(data_path, 'file0', '0', '')
         self.assertIn(messages[13] % 'dataset', check_output(MLGIT_ADD % ('dataset', 'dataset-ex', '--bumpversion')))
         self.assertRegex(check_output(MLGIT_STATUS_SHORT % ('dataset', 'dataset-ex')),
-                         r'Changes to be committed:(\s|.)*New file: data/file0(\s|.)*'
+                         r'Changes to be committed:(\s|.)*New file: data(\\|/)file0(\s|.)*'
                          r'Untracked files:\n\nCorrupted files:')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -182,7 +182,7 @@ def change_branch_name(request):
 def create_csv_file(request):
 
     def _create_csv_file(_, path, table):
-        with open(path, 'w') as file:
+        with open(path, 'w', newline='') as file:
             writer = csv.writer(file)
             row_list = list()
             row_list.append(table.keys())

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -238,14 +238,14 @@ class MetadataTestCases(unittest.TestCase):
         m = Metadata(entity, self.test_dir, config, repo_type)
         m.init()
         ensure_path_exists(os.path.join(mdpath, specpath, entity))
-        spec_metadata_path = os.path.join(mdpath, specpath, entity) + '/model-ex.spec'
+        spec_metadata_path = os.path.join(mdpath, specpath, entity, 'model-ex.spec')
         shutil.copy('hdata/dataset-ex.spec', spec_metadata_path)
 
         spec_file = yaml_load(spec_metadata_path)
         spec_file[repo_type] = deepcopy(spec_file['dataset'])
         del spec_file['dataset']
         spec_file[repo_type]['metrics'] = {'metric_1': 0, 'metric_2': 1}
-        yaml_save(spec_file,  spec_metadata_path)
+        yaml_save(spec_file, spec_metadata_path)
 
         tag = 'vision-computer__images__model-ex__1'
         sha = m.commit(spec_metadata_path, specpath)


### PR DESCRIPTION
When run in a Windows environment, the tests show some errors related to file path and regex that become invalid.

**- Observed behavior:**

**Integration**
```
[gw0] [ 17%] FAILED tests/integration/test_07_push_files.py::PushFilesAcceptanceTests::test_04_push_with_wrong_repository
[gw4] [ 21%] FAILED tests/integration/test_05_add_files.py::AddFilesAcceptanceTests::test_10_add_command_with_metric_file
[gw2] [ 90%] FAILED tests/integration/test_35_status_short_mode.py::StatusShortModeAcceptanceTests::test_01_status_after_put_on_new_file_in_dataset
[gw2] [ 93%] FAILED tests/integration/test_35_status_short_mode.py::StatusShortModeAcceptanceTests::test_03_status_after_add_command_in_dataset

4 failed, 269 passed, 18 warnings in 1548.65s (0:25:48)
```

**Unit**
```
[gw0] [ 32%] FAILED tests/unit/test_local.py::LocalRepositoryTestCases::test_add_metrics_file
[gw2] [ 91%] FAILED tests/unit/test_metadata.py::MetadataTestCases::test_get_metrics
[gw2] [ 93%] FAILED tests/unit/test_metadata.py::MetadataTestCases::test_get_metrics_without_metrics

3 failed, 141 passed, 7 warnings in 52.98s
```




**- Fixed behavior:**

**Integration**
`273 passed, 18 warnings in 1548.65s (0:26:51)`

**Unit**
`144 passed, 7 warnings in 52.22s`