### PR TITLE
Changing keys in configuration files

### DIFF
--- a/docs/centralized_cache_and_objects.md
+++ b/docs/centralized_cache_and_objects.md
@@ -69,7 +69,7 @@ labels:
 models:
   git: ''
   cache_path: 'Path directory created on step 1 for model entity'
-storage:
+storages:
   s3:
     mlgit-datasets:
       aws-credentials:
@@ -133,7 +133,7 @@ labels:
 models:
   git: ''
   objects_path: 'Path directory created on step 1 for model entity'
-storage:
+storages:
   s3:
     mlgit-datasets:
       aws-credentials:

--- a/docs/first_project.md
+++ b/docs/first_project.md
@@ -120,7 +120,7 @@ config:
  'object_path': '',
  'push_threads_count': 10,
  'refs_path': '',
- 'storage': {'s3': {'mlgit-datasets': {'aws-credentials': {'profile': 'default'},
+ 'storages': {'s3': {'mlgit-datasets': {'aws-credentials': {'profile': 'default'},
                                      'region': 'us-east-1'}},
            's3h': {'mlgit-datasets': {'aws-credentials': {'profile': 'mlgit'},
                                       'endpoint-url': <minio-endpoint-url>,
@@ -149,7 +149,7 @@ $ ml-git datasets create imagenet8 --category=computer-vision --category=images 
 After that a file must have been created in dataset/folderA/folderB/imagenet8/imagenet8.spec and should look like this:
 
 ```
-datasets:
+dataset:
   categories:
     - computer-vision
     - images
@@ -172,7 +172,7 @@ The items listed above are mandatory in the spec. An important point to note her
 The example below presents a spec with the entity's owner information to be versioned. Those information were put under metadata field just for purpose of organization.
 
 ```
-datasets:
+dataset:
   categories:
     - computer-vision
     - images
@@ -337,7 +337,7 @@ config:
  'models': {'git': ''},
  'object_path': '',
  'refs_path': '',
- 'storage': {'s3': {'mlgit-datasets': {'aws-credentials': {'profile': 'default'},
+ 'storages': {'s3': {'mlgit-datasets': {'aws-credentials': {'profile': 'default'},
                                      'region': 'us-east-1'}},
            's3h': {'mlgit-datasets': {'aws-credentials': {'profile': 'default'},
                                       'endpoint-url': None,
@@ -464,7 +464,7 @@ Obs: The parameters used above were chosen for example purposes, you can name yo
 When inserting the metrics, they will be included in the structure of your model's spec file. An example of what it would look like would be the following structure:
 
 ```
-models:
+model:
   categories:
     - computer-vision
     - images

--- a/docs/gdrive_configurations.md
+++ b/docs/gdrive_configurations.md
@@ -99,7 +99,7 @@ labels:
   git: ''
 models:
   git: ''
-storage:
+storages:
   s3:
     mlgit-datasets:
       aws-credentials:

--- a/docs/mlgit_commands.md
+++ b/docs/mlgit_commands.md
@@ -787,8 +787,8 @@ Example:
 ```
 $ ml-git repository config
 config:
-{'dataset': {'git': 'git@github.com:example/your-mlgit-datasets'},
- 'storage': {'s3': {'mlgit-datasets': {'aws-credentials': {'profile': 'mlgit'},
+{'datasets': {'git': 'git@github.com:example/your-mlgit-datasets'},
+ 'storages': {'s3': {'mlgit-datasets': {'aws-credentials': {'profile': 'mlgit'},
                                      'region': 'us-east-1'}}},
  'verbose': 'info'}
 ```

--- a/docs/mlgit_internals.md
+++ b/docs/mlgit_internals.md
@@ -396,7 +396,7 @@ ml-git_project/
 Get content of \<ml-entity-name\>.spec (structure with representational values):
 
 ```
-datasets:
+dataset:
   categories:
     - computer-vision
     - images
@@ -410,7 +410,7 @@ datasets:
 And insert new attribute:
 
 ```
-datasets:
+dataset:
   categories:
   - computer-vision
   - images
@@ -628,7 +628,7 @@ Verify the git global configuration, and try upload **objects** from local repos
 .spec file:
 
 ```
-datasets:
+dataset:
   categories:
     - computer-vision
     - images
@@ -935,7 +935,7 @@ ml-git-project/
 ```
 datasets:
   git: git@github.com:standel/ml-datasets.git <-- git project url
-storage:
+storages:
   s3: <-- storage type (AWS)
     mlgit-datasets: <-- bucket name
       aws-credentials:
@@ -986,7 +986,7 @@ ml-git open existent file **.ml-git/config.yaml**:
 ```
 datasets:
   git: git@github.com:standel/ml-datasets.git <-- git project url
-storage:
+storages:
   s3: <-- storage type (AWS)
     mlgit-datasets: <-- bucket name
       aws-credentials:

--- a/docs/mutability_helper.md
+++ b/docs/mutability_helper.md
@@ -18,7 +18,7 @@ With the command ```ml-git (datasets|labels|models) create``` you must pass the 
 Your entity specification file (.spec) should look like this:
 
 ```
-datasets:
+dataset:
   categories:
     - computer-vision
     - images

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -134,7 +134,7 @@ For an entity of your preference, change the spec file like below:
 
 *(ex: dataset/dataset-ex/dataset-ex.spec)*
 ```yaml
-datasets:
+dataset:
   categories:
   - computer-vision
   - images

--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -79,11 +79,11 @@ class MetadataRepo(object):
             return False
         return True
 
-    def checkout(self, sha=None):
+    def checkout(self, sha=None, force=False):
         repo = Git(self.__path)
         if sha is None:
             sha = self.get_default_branch()
-        repo.checkout(sha)
+        repo.checkout(sha, force=force)
 
     def _get_symbolic_ref(self):
         repo = Repo(self.__path)

--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -358,7 +358,6 @@ class MetadataRepo(object):
 
     def _get_metrics(self, spec, sha):
         spec_file = self._get_spec_content(spec, sha)
-
         entity_spec_key = get_spec_key(self.__repo_type)
         metrics = spec_file[entity_spec_key].get(PERFORMANCE_KEY, {})
         metrics_table = PrettyTable()

--- a/ml_git/admin.py
+++ b/ml_git/admin.py
@@ -9,7 +9,7 @@ from git import Repo, GitCommandError
 
 from ml_git import log
 from ml_git.config import mlgit_config_save, get_global_config_path
-from ml_git.constants import ROOT_FILE_NAME, CONFIG_FILE, ADMIN_CLASS_NAME, StorageType, STORAGE_KEY
+from ml_git.constants import ROOT_FILE_NAME, CONFIG_FILE, ADMIN_CLASS_NAME, StorageType, STORAGE_CONFIG_KEY
 from ml_git.ml_git_message import output_messages
 from ml_git.storages.store_utils import get_bucket_region
 from ml_git.utils import get_root_path
@@ -110,23 +110,23 @@ def storage_add(storage_type, bucket, credentials_profile, global_conf=False, en
         log.error(e, class_name=ADMIN_CLASS_NAME)
         return
 
-    if STORAGE_KEY not in conf:
-        conf[STORAGE_KEY] = {}
-    if storage_type not in conf[STORAGE_KEY]:
-        conf[STORAGE_KEY][storage_type] = {}
-    conf[STORAGE_KEY][storage_type][bucket] = {}
+    if STORAGE_CONFIG_KEY not in conf:
+        conf[STORAGE_CONFIG_KEY] = {}
+    if storage_type not in conf[STORAGE_CONFIG_KEY]:
+        conf[STORAGE_CONFIG_KEY][storage_type] = {}
+    conf[STORAGE_CONFIG_KEY][storage_type][bucket] = {}
     if storage_type in [StorageType.S3.value, StorageType.S3H.value]:
-        conf[STORAGE_KEY][storage_type][bucket]['aws-credentials'] = {}
-        conf[STORAGE_KEY][storage_type][bucket]['aws-credentials']['profile'] = credentials_profile
-        conf[STORAGE_KEY][storage_type][bucket]['region'] = region
-        conf[STORAGE_KEY][storage_type][bucket]['endpoint-url'] = endpoint_url
+        conf[STORAGE_CONFIG_KEY][storage_type][bucket]['aws-credentials'] = {}
+        conf[STORAGE_CONFIG_KEY][storage_type][bucket]['aws-credentials']['profile'] = credentials_profile
+        conf[STORAGE_CONFIG_KEY][storage_type][bucket]['region'] = region
+        conf[STORAGE_CONFIG_KEY][storage_type][bucket]['endpoint-url'] = endpoint_url
     elif storage_type in [StorageType.GDRIVEH.value]:
-        conf[STORAGE_KEY][storage_type][bucket]['credentials-path'] = credentials_profile
+        conf[STORAGE_CONFIG_KEY][storage_type][bucket]['credentials-path'] = credentials_profile
     elif storage_type in [StorageType.SFTPH.value]:
-        conf[STORAGE_KEY][storage_type][bucket]['endpoint-url'] = endpoint_url
-        conf[STORAGE_KEY][storage_type][bucket]['username'] = sftp_configs['username']
-        conf[STORAGE_KEY][storage_type][bucket]['private-key'] = sftp_configs['private_key']
-        conf[STORAGE_KEY][storage_type][bucket]['port'] = sftp_configs['port']
+        conf[STORAGE_CONFIG_KEY][storage_type][bucket]['endpoint-url'] = endpoint_url
+        conf[STORAGE_CONFIG_KEY][storage_type][bucket]['username'] = sftp_configs['username']
+        conf[STORAGE_CONFIG_KEY][storage_type][bucket]['private-key'] = sftp_configs['private_key']
+        conf[STORAGE_CONFIG_KEY][storage_type][bucket]['port'] = sftp_configs['port']
     yaml_save(conf, file)
 
 
@@ -141,13 +141,13 @@ def storage_del(storage_type, bucket, global_conf=False):
         log.error(e, class_name=ADMIN_CLASS_NAME)
         return
 
-    storage_exists = STORAGE_KEY in conf and storage_type in conf[STORAGE_KEY] and bucket in conf[STORAGE_KEY][storage_type]
+    storage_exists = STORAGE_CONFIG_KEY in conf and storage_type in conf[STORAGE_CONFIG_KEY] and bucket in conf[STORAGE_CONFIG_KEY][storage_type]
 
     if not storage_exists:
         log.warn(output_messages['WARN_STORAGE_NOT_IN_CONFIG'] % (storage_type, bucket), class_name=ADMIN_CLASS_NAME)
         return
 
-    del conf[STORAGE_KEY][storage_type][bucket]
+    del conf[STORAGE_CONFIG_KEY][storage_type][bucket]
     log.info(output_messages['INFO_REMOVED_STORAGE'] % (storage_type, bucket), class_name=ADMIN_CLASS_NAME)
 
     yaml_save(conf, config_path)

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -263,7 +263,7 @@ def get_sample_spec_doc(bucket, repotype=DATASET_SPEC_KEY):
         manifest:
           files: MANIFEST.yaml
           storage: s3h://%s
-        name: %-ex
+        name: %s-ex
         version: 5
     ''' % (repotype, bucket, repotype)
     return doc

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -263,7 +263,7 @@ def get_sample_spec_doc(bucket, repotype=DATASET_SPEC_KEY):
         manifest:
           files: MANIFEST.yaml
           storage: s3h://%s
-        name: %s-ex
+        name: %-ex
         version: 5
     ''' % (repotype, bucket, repotype)
     return doc
@@ -321,9 +321,9 @@ def create_workspace_tree_structure(repo_type, artifact_name, categories, storag
     file_exists = os.path.isfile(spec_path)
 
     storage = '%s://%s' % (storage_type, FAKE_STORAGE if bucket_name is None else bucket_name)
-    spec_key = get_spec_key(repo_type)
+    entity_spec_key = get_spec_key(repo_type)
     spec_structure = {
-        spec_key: {
+        entity_spec_key: {
             'categories': categories,
             'manifest': {
                 STORAGE_SPEC_KEY: storage

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -11,8 +11,9 @@ from halo import Halo
 
 from ml_git import spec
 from ml_git.constants import FAKE_STORAGE, BATCH_SIZE_VALUE, BATCH_SIZE, StorageType, GLOBAL_ML_GIT_CONFIG, \
-    PUSH_THREADS_COUNT, SPEC_EXTENSION, EntityType, STORAGE_CONFIG_KEY, STORAGE_SPEC_KEY
+    PUSH_THREADS_COUNT, SPEC_EXTENSION, EntityType, STORAGE_CONFIG_KEY, STORAGE_SPEC_KEY, DATASET_SPEC_KEY
 from ml_git.ml_git_message import output_messages
+from ml_git.spec import get_spec_key
 from ml_git.utils import getOrElse, yaml_load, yaml_save, get_root_path, yaml_load_str
 
 push_threads = os.cpu_count()*5
@@ -252,7 +253,7 @@ def validate_bucket_config(the_bucket_hash, storage_type=StorageType.S3H.value):
     return True
 
 
-def get_sample_spec_doc(bucket, repotype=EntityType.DATASETS.value):
+def get_sample_spec_doc(bucket, repotype=DATASET_SPEC_KEY):
     doc = '''
       %s:
         categories:
@@ -268,34 +269,34 @@ def get_sample_spec_doc(bucket, repotype=EntityType.DATASETS.value):
     return doc
 
 
-def get_sample_spec(bucket, repotype=EntityType.DATASETS.value):
+def get_sample_spec(bucket, repotype=DATASET_SPEC_KEY):
     c = yaml_load_str(get_sample_spec_doc(bucket, repotype))
     return c
 
 
-def validate_spec_hash(the_hash, repotype=EntityType.DATASETS.value):
+def validate_spec_hash(the_hash, entity_key=DATASET_SPEC_KEY):
     if the_hash in [None, {}]:
         return False
 
-    if not spec.is_valid_version(the_hash, repotype):
+    if not spec.is_valid_version(the_hash, entity_key):
         return False  # Also checks for the existence of 'dataset'
 
-    if 'categories' not in the_hash[repotype] or 'manifest' not in the_hash[repotype]:
+    if 'categories' not in the_hash[entity_key] or 'manifest' not in the_hash[entity_key]:
         return False
 
-    if the_hash[repotype]['categories'] == {}:
+    if the_hash[entity_key]['categories'] == {}:
         return False
 
-    if STORAGE_SPEC_KEY not in the_hash[repotype]['manifest']:
+    if STORAGE_SPEC_KEY not in the_hash[entity_key]['manifest']:
         return False
 
-    if not validate_spec_string(the_hash[repotype]['manifest'][STORAGE_SPEC_KEY]):
+    if not validate_spec_string(the_hash[entity_key]['manifest'][STORAGE_SPEC_KEY]):
         return False
 
-    if 'name' not in the_hash[repotype]:
+    if 'name' not in the_hash[entity_key]:
         return False
 
-    if the_hash[repotype]['name'] == '':
+    if the_hash[entity_key]['name'] == '':
         return False
 
     return True
@@ -320,8 +321,9 @@ def create_workspace_tree_structure(repo_type, artifact_name, categories, storag
     file_exists = os.path.isfile(spec_path)
 
     storage = '%s://%s' % (storage_type, FAKE_STORAGE if bucket_name is None else bucket_name)
+    spec_key = get_spec_key(repo_type)
     spec_structure = {
-        repo_type: {
+        spec_key: {
             'categories': categories,
             'manifest': {
                 STORAGE_SPEC_KEY: storage

--- a/ml_git/constants.py
+++ b/ml_git/constants.py
@@ -54,7 +54,6 @@ MANIFEST_FILE = 'MANIFEST.yaml'
 INDEX_FILE = 'INDEX.yaml'
 DEFAULT_BRANCH_FOR_EMPTY_REPOSITORY = 'master'
 PERFORMANCE_KEY = 'metrics'
-STORAGE_KEY = 'storage'
 V1_STORAGE_KEY = 'store'
 V1_DATASETS_KEY = 'dataset'
 V1_MODELS_KEY = 'model'
@@ -63,6 +62,13 @@ STATUS_NEW_FILE = 'New file: '
 STATUS_DELETED_FILE = 'Deleted: '
 RELATED_DATASET_TABLE_INFO = 'Related dataset - (version)'
 RELATED_LABELS_TABLE_INFO = 'Related labels - (version)'
+
+DATASET_SPEC_KEY = 'dataset'
+LABELS_SPEC_KEY = 'labels'
+MODEL_SPEC_KEY = 'model'
+STORAGE_SPEC_KEY = 'storage'
+
+STORAGE_CONFIG_KEY = 'storages'
 
 
 class MutabilityType(Enum):

--- a/ml_git/constants.py
+++ b/ml_git/constants.py
@@ -62,12 +62,10 @@ STATUS_NEW_FILE = 'New file: '
 STATUS_DELETED_FILE = 'Deleted: '
 RELATED_DATASET_TABLE_INFO = 'Related dataset - (version)'
 RELATED_LABELS_TABLE_INFO = 'Related labels - (version)'
-
 DATASET_SPEC_KEY = 'dataset'
 LABELS_SPEC_KEY = 'labels'
 MODEL_SPEC_KEY = 'model'
 STORAGE_SPEC_KEY = 'storage'
-
 STORAGE_CONFIG_KEY = 'storages'
 
 

--- a/ml_git/file_system/local.py
+++ b/ml_git/file_system/local.py
@@ -29,7 +29,7 @@ from ml_git.ml_git_message import output_messages
 from ml_git.pool import pool_factory, process_futures
 from ml_git.refs import Refs
 from ml_git.sample import SampleValidate
-from ml_git.spec import spec_parse, search_spec_file, get_entity_dir
+from ml_git.spec import spec_parse, search_spec_file, get_entity_dir, get_spec_key
 from ml_git.storages.store_utils import storage_factory
 from ml_git.utils import yaml_load, ensure_path_exists, convert_path, normalize_path, \
     posix_path, set_write_read, change_mask_for_routine, run_function_per_group, get_root_path, yaml_save
@@ -57,9 +57,10 @@ class LocalRepository(MultihashFS):
 
     def push(self, object_path, spec_file, retry=2, clear_on_fail=False):
         repo_type = self.__repo_type
+        entity_spec_key = get_spec_key(repo_type)
 
         spec = yaml_load(spec_file)
-        manifest = spec[repo_type]['manifest']
+        manifest = spec[entity_spec_key]['manifest']
         idx = MultihashFS(object_path)
         objs = idx.get_log()
 
@@ -117,7 +118,8 @@ class LocalRepository(MultihashFS):
         repo_type = self.__repo_type
 
         spec = yaml_load(spec_file)
-        manifest = spec[repo_type]['manifest']
+        entity_spec_key = get_spec_key(repo_type)
+        manifest = spec[entity_spec_key]['manifest']
         storage = storage_factory(self.__config, manifest[STORAGE_SPEC_KEY])
         if storage is None:
             log.error(output_messages['ERROR_WITHOUT_STORAGE'] % (manifest[STORAGE_SPEC_KEY]), class_name=STORAGE_FACTORY_CLASS_NAME)
@@ -237,11 +239,12 @@ class LocalRepository(MultihashFS):
         spec_path, spec_file = search_spec_file(repo_type, spec_name, root_path=metadata_path)
         entity_dir = os.path.relpath(spec_path, metadata_path)
         spec = yaml_load(os.path.join(spec_path, spec_file))
-        if repo_type not in spec:
+        entity_spec_key = get_spec_key(repo_type)
+        if entity_spec_key not in spec:
             log.error(output_messages['ERROR_NO_SPEC_FILE_FOUND'],
                       class_name=LOCAL_REPOSITORY_CLASS_NAME)
             return False
-        manifest = spec[repo_type]['manifest']
+        manifest = spec[entity_spec_key]['manifest']
         storage = storage_factory(self.__config, manifest[STORAGE_SPEC_KEY])
         if storage is None:
             return False
@@ -578,7 +581,8 @@ class LocalRepository(MultihashFS):
 
     def remote_fsck(self, metadata_path, tag, spec_file, retries=2, thorough=False, paranoid=False):
         spec = yaml_load(spec_file)
-        manifest = spec[self.__repo_type]['manifest']
+        entity_spec_key = get_spec_key(self.__repo_type)
+        manifest = spec[entity_spec_key]['manifest']
         _, spec_name, _ = spec_parse(tag)
         # get all files for specific tag
         entity_dir = get_entity_dir(self.__repo_type, spec_name, root_path=metadata_path)
@@ -729,7 +733,6 @@ class LocalRepository(MultihashFS):
         bare_mode = os.path.exists(os.path.join(index_metadata_path, spec, 'bare'))
         new_files, deleted_files, all_files, corrupted_files = self._get_index_files_status(bare_mode, idx_yaml_mf,
                                                                                             path, status_directory)
-
         if path is not None:
             changed_files, untracked_files = \
                 self._get_workspace_files_status(all_files, full_metadata_path, idx_yaml_mf,
@@ -901,12 +904,13 @@ class LocalRepository(MultihashFS):
         spec_path = os.path.join(metadata_path, entity_dir, spec_name + SPEC_EXTENSION)
         spec = yaml_load(spec_path)
 
-        if self.__repo_type not in spec:
+        entity_spec_key = get_spec_key(self.__repo_type)
+        if entity_spec_key not in spec:
             log.error(output_messages['ERROR_NO_SPEC_FILE_FOUND'],
                       class_name=LOCAL_REPOSITORY_CLASS_NAME)
             return
 
-        manifest = spec[self.__repo_type]['manifest']
+        manifest = spec[entity_spec_key]['manifest']
         storage = storage_factory(self.__config, manifest[STORAGE_SPEC_KEY])
         if storage is None:
             log.error(output_messages['ERROR_WITHOUT_STORAGE'] % (manifest[STORAGE_SPEC_KEY]), class_name=LOCAL_REPOSITORY_CLASS_NAME)
@@ -969,8 +973,9 @@ class LocalRepository(MultihashFS):
         if not index or not compare:
             return False
 
-        entity = index[self.__repo_type]
-        entity_compare = compare[self.__repo_type]
+        entity_spec_key = get_spec_key(self.__repo_type)
+        entity = index[entity_spec_key]
+        entity_compare = compare[entity_spec_key]
         if entity['categories'] != entity_compare['categories']:
             return False
         if entity['manifest'][STORAGE_SPEC_KEY] != entity_compare['manifest'][STORAGE_SPEC_KEY]:
@@ -1020,7 +1025,8 @@ class LocalRepository(MultihashFS):
         file_ws_spec = yaml_load(full_spec_path)
 
         try:
-            spec_mutability = file_ws_spec[repo_type].get('mutability', MutabilityType.STRICT.value)
+            entity_spec_key = get_spec_key(repo_type)
+            spec_mutability = file_ws_spec[entity_spec_key].get('mutability', MutabilityType.STRICT.value)
             if spec_mutability not in MutabilityType.to_list():
                 log.error(output_messages['ERROR_INVALID_MUTABILITY_TYPE'], class_name=REPOSITORY_CLASS_NAME)
                 return None, False
@@ -1034,8 +1040,9 @@ class LocalRepository(MultihashFS):
         ws_spec_path = os.path.join(spec_path, spec + SPEC_EXTENSION)
         file_ws_spec = yaml_load(ws_spec_path)
         ws_spec_mutability = None
-        if 'mutability' in file_ws_spec[repo_type]:
-            ws_spec_mutability = file_ws_spec[repo_type]['mutability']
+        entity_spec_key = get_spec_key(repo_type)
+        if 'mutability' in file_ws_spec[entity_spec_key]:
+            ws_spec_mutability = file_ws_spec[entity_spec_key]['mutability']
 
         metadata_spec_path = os.path.join(metadata_path, entity_dir, spec + SPEC_EXTENSION)
         if os.path.exists(metadata_spec_path):
@@ -1044,8 +1051,8 @@ class LocalRepository(MultihashFS):
             try:
                 if ws_spec_mutability is None:
                     ws_spec_mutability = MutabilityType.STRICT.value
-                if 'mutability' in file_md_spec[repo_type]:
-                    md_spec_mutability = file_md_spec[repo_type]['mutability']
+                if 'mutability' in file_md_spec[entity_spec_key]:
+                    md_spec_mutability = file_md_spec[entity_spec_key]['mutability']
                 else:
                     md_spec_mutability = MutabilityType.STRICT.value
                 return ws_spec_mutability == md_spec_mutability
@@ -1095,5 +1102,6 @@ class LocalRepository(MultihashFS):
 
         for metric, value in metrics:
             metrics_to_save[metric] = float(value)
-        spec_file[self.__repo_type][PERFORMANCE_KEY] = metrics_to_save
+
+        spec_file[get_spec_key(self.__repo_type)][PERFORMANCE_KEY] = metrics_to_save
         yaml_save(spec_file, spec_path)

--- a/ml_git/metadata.py
+++ b/ml_git/metadata.py
@@ -12,7 +12,7 @@ from ml_git import log
 from ml_git._metadata import MetadataManager
 from ml_git.config import get_refs_path, get_sample_spec_doc
 from ml_git.constants import METADATA_CLASS_NAME, LOCAL_REPOSITORY_CLASS_NAME, ROOT_FILE_NAME, MutabilityType, \
-    SPEC_EXTENSION, MANIFEST_FILE, EntityType, STORAGE_KEY
+    SPEC_EXTENSION, MANIFEST_FILE, EntityType, STORAGE_SPEC_KEY
 from ml_git.manifest import Manifest
 from ml_git.ml_git_message import output_messages
 from ml_git.plugin_interface.data_plugin_constants import ADD_METADATA
@@ -146,7 +146,7 @@ class Metadata(MetadataManager):
         metadata[self.__repo_type]['manifest']['files'] = MANIFEST_FILE
         metadata[self.__repo_type]['manifest']['size'] = humanize.naturalsize(workspace_size)
         metadata[self.__repo_type]['manifest']['amount'] = amount
-        storage = metadata[self.__repo_type]['manifest'][STORAGE_KEY]
+        storage = metadata[self.__repo_type]['manifest'][STORAGE_SPEC_KEY]
 
         manifest = metadata[self.__repo_type]['manifest']
         PluginCaller(manifest).call(ADD_METADATA, ws_path, manifest)

--- a/ml_git/metadata.py
+++ b/ml_git/metadata.py
@@ -12,13 +12,13 @@ from ml_git import log
 from ml_git._metadata import MetadataManager
 from ml_git.config import get_refs_path, get_sample_spec_doc
 from ml_git.constants import METADATA_CLASS_NAME, LOCAL_REPOSITORY_CLASS_NAME, ROOT_FILE_NAME, MutabilityType, \
-    SPEC_EXTENSION, MANIFEST_FILE, EntityType, STORAGE_SPEC_KEY
+    SPEC_EXTENSION, MANIFEST_FILE, EntityType, STORAGE_SPEC_KEY, DATASET_SPEC_KEY, LABELS_SPEC_KEY
 from ml_git.manifest import Manifest
 from ml_git.ml_git_message import output_messages
 from ml_git.plugin_interface.data_plugin_constants import ADD_METADATA
 from ml_git.plugin_interface.plugin_especialization import PluginCaller
 from ml_git.refs import Refs
-from ml_git.spec import spec_parse, get_entity_dir
+from ml_git.spec import spec_parse, get_entity_dir, get_spec_key
 from ml_git.utils import ensure_path_exists, yaml_save, yaml_load, clear, get_file_size, normalize_path
 
 
@@ -143,12 +143,14 @@ class Metadata(MetadataManager):
                 raise e
         amount, workspace_size = self._get_amount_and_size_of_workspace_files(full_metadata_path, ws_path)
         # saves metadata and commit
-        metadata[self.__repo_type]['manifest']['files'] = MANIFEST_FILE
-        metadata[self.__repo_type]['manifest']['size'] = humanize.naturalsize(workspace_size)
-        metadata[self.__repo_type]['manifest']['amount'] = amount
-        storage = metadata[self.__repo_type]['manifest'][STORAGE_SPEC_KEY]
 
-        manifest = metadata[self.__repo_type]['manifest']
+        entity_spec_key = get_spec_key(self.__repo_type)
+        metadata[entity_spec_key]['manifest']['files'] = MANIFEST_FILE
+        metadata[entity_spec_key]['manifest']['size'] = humanize.naturalsize(workspace_size)
+        metadata[entity_spec_key]['manifest']['amount'] = amount
+        storage = metadata[entity_spec_key]['manifest'][STORAGE_SPEC_KEY]
+
+        manifest = metadata[entity_spec_key]['manifest']
         PluginCaller(manifest).call(ADD_METADATA, ws_path, manifest)
 
         # Add metadata specific to labels ML entity type
@@ -161,6 +163,7 @@ class Metadata(MetadataManager):
         dataset = EntityType.DATASETS.value
         labels = EntityType.LABELS.value
         model = EntityType.MODELS.value
+        entity_spec_key = get_spec_key(self.__repo_type)
         if dataset in specs and self.__repo_type in [labels, model]:
             d_spec = specs[dataset]
             refs_path = get_refs_path(self.__config, dataset)
@@ -169,9 +172,9 @@ class Metadata(MetadataManager):
             if tag is not None:
                 log.info(output_messages['INFO_ASSOCIATE_DATASETS'] % (d_spec, tag, self.__repo_type),
                          class_name=LOCAL_REPOSITORY_CLASS_NAME)
-                metadata[self.__repo_type][dataset] = {}
-                metadata[self.__repo_type][dataset]['tag'] = tag
-                metadata[self.__repo_type][dataset]['sha'] = sha
+                metadata[entity_spec_key][DATASET_SPEC_KEY] = {}
+                metadata[entity_spec_key][DATASET_SPEC_KEY]['tag'] = tag
+                metadata[entity_spec_key][DATASET_SPEC_KEY]['sha'] = sha
         if labels in specs and self.__repo_type in [model]:
             l_spec = specs[labels]
             refs_path = get_refs_path(self.__config, labels)
@@ -181,9 +184,9 @@ class Metadata(MetadataManager):
                 log.info(
                     'Associate labels [%s]-[%s] to the %s.' % (l_spec, tag, self.__repo_type),
                     class_name=LOCAL_REPOSITORY_CLASS_NAME)
-                metadata[self.__repo_type][labels] = {}
-                metadata[self.__repo_type][labels]['tag'] = tag
-                metadata[self.__repo_type][labels]['sha'] = sha
+                metadata[entity_spec_key][LABELS_SPEC_KEY] = {}
+                metadata[entity_spec_key][LABELS_SPEC_KEY]['tag'] = tag
+                metadata[entity_spec_key][LABELS_SPEC_KEY]['sha'] = sha
 
     def _get_amount_and_size_of_workspace_files(self, full_metadata_path, ws_path):
         full_path = os.path.join(full_metadata_path, MANIFEST_FILE)
@@ -209,7 +212,8 @@ class Metadata(MetadataManager):
 
     def __metadata_spec(self, metadata, sep):
         repo_type = self.__repo_type
-        cats = metadata[repo_type]['categories']
+        entity_sepc_key = get_spec_key(repo_type)
+        cats = metadata[entity_sepc_key]['categories']
         if cats is None:
             log.error(output_messages['ERROR_ENTITY_NEEDS_CATATEGORY'])
             return
@@ -220,19 +224,19 @@ class Metadata(MetadataManager):
 
         # Generate Spec from Dataset Name & Categories
         try:
-            return sep.join([categories, metadata[repo_type]['name']])
+            return sep.join([categories, metadata[entity_sepc_key]['name']])
         except Exception:
             log.error(output_messages['ERROR_INVALID_DATASET_SPEC']
-                      % (get_sample_spec_doc('somebucket', repo_type)))
+                      % (get_sample_spec_doc('somebucket', entity_sepc_key)))
             return None
 
     def metadata_tag(self, metadata):
         repo_type = self.__repo_type
-
+        entity_spec_key = get_spec_key(repo_type)
         sep = '__'
         tag = self.__metadata_spec(metadata, sep)
 
-        tag = sep.join([tag, str(metadata[repo_type]['version'])])
+        tag = sep.join([tag, str(metadata[entity_spec_key]['version'])])
 
         log.debug(output_messages['DEBUG_NEW_TAG_CREATED'] % tag, class_name=METADATA_CLASS_NAME)
         return tag

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -600,7 +600,7 @@ class Repository(object):
         if ref is None:
             ref = m.get_default_branch()
 
-        m.checkout(ref)
+        m.checkout(ref, force=True)
 
     '''Performs fsck on several aspects of ml-git filesystem.
         TODO: add options like following:

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -17,9 +17,10 @@ from ml_git.config import get_index_path, get_objects_path, get_cache_path, get_
     validate_config_spec_hash, validate_spec_hash, get_sample_config_spec, get_sample_spec_doc, \
     get_index_metadata_path, create_workspace_tree_structure, start_wizard_questions, config_load, \
     get_global_config_path, save_global_config_in_local
-from ml_git.constants import REPOSITORY_CLASS_NAME, LOCAL_REPOSITORY_CLASS_NAME, HEAD, HEAD_1, MutabilityType, StorageType, \
+from ml_git.constants import REPOSITORY_CLASS_NAME, LOCAL_REPOSITORY_CLASS_NAME, HEAD, HEAD_1, MutabilityType, \
+    StorageType, \
     RGX_TAG_FORMAT, EntityType, MANIFEST_FILE, SPEC_EXTENSION, MANIFEST_KEY, STATUS_NEW_FILE, STATUS_DELETED_FILE, \
-    STORAGE_KEY, FileType
+    FileType, STORAGE_CONFIG_KEY
 from ml_git.file_system.cache import Cache
 from ml_git.file_system.hashfs import MultihashFS
 from ml_git.file_system.index import MultihashIndex, Status, FullIndex
@@ -992,7 +993,7 @@ class Repository(object):
 
     def create_config_storage(self, storage_type, credentials_path):
         bucket = {'credentials-path': credentials_path}
-        self.__config[STORAGE_KEY][storage_type] = {storage_type: bucket}
+        self.__config[STORAGE_CONFIG_KEY][storage_type] = {storage_type: bucket}
 
     def create(self, kwargs):
         artifact_name = kwargs['artifact_name']

--- a/ml_git/spec.py
+++ b/ml_git/spec.py
@@ -7,7 +7,8 @@ import os
 
 from ml_git import log
 from ml_git import utils
-from ml_git.constants import ML_GIT_PROJECT_NAME, SPEC_EXTENSION, EntityType, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY
+from ml_git.constants import ML_GIT_PROJECT_NAME, SPEC_EXTENSION, EntityType, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY, \
+    DATASET_SPEC_KEY, LABELS_SPEC_KEY, MODEL_SPEC_KEY
 from ml_git.ml_git_message import output_messages
 from ml_git.utils import get_root_path, yaml_load
 
@@ -53,22 +54,24 @@ def spec_parse(spec):
 """Increment the version number inside the given dataset specification file."""
 
 
-def incr_version(file, repotype=DATASETS):
+def incr_version(file, repo_type=DATASETS):
     spec_hash = utils.yaml_load(file)
-    if is_valid_version(spec_hash, repotype):
-        spec_hash[repotype]['version'] += 1
+    entity_spec_key = get_spec_key(repo_type)
+    if is_valid_version(spec_hash, entity_spec_key):
+        spec_hash[entity_spec_key]['version'] += 1
         utils.yaml_save(spec_hash, file)
-        log.debug(output_messages['DEBUG_VERSION_INCREMENTED_TO'] % spec_hash[repotype]['version'], class_name=ML_GIT_PROJECT_NAME)
-        return spec_hash[repotype]['version']
+        log.debug(output_messages['DEBUG_VERSION_INCREMENTED_TO'] % spec_hash[entity_spec_key]['version'], class_name=ML_GIT_PROJECT_NAME)
+        return spec_hash[entity_spec_key]['version']
     else:
         log.error(output_messages['ERROR_INVALID_VERSION_INCREMENT'] % file, class_name=ML_GIT_PROJECT_NAME)
         return -1
 
 
-def get_version(file, repotype=DATASETS):
+def get_version(file, repo_type=DATASETS):
     spec_hash = utils.yaml_load(file)
-    if is_valid_version(spec_hash, repotype):
-        return spec_hash[DATASETS]['version']
+    entity_spec_key = get_spec_key(repo_type)
+    if is_valid_version(spec_hash, entity_spec_key):
+        return spec_hash[entity_spec_key]['version']
     else:
         log.error(output_messages['ERROR_INVALID_VERSION_GET'] % file, class_name=ML_GIT_PROJECT_NAME)
         return -1
@@ -77,14 +80,14 @@ def get_version(file, repotype=DATASETS):
 """Validate the version inside the dataset specification file hash can be located and is an int."""
 
 
-def is_valid_version(the_hash, repotype=DATASETS):
+def is_valid_version(the_hash, entity_key=DATASET_SPEC_KEY):
     if the_hash is None or the_hash == {}:
         return False
-    if repotype not in the_hash or 'version' not in the_hash[repotype]:
+    if entity_key not in the_hash or 'version' not in the_hash[entity_key]:
         return False
-    if not isinstance(the_hash[repotype]['version'], int):
+    if not isinstance(the_hash[entity_key]['version'], int):
         return False
-    if int(the_hash[repotype]['version']) < 0:
+    if int(the_hash[entity_key]['version']) < 0:
         return False
     return True
 
@@ -94,11 +97,12 @@ def get_spec_file_dir(entity_name, repotype=DATASETS):
     return dir1
 
 
-def set_version_in_spec(version_number, spec_path, repotype=DATASETS):
+def set_version_in_spec(version_number, spec_path, repo_type=DATASETS):
+    entity_spec_key = get_spec_key(repo_type)
     spec_hash = utils.yaml_load(spec_path)
-    spec_hash[repotype]['version'] = version_number
+    spec_hash[entity_spec_key]['version'] = version_number
     utils.yaml_save(spec_hash, spec_path)
-    log.debug(output_messages['DEBUG_VERSION_CHANGED_TO'] % spec_hash[repotype]['version'], class_name=ML_GIT_PROJECT_NAME)
+    log.debug(output_messages['DEBUG_VERSION_CHANGED_TO'] % spec_hash[entity_spec_key]['version'], class_name=ML_GIT_PROJECT_NAME)
 
 
 """When --bumpversion is specified during 'dataset add', this increments the version number in the right place"""
@@ -123,25 +127,29 @@ def increment_version_in_spec(entity_name, repotype=DATASETS):
         return False
 
 
-def get_entity_tag(specpath, repotype, entity):
+def get_entity_tag(specpath, repo_type, entity):
     entity_tag = None
+    entity_spec_key = get_spec_key(repo_type)
     try:
         spec = yaml_load(specpath)
-        entity_tag = spec[repotype][entity]['tag']
+        related_entity_spec_key = get_spec_key(entity)
+        entity_tag = spec[entity_spec_key][related_entity_spec_key]['tag']
     except Exception:
         log.warn(output_messages['WARN_NOT_EXIST_FOR_RELATED_DOWNLOAD'] % entity)
     return entity_tag
 
 
-def update_storage_spec(repotype, artifact_name, storage_type, bucket, entity_dir=''):
+def update_storage_spec(repo_type, artifact_name, storage_type, bucket, entity_dir=''):
     path = None
     try:
         path = get_root_path()
     except Exception as e:
         log.error(e, CLASS_NAME=ML_GIT_PROJECT_NAME)
-    spec_path = os.path.join(path, repotype, entity_dir, artifact_name, artifact_name + SPEC_EXTENSION)
+    spec_path = os.path.join(path, repo_type, entity_dir, artifact_name, artifact_name + SPEC_EXTENSION)
     spec_hash = utils.yaml_load(spec_path)
-    spec_hash[repotype]['manifest'][STORAGE_SPEC_KEY] = storage_type + '://' + bucket
+
+    entity_spec_key = get_spec_key(repo_type)
+    spec_hash[entity_spec_key]['manifest'][STORAGE_SPEC_KEY] = storage_type + '://' + bucket
     utils.yaml_save(spec_hash, spec_path)
     return
 
@@ -165,3 +173,13 @@ def validate_bucket_name(spec, config):
         'Bucket name [%s] not found in config.\n'
         % bucket_name, CLASS_NAME=ML_GIT_PROJECT_NAME)
     return False
+
+
+def get_spec_key(repo_type):
+    if repo_type == EntityType.DATASETS.value:
+        return DATASET_SPEC_KEY
+    elif repo_type == EntityType.LABELS.value:
+        return LABELS_SPEC_KEY
+    elif repo_type == EntityType.MODELS.value:
+        return MODEL_SPEC_KEY
+    raise Exception(output_messages['ERROR_INVALID_ENTITY_TYPE'])

--- a/ml_git/spec.py
+++ b/ml_git/spec.py
@@ -7,7 +7,7 @@ import os
 
 from ml_git import log
 from ml_git import utils
-from ml_git.constants import ML_GIT_PROJECT_NAME, SPEC_EXTENSION, EntityType, STORAGE_KEY
+from ml_git.constants import ML_GIT_PROJECT_NAME, SPEC_EXTENSION, EntityType, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY
 from ml_git.ml_git_message import output_messages
 from ml_git.utils import get_root_path, yaml_load
 
@@ -141,13 +141,13 @@ def update_storage_spec(repotype, artifact_name, storage_type, bucket, entity_di
         log.error(e, CLASS_NAME=ML_GIT_PROJECT_NAME)
     spec_path = os.path.join(path, repotype, entity_dir, artifact_name, artifact_name + SPEC_EXTENSION)
     spec_hash = utils.yaml_load(spec_path)
-    spec_hash[repotype]['manifest'][STORAGE_KEY] = storage_type + '://' + bucket
+    spec_hash[repotype]['manifest'][STORAGE_SPEC_KEY] = storage_type + '://' + bucket
     utils.yaml_save(spec_hash, spec_path)
     return
 
 
 def validate_bucket_name(spec, config):
-    values = spec['manifest'][STORAGE_KEY].split('://')
+    values = spec['manifest'][STORAGE_SPEC_KEY].split('://')
     len_info = 2
 
     if len(values) != len_info:
@@ -156,7 +156,7 @@ def validate_bucket_name(spec, config):
 
     bucket_name = values[1]
     storage_type = values[0]
-    storage = config[STORAGE_KEY]
+    storage = config[STORAGE_CONFIG_KEY]
 
     if storage_type in storage and bucket_name in storage[storage_type]:
         return True

--- a/ml_git/storages/azure_storage.py
+++ b/ml_git/storages/azure_storage.py
@@ -9,7 +9,7 @@ import toml
 from azure.storage.blob import BlobServiceClient, ContainerClient
 
 from ml_git import log
-from ml_git.constants import AZURE_STORAGE_NAME, StorageType, STORAGE_KEY
+from ml_git.constants import AZURE_STORAGE_NAME, StorageType, STORAGE_SPEC_KEY
 from ml_git.ml_git_message import output_messages
 from ml_git.storages.multihash_storage import MultihashStorage
 from ml_git.storages.storage import Storage
@@ -83,7 +83,7 @@ class AzureMultihashStorage(Storage, MultihashStorage):
         try:
             azure_folder = os.path.expanduser(os.path.join('~', '.azure'))
             config = toml.load(os.path.join(azure_folder, 'config'))
-            connection = config[STORAGE_KEY]['connection_string']
+            connection = config[STORAGE_SPEC_KEY]['connection_string']
             if connection != '':
                 return connection
         except Exception:

--- a/ml_git/storages/store_utils.py
+++ b/ml_git/storages/store_utils.py
@@ -7,7 +7,7 @@ import boto3
 from botocore.exceptions import ProfileNotFound
 
 from ml_git import log
-from ml_git.constants import STORAGE_FACTORY_CLASS_NAME, StorageType, STORAGE_KEY
+from ml_git.constants import STORAGE_FACTORY_CLASS_NAME, StorageType, STORAGE_CONFIG_KEY
 from ml_git.ml_git_message import output_messages
 from ml_git.storages.azure_storage import AzureMultihashStorage
 from ml_git.storages.google_drive_storage import GoogleDriveMultihashStorage, GoogleDriveStorage
@@ -29,13 +29,13 @@ def storage_factory(config, storage_string):
         bucket_name = sp[2]
         config_bucket_name = []
         log.debug(output_messages['DEBUG_STORAGE_AND_BUCKET'] % (storage_type, bucket_name), class_name=STORAGE_FACTORY_CLASS_NAME)
-        for k in config[STORAGE_KEY][storage_type]:
+        for k in config[STORAGE_CONFIG_KEY][storage_type]:
             config_bucket_name.append(k)
         if bucket_name not in config_bucket_name:
             log.warn(output_messages['WARN_EXCPETION_CREATING_STORAGE'] % (
                 bucket_name, storage_type, config_bucket_name), class_name=STORAGE_FACTORY_CLASS_NAME)
             return None
-        bucket = config[STORAGE_KEY][storage_type][bucket_name]
+        bucket = config[STORAGE_CONFIG_KEY][storage_type][bucket_name]
         return storages[storage_type](bucket_name, bucket)
     except ProfileNotFound as pfn:
         log.error(pfn, class_name=STORAGE_FACTORY_CLASS_NAME)

--- a/ml_git/utils.py
+++ b/ml_git/utils.py
@@ -20,8 +20,8 @@ from ruamel.yaml import YAML
 from ruamel.yaml.compat import StringIO
 
 from ml_git import log
-from ml_git.constants import SPEC_EXTENSION, CONFIG_FILE, EntityType, ROOT_FILE_NAME, V1_STORAGE_KEY, STORAGE_KEY, \
-    V1_DATASETS_KEY, V1_MODELS_KEY
+from ml_git.constants import SPEC_EXTENSION, CONFIG_FILE, EntityType, ROOT_FILE_NAME, V1_STORAGE_KEY, V1_DATASETS_KEY, \
+    V1_MODELS_KEY, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY
 from ml_git.ml_git_message import output_messages
 from ml_git.pool import pool_factory
 
@@ -67,14 +67,10 @@ def json_load(file):
 
 
 def check_spec_file(file, hash):
-    if V1_DATASETS_KEY in hash:
-        hash[EntityType.DATASETS.value] = hash.pop(V1_DATASETS_KEY)
-    if V1_MODELS_KEY in hash:
-        hash[EntityType.MODELS.value] = hash.pop(V1_MODELS_KEY)
     entity_type = next(iter(hash))
     manifest_values = hash[entity_type]['manifest']
     if V1_STORAGE_KEY in manifest_values:
-        manifest_values[STORAGE_KEY] = manifest_values.pop(V1_STORAGE_KEY)
+        manifest_values[STORAGE_SPEC_KEY] = manifest_values.pop(V1_STORAGE_KEY)
     yaml_save(hash, file)
     return hash
 
@@ -300,7 +296,7 @@ def change_keys_in_config(root_path):
     if V1_MODELS_KEY in conf:
         conf[EntityType.MODELS.value] = conf.pop(V1_MODELS_KEY)
     if V1_STORAGE_KEY in conf:
-        conf[STORAGE_KEY] = conf.pop(V1_STORAGE_KEY)
+        conf[STORAGE_CONFIG_KEY] = conf.pop(V1_STORAGE_KEY)
     yaml_save(conf, file)
 
 

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -14,7 +14,8 @@ from zipfile import ZipFile
 
 from ruamel.yaml import YAML
 
-from ml_git.constants import GLOBAL_ML_GIT_CONFIG, MutabilityType, StorageType, STORAGE_KEY, EntityType
+from ml_git.constants import GLOBAL_ML_GIT_CONFIG, MutabilityType, StorageType, EntityType, STORAGE_SPEC_KEY, \
+    STORAGE_CONFIG_KEY
 from ml_git.ml_git_message import output_messages
 from ml_git.utils import ensure_path_exists
 from tests.integration.commands import MLGIT_INIT, MLGIT_REMOTE_ADD, MLGIT_ENTITY_INIT, MLGIT_ADD, \
@@ -145,7 +146,7 @@ def init_repository(entity, self, version=1, storage_type=S3H, profile=PROFILE, 
             'categories': ['computer-vision', category],
             'manifest': {
                 'files': 'MANIFEST.yaml',
-                STORAGE_KEY: '%s://mlgit' % storage_type
+                STORAGE_SPEC_KEY: '%s://mlgit' % storage_type
             },
             'mutability': STRICT,
             'name': artifact_name,
@@ -195,7 +196,7 @@ def delete_file(workspace_path, delete_files):
 def edit_config_yaml(ml_git_dir, storage_type=S3H):
     with open(os.path.join(ml_git_dir, 'config.yaml'), 'r') as config_file:
         config = yaml_processor.load(config_file)
-        config[STORAGE_KEY][storage_type]['mlgit']['endpoint-url'] = MINIO_ENDPOINT_URL
+        config[STORAGE_CONFIG_KEY][storage_type]['mlgit']['endpoint-url'] = MINIO_ENDPOINT_URL
     with open(os.path.join(ml_git_dir, 'config.yaml'), 'w') as config_file:
         yaml_processor.dump(config, config_file)
 
@@ -216,7 +217,7 @@ def create_git_clone_repo(git_dir, tmp_dir, git_path=GIT_PATH):
         DATASETS: {
             'git': os.path.join(tmp_dir, git_path),
         },
-        STORAGE_KEY: {
+        STORAGE_CONFIG_KEY: {
             S3: {
                 'mlgit-datasets': {
                     'region': 'us-east-1',
@@ -248,7 +249,7 @@ def create_spec(self, model, tmpdir, version=1, mutability=STRICT, storage_type=
             'mutability': mutability,
             'manifest': {
                 'files': 'MANIFEST.yaml',
-                STORAGE_KEY: '%s://mlgit' % storage_type
+                STORAGE_SPEC_KEY: '%s://mlgit' % storage_type
             },
             'name': artifact_name,
             'version': version
@@ -304,7 +305,7 @@ def configure_global(self, entity_type):
 def edit_global_config_yaml(storage_type=S3H):
     with open(os.path.join(GLOBAL_CONFIG_PATH, GLOBAL_ML_GIT_CONFIG), 'r') as config_file:
         config = yaml_processor.load(config_file)
-        config[STORAGE_KEY][storage_type]['mlgit']['endpoint-url'] = MINIO_ENDPOINT_URL
+        config[STORAGE_CONFIG_KEY][storage_type]['mlgit']['endpoint-url'] = MINIO_ENDPOINT_URL
     with open(os.path.join(GLOBAL_CONFIG_PATH, GLOBAL_ML_GIT_CONFIG), 'w') as config_file:
         yaml_processor.dump(config, config_file)
 

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -17,6 +17,7 @@ from ruamel.yaml import YAML
 from ml_git.constants import GLOBAL_ML_GIT_CONFIG, MutabilityType, StorageType, EntityType, STORAGE_SPEC_KEY, \
     STORAGE_CONFIG_KEY, FileType
 from ml_git.ml_git_message import output_messages
+from ml_git.spec import get_spec_key
 from ml_git.utils import ensure_path_exists
 from tests.integration.commands import MLGIT_INIT, MLGIT_REMOTE_ADD, MLGIT_ENTITY_INIT, MLGIT_ADD, \
     MLGIT_STORAGE_ADD_WITH_TYPE, MLGIT_REMOTE_ADD_GLOBAL, MLGIT_STORAGE_ADD, MLGIT_STORAGE_ADD_WITHOUT_CREDENTIALS, \
@@ -143,8 +144,9 @@ def init_repository(entity, self, version=1, storage_type=S3H, profile=PROFILE, 
     edit_config_yaml(os.path.join(self.tmp_dir, ML_GIT_DIR), storage_type)
     workspace = os.path.join(self.tmp_dir, entity, artifact_name)
     os.makedirs(workspace)
+    spec_key = get_spec_key(entity)
     spec = {
-        entity: {
+        spec_key: {
             'categories': ['computer-vision', category],
             'manifest': {
                 'files': 'MANIFEST.yaml',
@@ -245,8 +247,9 @@ def create_git_clone_repo(git_dir, tmp_dir, git_path=GIT_PATH):
 def create_spec(self, model, tmpdir, version=1, mutability=STRICT, storage_type=STORAGE_TYPE, artifact_name=None):
     if not artifact_name:
         artifact_name = f'{model}-ex'
+    spec_key = get_spec_key(model)
     spec = {
-        model: {
+        spec_key: {
             'categories': ['computer-vision', 'images'],
             'mutability': mutability,
             'manifest': {

--- a/tests/integration/test_03_add_store.py
+++ b/tests/integration/test_03_add_store.py
@@ -8,11 +8,12 @@ import unittest
 
 import pytest
 
-from ml_git.constants import STORAGE_KEY
+from ml_git.constants import STORAGE_CONFIG_KEY
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_INIT, MLGIT_STORAGE_ADD, MLGIT_STORAGE_DEL, MLGIT_STORAGE_ADD_WITH_TYPE, \
     MLGIT_STORAGE_ADD_WITH_ENDPOINT, MLGIT_STORAGE_ADD_WITHOUT_CREDENTIALS
-from tests.integration.helper import check_output, ML_GIT_DIR, BUCKET_NAME, PROFILE, STORAGE_TYPE, yaml_processor, S3H, AZUREBLOBH, GDRIVEH
+from tests.integration.helper import check_output, ML_GIT_DIR, BUCKET_NAME, PROFILE, STORAGE_TYPE, yaml_processor, S3H, \
+    AZUREBLOBH, GDRIVEH
 
 
 @pytest.mark.usefixtures('tmp_dir')
@@ -26,19 +27,19 @@ class AddStoreAcceptanceTests(unittest.TestCase):
 
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
-            self.assertEqual(PROFILE, config[STORAGE_KEY][S3H][BUCKET_NAME]['aws-credentials']['profile'])
+            self.assertEqual(PROFILE, config[STORAGE_CONFIG_KEY][S3H][BUCKET_NAME]['aws-credentials']['profile'])
 
     def _del_storage(self):
         self.assertIn(output_messages['INFO_REMOVED_STORAGE'] % (STORAGE_TYPE, BUCKET_NAME),
                       check_output(MLGIT_STORAGE_DEL % BUCKET_NAME))
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
-            self.assertEqual(config[STORAGE_KEY][S3H], {})
+            self.assertEqual(config[STORAGE_CONFIG_KEY][S3H], {})
 
     def check_storage(self):
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
-            self.assertNotIn(S3H, config[STORAGE_KEY])
+            self.assertNotIn(S3H, config[STORAGE_CONFIG_KEY])
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_01_add_storage_root_directory(self):
@@ -55,7 +56,7 @@ class AddStoreAcceptanceTests(unittest.TestCase):
         self.assertIn(output_messages['INFO_INITIALIZED_PROJECT_IN'] % self.tmp_dir, check_output(MLGIT_INIT))
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
-            self.assertNotIn(S3H, config[STORAGE_KEY])
+            self.assertNotIn(S3H, config[STORAGE_CONFIG_KEY])
 
         os.chdir(os.path.join(self.tmp_dir, ML_GIT_DIR))
         self.assertIn(output_messages['INFO_ADD_STORAGE'] % (STORAGE_TYPE, BUCKET_NAME, PROFILE),
@@ -77,7 +78,7 @@ class AddStoreAcceptanceTests(unittest.TestCase):
         bucket_name = 'bucket_s3'
         profile = 'profile_s3'
         config = self.add_storage_type(bucket_name, profile, storage_type)
-        self.assertEqual(profile, config[STORAGE_KEY][storage_type][bucket_name]['aws-credentials']['profile'])
+        self.assertEqual(profile, config[STORAGE_CONFIG_KEY][storage_type][bucket_name]['aws-credentials']['profile'])
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_07_add_storage_type_azure(self):
@@ -85,7 +86,7 @@ class AddStoreAcceptanceTests(unittest.TestCase):
         bucket_name = 'container_azure'
         profile = 'profile_azure'
         config = self.add_storage_type(bucket_name, profile, storage_type)
-        self.assertIn(bucket_name, config[STORAGE_KEY][storage_type])
+        self.assertIn(bucket_name, config[STORAGE_CONFIG_KEY][storage_type])
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_08_add_storage_type_gdriveh(self):
@@ -93,7 +94,7 @@ class AddStoreAcceptanceTests(unittest.TestCase):
         bucket_name = 'google'
         profile = 'path/to/cred.json'
         config = self.add_storage_type(bucket_name, profile, storage_type)
-        self.assertEqual(profile, config[STORAGE_KEY][storage_type][bucket_name]['credentials-path'])
+        self.assertEqual(profile, config[STORAGE_CONFIG_KEY][storage_type][bucket_name]['credentials-path'])
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def add_storage_type(self, bucket, profile, storage_type):
@@ -117,8 +118,8 @@ class AddStoreAcceptanceTests(unittest.TestCase):
 
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
-            self.assertEqual(PROFILE, config[STORAGE_KEY][S3H][BUCKET_NAME]['aws-credentials']['profile'])
-            self.assertEqual(endpoint, config[STORAGE_KEY][S3H][BUCKET_NAME]['endpoint-url'])
+            self.assertEqual(PROFILE, config[STORAGE_CONFIG_KEY][S3H][BUCKET_NAME]['aws-credentials']['profile'])
+            self.assertEqual(endpoint, config[STORAGE_CONFIG_KEY][S3H][BUCKET_NAME]['endpoint-url'])
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_10_add_storage_without_credentials(self):
@@ -128,5 +129,5 @@ class AddStoreAcceptanceTests(unittest.TestCase):
                       check_output(MLGIT_STORAGE_ADD_WITHOUT_CREDENTIALS % BUCKET_NAME))
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
-            self.assertEqual(None, config[STORAGE_KEY][S3H][BUCKET_NAME]['aws-credentials']['profile'])
-            self.assertEqual(None, config[STORAGE_KEY][S3H][BUCKET_NAME]['region'])
+            self.assertEqual(None, config[STORAGE_CONFIG_KEY][S3H][BUCKET_NAME]['aws-credentials']['profile'])
+            self.assertEqual(None, config[STORAGE_CONFIG_KEY][S3H][BUCKET_NAME]['region'])

--- a/tests/integration/test_05_add_files.py
+++ b/tests/integration/test_05_add_files.py
@@ -10,6 +10,7 @@ from stat import S_IWUSR, S_IREAD
 import pytest
 
 from ml_git.ml_git_message import output_messages
+from ml_git.spec import get_spec_key
 from tests.integration.helper import ML_GIT_DIR, create_spec, init_repository, ERROR_MESSAGE, MLGIT_ADD, \
     create_file, DATASETS, DATASET_NAME, MODELS, LABELS
 from tests.integration.helper import clear, check_output, add_file, entity_init, yaml_processor
@@ -118,7 +119,8 @@ class AddFilesAcceptanceTests(unittest.TestCase):
 
         with open(os.path.join(workspace, entity_name + '.spec')) as spec:
             spec_file = yaml_processor.load(spec)
-            metrics = spec_file[repo_type].get('metrics', {})
+            spec_key = get_spec_key(repo_type)
+            metrics = spec_file[spec_key].get('metrics', {})
             self.assertFalse(metrics == {})
             self.assertTrue(metrics['Accuracy'] == 1)
             self.assertTrue(metrics['Recall'] == 2)
@@ -143,7 +145,8 @@ class AddFilesAcceptanceTests(unittest.TestCase):
 
         with open(os.path.join(workspace, DATASET_NAME+'.spec')) as spec:
             spec_file = yaml_processor.load(spec)
-            metrics = spec_file[repo_type].get('metrics', {})
+            spec_key = get_spec_key(repo_type)
+            metrics = spec_file[spec_key].get('metrics', {})
             self.assertTrue(metrics == {})
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir', 'create_csv_file')
@@ -171,7 +174,8 @@ class AddFilesAcceptanceTests(unittest.TestCase):
 
         with open(os.path.join(workspace, entity_name + '.spec')) as spec:
             spec_file = yaml_processor.load(spec)
-            metrics = spec_file[repo_type].get('metrics', {})
+            spec_key = get_spec_key(repo_type)
+            metrics = spec_file[spec_key].get('metrics', {})
             self.assertFalse(metrics == {})
             self.assertTrue(metrics['Accuracy'] == 1)
             self.assertTrue(metrics['Recall'] == 2)

--- a/tests/integration/test_19_create.py
+++ b/tests/integration/test_19_create.py
@@ -8,8 +8,9 @@ import unittest
 
 import pytest
 
-from ml_git.constants import STORAGE_SPEC_KEY
+from ml_git.constants import STORAGE_SPEC_KEY, DATASET_SPEC_KEY
 from ml_git.ml_git_message import output_messages
+from ml_git.spec import get_spec_key
 from tests.integration.commands import MLGIT_CREATE, MLGIT_INIT
 from tests.integration.helper import check_output, ML_GIT_DIR, IMPORT_PATH, create_file, ERROR_MESSAGE, yaml_processor, \
     create_zip_file, DATASETS, DATASET_NAME, MODELS, LABELS, STRICT, FLEXIBLE, MUTABLE, GDRIVEH, AZUREBLOBH, S3H
@@ -30,11 +31,12 @@ class CreateAcceptanceTests(unittest.TestCase):
         folder_data = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'data')
         spec = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', entity_type + '-ex.spec')
         readme = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'README.md')
+        entity_spec_key = get_spec_key(entity_type)
         with open(spec, 'r') as s:
             spec_file = yaml_processor.load(s)
-            self.assertEqual(spec_file[entity_type]['manifest'][STORAGE_SPEC_KEY], storage_type + '://minio')
-            self.assertEqual(spec_file[entity_type]['name'], entity_type + '-ex')
-            self.assertEqual(spec_file[entity_type]['version'], 1)
+            self.assertEqual(spec_file[entity_spec_key]['manifest'][STORAGE_SPEC_KEY], storage_type + '://minio')
+            self.assertEqual(spec_file[entity_spec_key]['name'], entity_type + '-ex')
+            self.assertEqual(spec_file[entity_spec_key]['version'], 1)
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as y:
             config = yaml_processor.load(y)
             self.assertIn(entity_type, config)
@@ -58,9 +60,9 @@ class CreateAcceptanceTests(unittest.TestCase):
         spec = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, DATASET_NAME+'.spec')
         with open(spec, 'r') as s:
             spec_file = yaml_processor.load(s)
-            self.assertEqual(spec_file[DATASETS]['mutability'], mutability)
-            self.assertEqual(spec_file[DATASETS]['name'], DATASET_NAME)
-            self.assertEqual(spec_file[DATASETS]['version'], 1)
+            self.assertEqual(spec_file[DATASET_SPEC_KEY]['mutability'], mutability)
+            self.assertEqual(spec_file[DATASET_SPEC_KEY]['name'], DATASET_NAME)
+            self.assertEqual(spec_file[DATASET_SPEC_KEY]['version'], 1)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_01_create_dataset(self):
@@ -89,9 +91,9 @@ class CreateAcceptanceTests(unittest.TestCase):
         readme = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, 'README.md')
         with open(spec, 'r') as s:
             spec_file = yaml_processor.load(s)
-            self.assertEqual(spec_file[DATASETS]['manifest'][STORAGE_SPEC_KEY], 's3h://minio')
-            self.assertEqual(spec_file[DATASETS]['name'], DATASET_NAME)
-            self.assertEqual(spec_file[DATASETS]['version'], 1)
+            self.assertEqual(spec_file[DATASET_SPEC_KEY]['manifest'][STORAGE_SPEC_KEY], 's3h://minio')
+            self.assertEqual(spec_file[DATASET_SPEC_KEY]['name'], DATASET_NAME)
+            self.assertEqual(spec_file[DATASET_SPEC_KEY]['version'], 1)
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as y:
             config = yaml_processor.load(y)
             self.assertIn(DATASETS, config)

--- a/tests/integration/test_19_create.py
+++ b/tests/integration/test_19_create.py
@@ -8,7 +8,7 @@ import unittest
 
 import pytest
 
-from ml_git.constants import STORAGE_KEY
+from ml_git.constants import STORAGE_SPEC_KEY
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_CREATE, MLGIT_INIT
 from tests.integration.helper import check_output, ML_GIT_DIR, IMPORT_PATH, create_file, ERROR_MESSAGE, yaml_processor, \
@@ -32,7 +32,7 @@ class CreateAcceptanceTests(unittest.TestCase):
         readme = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'README.md')
         with open(spec, 'r') as s:
             spec_file = yaml_processor.load(s)
-            self.assertEqual(spec_file[entity_type]['manifest'][STORAGE_KEY], storage_type + '://minio')
+            self.assertEqual(spec_file[entity_type]['manifest'][STORAGE_SPEC_KEY], storage_type + '://minio')
             self.assertEqual(spec_file[entity_type]['name'], entity_type + '-ex')
             self.assertEqual(spec_file[entity_type]['version'], 1)
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as y:
@@ -89,7 +89,7 @@ class CreateAcceptanceTests(unittest.TestCase):
         readme = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, 'README.md')
         with open(spec, 'r') as s:
             spec_file = yaml_processor.load(s)
-            self.assertEqual(spec_file[DATASETS]['manifest'][STORAGE_KEY], 's3h://minio')
+            self.assertEqual(spec_file[DATASETS]['manifest'][STORAGE_SPEC_KEY], 's3h://minio')
             self.assertEqual(spec_file[DATASETS]['name'], DATASET_NAME)
             self.assertEqual(spec_file[DATASETS]['version'], 1)
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as y:

--- a/tests/integration/test_23_metadata_persistence.py
+++ b/tests/integration/test_23_metadata_persistence.py
@@ -8,11 +8,12 @@ import unittest
 
 import pytest
 
-from ml_git.constants import STORAGE_KEY
+from ml_git.constants import STORAGE_SPEC_KEY
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_STATUS, MLGIT_ADD, MLGIT_PUSH, MLGIT_COMMIT, MLGIT_INIT, \
     MLGIT_REMOTE_ADD, MLGIT_ENTITY_INIT, MLGIT_CHECKOUT, MLGIT_STORAGE_ADD_WITH_TYPE
-from tests.integration.helper import ML_GIT_DIR, GIT_PATH, BUCKET_NAME, PROFILE, STORAGE_TYPE, DATASETS, DATASET_NAME, STRICT, S3H
+from tests.integration.helper import ML_GIT_DIR, GIT_PATH, BUCKET_NAME, PROFILE, STORAGE_TYPE, DATASETS, DATASET_NAME, \
+    STRICT, S3H
 from tests.integration.helper import check_output, clear, init_repository, yaml_processor
 
 
@@ -50,7 +51,7 @@ class MetadataPersistenceTests(unittest.TestCase):
                 'categories': ['computer-vision', 'images'],
                 'manifest': {
                     'files': 'MANIFEST.yaml',
-                    STORAGE_KEY: '%s://mlgit' % S3H
+                    STORAGE_SPEC_KEY: '%s://mlgit' % S3H
                 },
                 'mutability': STRICT,
                 'name': 'datasets-ex',

--- a/tests/integration/test_23_metadata_persistence.py
+++ b/tests/integration/test_23_metadata_persistence.py
@@ -8,7 +8,7 @@ import unittest
 
 import pytest
 
-from ml_git.constants import STORAGE_SPEC_KEY
+from ml_git.constants import STORAGE_SPEC_KEY, DATASET_SPEC_KEY
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_STATUS, MLGIT_ADD, MLGIT_PUSH, MLGIT_COMMIT, MLGIT_INIT, \
     MLGIT_REMOTE_ADD, MLGIT_ENTITY_INIT, MLGIT_CHECKOUT, MLGIT_STORAGE_ADD_WITH_TYPE
@@ -47,7 +47,7 @@ class MetadataPersistenceTests(unittest.TestCase):
             file.write('NEW2')
 
         spec = {
-            DATASETS: {
+            DATASET_SPEC_KEY: {
                 'categories': ['computer-vision', 'images'],
                 'manifest': {
                     'files': 'MANIFEST.yaml',
@@ -60,7 +60,7 @@ class MetadataPersistenceTests(unittest.TestCase):
         }
 
         with open(os.path.join(DATASETS, DATASET_NAME, 'datasets-ex.spec'), 'w') as y:
-            spec[DATASETS]['version'] = 17
+            spec[DATASET_SPEC_KEY]['version'] = 17
             yaml_processor.dump(spec, y)
 
         status = check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME))
@@ -97,7 +97,7 @@ class MetadataPersistenceTests(unittest.TestCase):
 
         with open(spec_file, 'r') as f:
             spec = yaml_processor.load(f)
-            self.assertEqual(spec[DATASETS]['version'], 17)
+            self.assertEqual(spec[DATASET_SPEC_KEY]['version'], 17)
 
         with open(readme, 'r') as f:
             self.assertEqual(f.read(), 'NEW2')

--- a/tests/integration/test_24_api.py
+++ b/tests/integration/test_24_api.py
@@ -10,8 +10,9 @@ import pytest
 
 from ml_git import api
 from ml_git.constants import EntityType, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY, DATE, RELATED_DATASET_TABLE_INFO, \
-    RELATED_LABELS_TABLE_INFO, TAG
+    RELATED_LABELS_TABLE_INFO, TAG, LABELS_SPEC_KEY, DATASET_SPEC_KEY
 from ml_git.ml_git_message import output_messages
+from ml_git.spec import get_spec_key
 from tests.integration.commands import MLGIT_INIT
 from tests.integration.helper import ML_GIT_DIR, check_output, init_repository, create_git_clone_repo, \
     clear, yaml_processor, create_zip_file, CLONE_FOLDER, GIT_PATH, BUCKET_NAME, PROFILE, STORAGE_TYPE, DATASETS, \
@@ -47,7 +48,7 @@ class APIAcceptanceTests(unittest.TestCase):
         os.makedirs(workspace, exist_ok=True)
 
         spec = {
-            DATASETS: {
+            DATASET_SPEC_KEY: {
                 'categories': ['computer-vision', 'images'],
                 'manifest': {
                     'files': 'MANIFEST.yaml',
@@ -230,7 +231,7 @@ class APIAcceptanceTests(unittest.TestCase):
         spec_path = os.path.join(entity, entity+'-ex', entity+'-ex.spec')
         with open(spec_path) as y:
             ws_spec = yaml_processor.load(y)
-            self.assertEqual(ws_spec[entity]['version'], version)
+            self.assertEqual(ws_spec[DATASET_SPEC_KEY]['version'], version)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_10_add_files(self):
@@ -278,17 +279,18 @@ class APIAcceptanceTests(unittest.TestCase):
         HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, LABELS, 'refs', 'labels-ex', 'HEAD')
         self.assertTrue(os.path.exists(HEAD))
 
-        self.assertEqual('computer-vision__images__datasets-ex__2', spec[LABELS][DATASETS]['tag'])
+        self.assertEqual('computer-vision__images__datasets-ex__2', spec[LABELS_SPEC_KEY][DATASET_SPEC_KEY]['tag'])
 
     def check_created_folders(self, entity_type, storage_type=S3H, version=1, bucket_name='fake_storage'):
         folder_data = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'data')
         spec = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', entity_type + '-ex.spec')
         readme = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'README.md')
+        entity_spec_key = get_spec_key(entity_type)
         with open(spec, 'r') as s:
             spec_file = yaml_processor.load(s)
-            self.assertEqual(spec_file[entity_type]['manifest'][STORAGE_SPEC_KEY], storage_type + '://' + bucket_name)
-            self.assertEqual(spec_file[entity_type]['name'], entity_type + '-ex')
-            self.assertEqual(spec_file[entity_type]['version'], version)
+            self.assertEqual(spec_file[entity_spec_key]['manifest'][STORAGE_SPEC_KEY], storage_type + '://' + bucket_name)
+            self.assertEqual(spec_file[entity_spec_key]['name'], entity_type + '-ex')
+            self.assertEqual(spec_file[entity_spec_key]['version'], version)
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as y:
             config = yaml_processor.load(y)
             self.assertIn(entity_type, config)

--- a/tests/integration/test_24_api.py
+++ b/tests/integration/test_24_api.py
@@ -9,7 +9,7 @@ import unittest
 import pytest
 
 from ml_git import api
-from ml_git.constants import STORAGE_KEY, EntityType
+from ml_git.constants import EntityType, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_INIT
 from tests.integration.helper import ML_GIT_DIR, check_output, init_repository, create_git_clone_repo, \
@@ -50,7 +50,7 @@ class APIAcceptanceTests(unittest.TestCase):
                 'categories': ['computer-vision', 'images'],
                 'manifest': {
                     'files': 'MANIFEST.yaml',
-                    STORAGE_KEY: '%s://mlgit' % S3H
+                    STORAGE_SPEC_KEY: '%s://mlgit' % S3H
                 },
                 'mutability': STRICT,
                 'name': DATASET_NAME,
@@ -285,7 +285,7 @@ class APIAcceptanceTests(unittest.TestCase):
         readme = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'README.md')
         with open(spec, 'r') as s:
             spec_file = yaml_processor.load(s)
-            self.assertEqual(spec_file[entity_type]['manifest'][STORAGE_KEY], storage_type + '://' + bucket_name)
+            self.assertEqual(spec_file[entity_type]['manifest'][STORAGE_SPEC_KEY], storage_type + '://' + bucket_name)
             self.assertEqual(spec_file[entity_type]['name'], entity_type + '-ex')
             self.assertEqual(spec_file[entity_type]['version'], version)
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as y:
@@ -359,11 +359,11 @@ class APIAcceptanceTests(unittest.TestCase):
         api.init('repository')
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
-            self.assertNotIn(S3H, config[STORAGE_KEY])
+            self.assertNotIn(S3H, config[STORAGE_CONFIG_KEY])
         api.storage_add(bucket_name=BUCKET_NAME, credentials=PROFILE)
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
-            self.assertEqual(PROFILE, config[STORAGE_KEY][S3H][BUCKET_NAME]['aws-credentials']['profile'])
+            self.assertEqual(PROFILE, config[STORAGE_CONFIG_KEY][S3H][BUCKET_NAME]['aws-credentials']['profile'])
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_22_add_storage_azure_type(self):
@@ -371,11 +371,11 @@ class APIAcceptanceTests(unittest.TestCase):
         api.init('repository')
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
-            self.assertNotIn(AZUREBLOBH, config[STORAGE_KEY])
+            self.assertNotIn(AZUREBLOBH, config[STORAGE_CONFIG_KEY])
         api.storage_add(bucket_name=bucket_name, bucket_type=AZUREBLOBH)
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
-            self.assertIn(bucket_name, config[STORAGE_KEY][AZUREBLOBH])
+            self.assertIn(bucket_name, config[STORAGE_CONFIG_KEY][AZUREBLOBH])
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_23_add_storage_gdrive_type(self):
@@ -384,11 +384,11 @@ class APIAcceptanceTests(unittest.TestCase):
         api.init('repository')
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
-            self.assertNotIn(GDRIVEH, config[STORAGE_KEY])
+            self.assertNotIn(GDRIVEH, config[STORAGE_CONFIG_KEY])
         api.storage_add(bucket_name=bucket_name, bucket_type=GDRIVEH, credentials=profile)
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
-            self.assertEqual(profile, config[STORAGE_KEY][GDRIVEH][bucket_name]['credentials-path'])
+            self.assertEqual(profile, config[STORAGE_CONFIG_KEY][GDRIVEH][bucket_name]['credentials-path'])
 
     def _initialize_entity(self, entity_type, git=GIT_PATH):
         api.init('repository')

--- a/tests/integration/test_26_mutability.py
+++ b/tests/integration/test_26_mutability.py
@@ -9,6 +9,7 @@ import unittest
 import pytest
 
 from ml_git.ml_git_message import output_messages
+from ml_git.spec import get_spec_key
 from tests.integration.commands import MLGIT_ADD, MLGIT_COMMIT, MLGIT_PUSH, MLGIT_UPDATE, MLGIT_CHECKOUT
 from tests.integration.helper import ML_GIT_DIR, create_spec, create_file, DATASETS, MODELS, LABELS, DATASET_TAG, STRICT, MUTABLE, FLEXIBLE
 from tests.integration.helper import check_output, clear, init_repository, ERROR_MESSAGE, yaml_processor
@@ -61,8 +62,9 @@ class MutabilityAcceptanceTests(unittest.TestCase):
 
         spec_with_categories = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', entity_type + '-ex.spec')
 
-        ws_spec = self._verify_mutability(entity_type, STRICT, spec_with_categories)
-        self._change_mutability(entity_type, FLEXIBLE, spec_with_categories, ws_spec)
+        entity_spec_key = get_spec_key(entity_type)
+        ws_spec = self._verify_mutability(entity_spec_key, STRICT, spec_with_categories)
+        self._change_mutability(entity_spec_key, FLEXIBLE, spec_with_categories, ws_spec)
 
         create_file(os.path.join(entity_type, entity_type+'-ex'), 'file2', '012')
 
@@ -76,8 +78,9 @@ class MutabilityAcceptanceTests(unittest.TestCase):
 
         spec_with_categories = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', entity_type + '-ex.spec')
 
-        ws_spec = self._verify_mutability(entity_type, FLEXIBLE, spec_with_categories)
-        self._change_mutability(entity_type, STRICT, spec_with_categories, ws_spec)
+        entity_spec_key = get_spec_key(entity_type)
+        ws_spec = self._verify_mutability(entity_spec_key, FLEXIBLE, spec_with_categories)
+        self._change_mutability(entity_spec_key, STRICT, spec_with_categories, ws_spec)
 
         create_file(os.path.join(self.tmp_dir, entity_type, entity_type+'-ex'), 'file2', '012')
 
@@ -91,8 +94,9 @@ class MutabilityAcceptanceTests(unittest.TestCase):
 
         spec_with_categories = os.path.join(self.tmp_dir, entity_type,  entity_type + '-ex', entity_type + '-ex.spec')
 
-        ws_spec = self._verify_mutability(entity_type, MUTABLE, spec_with_categories)
-        self._change_mutability(entity_type, STRICT, spec_with_categories, ws_spec)
+        entity_spec_key = get_spec_key(entity_type)
+        ws_spec = self._verify_mutability(entity_spec_key, MUTABLE, spec_with_categories)
+        self._change_mutability(entity_spec_key, STRICT, spec_with_categories, ws_spec)
 
         create_file(os.path.join(self.tmp_dir, entity_type, entity_type+'-ex'), 'file2', '012')
 

--- a/tests/integration/test_28_checkout_bare.py
+++ b/tests/integration/test_28_checkout_bare.py
@@ -8,6 +8,7 @@ import unittest
 
 import pytest
 
+from ml_git.constants import DATASET_SPEC_KEY
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_ADD, MLGIT_COMMIT, MLGIT_PUSH, MLGIT_UPDATE, MLGIT_CHECKOUT
 from tests.integration.helper import ML_GIT_DIR, ERROR_MESSAGE, DATASETS, DATASET_NAME, DATASET_TAG, STRICT, MUTABLE
@@ -159,7 +160,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
             spec = yaml_processor.load(y)
 
         with open(spec_path, 'w') as y:
-            spec[DATASETS]['version'] = 2
+            spec[DATASET_SPEC_KEY]['version'] = 2
             yaml_processor.dump(spec, y)
 
         self._push_files(entity_type)

--- a/tests/integration/test_33_config.py
+++ b/tests/integration/test_33_config.py
@@ -20,8 +20,8 @@ class ConfigAcceptanceTests(unittest.TestCase):
                       "\n 'index_path': '',\n 'labels': {'git': ''},\n 'metadata_path': '',\n 'mlgit_conf': 'config.yaml'," \
                       "\n 'mlgit_path': '.ml-git',\n 'models': {'git': ''},\n 'object_path': ''," \
                       "\n 'push_threads_count': "+str(push_threads_count)+",\n 'refs_path': ''," \
-                      "\n 'storage': {'s3': {'mlgit-datasets': {'aws-credentials': {'profile': 'default'}," \
-                      "\n                                       'region': 'us-east-1'}}},\n 'verbose': 'info'}"
+                      "\n 'storages': {'s3': {'mlgit-datasets': {'aws-credentials': {'profile': 'default'}," \
+                      "\n                                        'region': 'us-east-1'}}},\n 'verbose': 'info'}"
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_01_config_command(self):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,7 +16,7 @@ import pytest
 from git import Repo
 
 from ml_git.config import config_load
-from ml_git.constants import STORAGE_KEY, StorageType, EntityType, MutabilityType, FileType
+from ml_git.constants import StorageType, EntityType, MutabilityType, FileType, STORAGE_CONFIG_KEY
 
 test_scr = Path('./tests/unit/test_dir').resolve()
 
@@ -75,7 +75,7 @@ def write_config(git_path, path):
                 aws-credentials:
                     profile: mlgit
                 region: us-east-1
-    """ % (git_path, STORAGE_KEY)
+    """ % (git_path, STORAGE_CONFIG_KEY)
 
     os.makedirs(path, exist_ok=True)
     with open(os.path.join(path, 'config.yaml'), 'w') as config_yaml:
@@ -136,14 +136,14 @@ def yaml_str_sample(request):
                 aws-credentials:
                   profile: profile_test
                 region: region_test
-        """ % STORAGE_KEY
+        """ % STORAGE_CONFIG_KEY
     request.cls.yaml_str_sample = textwrap.dedent(doc)
 
 
 @pytest.fixture
 def yaml_obj_sample(request):
     obj = {
-        STORAGE_KEY: {
+        STORAGE_CONFIG_KEY: {
             S3H: {
                 'bucket_test': {
                     'aws-credentials': {

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -12,7 +12,7 @@ from unittest import mock
 import pytest
 
 from ml_git.admin import init_mlgit, remote_add, storage_add, clone_config_repository, storage_del, remote_del
-from ml_git.constants import STORAGE_KEY
+from ml_git.constants import STORAGE_CONFIG_KEY
 from ml_git.utils import yaml_load
 from tests.unit.conftest import AZUREBLOBH, DATASETS, S3
 
@@ -57,22 +57,22 @@ class AdminTestCases(unittest.TestCase):
         init_mlgit()
         storage_add(S3, 'bucket_test', 'personal')
         config_edit = yaml_load('.ml-git/config.yaml')
-        self.assertEqual(config_edit[STORAGE_KEY][S3]['bucket_test']['aws-credentials']['profile'], 'personal')
-        self.assertEqual(config_edit[STORAGE_KEY][S3]['bucket_test']['region'], None)
+        self.assertEqual(config_edit[STORAGE_CONFIG_KEY][S3]['bucket_test']['aws-credentials']['profile'], 'personal')
+        self.assertEqual(config_edit[STORAGE_CONFIG_KEY][S3]['bucket_test']['region'], None)
         s = storage_add('s4', 'bucket_test', 'personal')
         self.assertEqual(s, None)
         config = yaml_load('.ml-git/config.yaml')
-        self.assertTrue(S3 in config[STORAGE_KEY])
+        self.assertTrue(S3 in config[STORAGE_CONFIG_KEY])
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_storage_del(self):
         init_mlgit()
         storage_add(S3, 'bucket_test', 'personal')
         config_edit = yaml_load('.ml-git/config.yaml')
-        self.assertEqual(config_edit[STORAGE_KEY][S3]['bucket_test']['aws-credentials']['profile'], 'personal')
+        self.assertEqual(config_edit[STORAGE_CONFIG_KEY][S3]['bucket_test']['aws-credentials']['profile'], 'personal')
         storage_del(S3, 'bucket_test')
         config = yaml_load('.ml-git/config.yaml')
-        self.assertFalse(S3 in config[STORAGE_KEY] and 'bucket_test' in config[STORAGE_KEY][S3])
+        self.assertFalse(S3 in config[STORAGE_CONFIG_KEY] and 'bucket_test' in config[STORAGE_CONFIG_KEY][S3])
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_storage_add_check_type_azureblobh(self):
@@ -84,8 +84,8 @@ class AdminTestCases(unittest.TestCase):
     def check_storage(self, container, storage_type, tmpdir):
         storage_add(storage_type, container, 'personal')
         config_edit = yaml_load(os.path.join(tmpdir, '.ml-git/config.yaml'))
-        self.assertIn(storage_type, config_edit[STORAGE_KEY])
-        self.assertIn(container, config_edit[STORAGE_KEY][storage_type])
+        self.assertIn(storage_type, config_edit[STORAGE_CONFIG_KEY])
+        self.assertIn(container, config_edit[STORAGE_CONFIG_KEY][storage_type])
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_clone_local_git_server')
     def test_clone_config_repository(self):
@@ -125,15 +125,15 @@ class AdminTestCases(unittest.TestCase):
             storage_add(S3, 'bucket_test', 'personal', global_conf=True)
 
         config_edit = yaml_load('.mlgitconfig')
-        self.assertEqual(config_edit[STORAGE_KEY][S3]['bucket_test']['aws-credentials']['profile'], 'personal')
-        self.assertEqual(config_edit[STORAGE_KEY][S3]['bucket_test']['region'], None)
+        self.assertEqual(config_edit[STORAGE_CONFIG_KEY][S3]['bucket_test']['aws-credentials']['profile'], 'personal')
+        self.assertEqual(config_edit[STORAGE_CONFIG_KEY][S3]['bucket_test']['region'], None)
 
         with mock.patch('pathlib.Path.home', return_value=self.tmp_dir):
             s = storage_add('s4', 'bucket_test', 'personal', global_conf=True)
 
         self.assertEqual(s, None)
         config = yaml_load('.mlgitconfig')
-        self.assertTrue(S3 in config[STORAGE_KEY])
+        self.assertTrue(S3 in config[STORAGE_CONFIG_KEY])
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_storage_del_global_config(self):
@@ -142,25 +142,25 @@ class AdminTestCases(unittest.TestCase):
             storage_add(S3, 'bucket_test', 'personal', global_conf=True)
 
         config_edit = yaml_load('.mlgitconfig')
-        self.assertEqual(config_edit[STORAGE_KEY][S3]['bucket_test']['aws-credentials']['profile'], 'personal')
+        self.assertEqual(config_edit[STORAGE_CONFIG_KEY][S3]['bucket_test']['aws-credentials']['profile'], 'personal')
 
         with mock.patch('pathlib.Path.home', return_value=self.tmp_dir):
             storage_del(S3, 'bucket_test', global_conf=True)
 
         config = yaml_load('.mlgitconfig')
-        self.assertFalse(S3 in config[STORAGE_KEY] and 'bucket_test' in config[STORAGE_KEY][S3])
+        self.assertFalse(S3 in config[STORAGE_CONFIG_KEY] and 'bucket_test' in config[STORAGE_CONFIG_KEY][S3])
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_storage_add_without_credentials(self):
         init_mlgit()
         storage_add(S3, 'bucket_test', None)
         config_edit = yaml_load('.ml-git/config.yaml')
-        self.assertEqual(config_edit[STORAGE_KEY][S3]['bucket_test']['aws-credentials']['profile'], None)
-        self.assertEqual(config_edit[STORAGE_KEY][S3]['bucket_test']['region'], None)
+        self.assertEqual(config_edit[STORAGE_CONFIG_KEY][S3]['bucket_test']['aws-credentials']['profile'], None)
+        self.assertEqual(config_edit[STORAGE_CONFIG_KEY][S3]['bucket_test']['region'], None)
         s = storage_add('s4', 'bucket_test', 'personal')
         self.assertEqual(s, None)
         config = yaml_load('.ml-git/config.yaml')
-        self.assertTrue(S3 in config[STORAGE_KEY])
+        self.assertTrue(S3 in config[STORAGE_CONFIG_KEY])
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_remote_del(self):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -16,7 +16,7 @@ from ml_git.config import validate_config_spec_hash, get_sample_config_spec, get
     get_index_path, get_objects_path, get_cache_path, get_metadata_path, import_dir, \
     extract_storage_info_from_list, create_workspace_tree_structure, get_batch_size, merge_conf, \
     merge_local_with_global_config, mlgit_config, save_global_config_in_local, start_wizard_questions
-from ml_git.constants import BATCH_SIZE_VALUE, BATCH_SIZE, STORAGE_CONFIG_KEY, STORAGE_SPEC_KEY
+from ml_git.constants import BATCH_SIZE_VALUE, BATCH_SIZE, STORAGE_CONFIG_KEY, STORAGE_SPEC_KEY, DATASET_SPEC_KEY
 from ml_git.utils import get_root_path, yaml_load
 from tests.unit.conftest import DATASETS, LABELS, MODELS, STRICT, S3H, S3, GDRIVEH
 
@@ -55,44 +55,44 @@ class ConfigTestCases(unittest.TestCase):
         self.assertFalse(validate_spec_hash({}))
 
         # Non-integer version
-        spec[DATASETS]['version'] = 'string'
+        spec[DATASET_SPEC_KEY]['version'] = 'string'
         self.assertFalse(validate_spec_hash(spec))
 
         # Missing version
-        spec[DATASETS].pop('version')
+        spec[DATASET_SPEC_KEY].pop('version')
         self.assertFalse(validate_spec_hash(spec))
 
         # Missing dataset
-        spec.pop(DATASETS)
+        spec.pop(DATASET_SPEC_KEY)
         self.assertFalse(validate_spec_hash(spec))
 
         # Empty category list
         spec = get_sample_spec('somebucket')
-        spec[DATASETS]['categories'] = {}
+        spec[DATASET_SPEC_KEY]['categories'] = {}
         self.assertFalse(validate_spec_hash(spec))
 
         # Missing categories
-        spec[DATASETS].pop('categories')
+        spec[DATASET_SPEC_KEY].pop('categories')
         self.assertFalse(validate_spec_hash(spec))
 
         # Missing storage
         spec = get_sample_spec('somebucket')
-        spec[DATASETS]['manifest'].pop(STORAGE_SPEC_KEY)
+        spec[DATASET_SPEC_KEY]['manifest'].pop(STORAGE_SPEC_KEY)
         self.assertFalse(validate_spec_hash(spec))
 
         # Missing manifest
-        spec[DATASETS].pop('manifest')
+        spec[DATASET_SPEC_KEY].pop('manifest')
 
         # Bad bucket URL format
         spec = get_sample_spec('somebucket')
-        spec[DATASETS]['manifest'][STORAGE_SPEC_KEY] = 'invalid'
+        spec[DATASET_SPEC_KEY]['manifest'][STORAGE_SPEC_KEY] = 'invalid'
         self.assertFalse(validate_spec_hash(spec))
 
         # Missing and empty dataset name
         spec = get_sample_spec('somebucket')
-        spec[DATASETS]['name'] = ''
+        spec[DATASET_SPEC_KEY]['name'] = ''
         self.assertFalse(validate_spec_hash(spec))
-        spec[DATASETS].pop('name')
+        spec[DATASET_SPEC_KEY].pop('name')
         self.assertFalse(validate_spec_hash(spec))
 
     def test_config_verbose(self):
@@ -132,18 +132,18 @@ class ConfigTestCases(unittest.TestCase):
         root_path = get_root_path()
         IMPORT_PATH = os.path.join(os.getcwd(), 'test', 'src')
         os.makedirs(IMPORT_PATH)
-        self.assertTrue(create_workspace_tree_structure('repotype', 'artefact_name',
+        self.assertTrue(create_workspace_tree_structure(DATASETS, 'artefact_name',
                                                         ['imgs', 'old', 'blue'], S3H, 'minio', 2, IMPORT_PATH, STRICT))
 
-        spec_path = os.path.join(os.getcwd(), os.sep.join(['repotype', 'artefact_name', 'artefact_name.spec']))
+        spec_path = os.path.join(os.getcwd(), os.sep.join([DATASETS, 'artefact_name', 'artefact_name.spec']))
         spec1 = yaml_load(spec_path)
-        self.assertEqual(spec1['repotype']['manifest'][STORAGE_SPEC_KEY], 's3h://minio')
-        self.assertEqual(spec1['repotype']['name'], 'artefact_name')
-        self.assertEqual(spec1['repotype']['mutability'], STRICT)
-        self.assertEqual(spec1['repotype']['version'], 2)
+        self.assertEqual(spec1[DATASET_SPEC_KEY]['manifest'][STORAGE_SPEC_KEY], 's3h://minio')
+        self.assertEqual(spec1[DATASET_SPEC_KEY]['name'], 'artefact_name')
+        self.assertEqual(spec1[DATASET_SPEC_KEY]['mutability'], STRICT)
+        self.assertEqual(spec1[DATASET_SPEC_KEY]['version'], 2)
 
         shutil.rmtree(IMPORT_PATH)
-        shutil.rmtree(os.path.join(root_path, 'repotype'))
+        shutil.rmtree(os.path.join(root_path, DATASETS))
 
     @pytest.mark.usefixtures('restore_config')
     def test_get_batch_size(self):

--- a/tests/unit/test_dir/.ml-git/config.yaml
+++ b/tests/unit/test_dir/.ml-git/config.yaml
@@ -1,6 +1,6 @@
 datasets:
   git: git_local_server.git
-storage:
+storages:
   s3:
     mlgit-datasets:
       aws-credentials:

--- a/tests/unit/test_dir/datasets/dataex/dataex.spec
+++ b/tests/unit/test_dir/datasets/dataex/dataex.spec
@@ -1,4 +1,4 @@
-datasets:
+dataset:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/hdata/config.yaml
+++ b/tests/unit/test_dir/hdata/config.yaml
@@ -1,4 +1,4 @@
-storage:
+storages:
   s3h:
     ml-git-datasets:
       aws-credentials:

--- a/tests/unit/test_dir/hdata/dataset-ex.spec
+++ b/tests/unit/test_dir/hdata/dataset-ex.spec
@@ -1,4 +1,4 @@
-datasets:
+dataset:
   categories:
   - vision-computing
   - images

--- a/tests/unit/test_dir/hdata/dataset-spec-3.spec
+++ b/tests/unit/test_dir/hdata/dataset-spec-3.spec
@@ -1,4 +1,4 @@
-datasets:
+dataset:
   categories: x
   manifest:
     files: MANIFEST.yaml

--- a/tests/unit/test_dir/mdata/metadata/dataset-ex-2/dataset-ex-2.spec
+++ b/tests/unit/test_dir/mdata/metadata/dataset-ex-2/dataset-ex-2.spec
@@ -1,4 +1,4 @@
-datasets:
+dataset:
   categories:
   - vision-computing
   - images

--- a/tests/unit/test_dir/mdata/metadata/dataset-ex/dataset-ex.spec
+++ b/tests/unit/test_dir/mdata/metadata/dataset-ex/dataset-ex.spec
@@ -1,4 +1,4 @@
-datasets:
+dataset:
   categories:
   - vision-computing
   - images

--- a/tests/unit/test_dir/minit/datasets/index/metadata/dataset-ex/dataset-ex.spec
+++ b/tests/unit/test_dir/minit/datasets/index/metadata/dataset-ex/dataset-ex.spec
@@ -1,4 +1,4 @@
-datasets:
+dataset:
   categories: imgs
   manifest:
     storage: s3h://some-bucket-name

--- a/tests/unit/test_dir/specdata/bad1/invalid-name.spec
+++ b/tests/unit/test_dir/specdata/bad1/invalid-name.spec
@@ -1,4 +1,4 @@
-datasets:
+dataset:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/specdata/invalid2.spec
+++ b/tests/unit/test_dir/specdata/invalid2.spec
@@ -1,4 +1,4 @@
-datasets:
+dataset:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/specdata/invalid3.spec
+++ b/tests/unit/test_dir/specdata/invalid3.spec
@@ -1,4 +1,4 @@
-datasets:
+dataset:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/specdata/invalid4.spec
+++ b/tests/unit/test_dir/specdata/invalid4.spec
@@ -1,4 +1,4 @@
-datasets:
+dataset:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/specdata/noaa-severe-weather-inventory/noaa-severe-weather-inventory.spec
+++ b/tests/unit/test_dir/specdata/noaa-severe-weather-inventory/noaa-severe-weather-inventory.spec
@@ -1,4 +1,4 @@
-datasets:
+dataset:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/specdata/sample.spec
+++ b/tests/unit/test_dir/specdata/sample.spec
@@ -1,4 +1,4 @@
-datasets:
+dataset:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/specdata/valid.spec
+++ b/tests/unit/test_dir/specdata/valid.spec
@@ -1,4 +1,4 @@
-datasets:
+dataset:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/specdata/valid2.spec
+++ b/tests/unit/test_dir/specdata/valid2.spec
@@ -1,4 +1,4 @@
-datasets:
+dataset:
   categories:
   - weather
   manifest:

--- a/tests/unit/test_dir/udata/data.yaml
+++ b/tests/unit/test_dir/udata/data.yaml
@@ -1,6 +1,6 @@
 datasets:
   git: https://github.com/ANYTHING.tmp21j9vqp2.git
-storage:
+storages:
   s3:
     mlgit-datasets:
       aws-credentials:

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -14,6 +14,7 @@ import pytest
 from moto import mock_s3
 
 from ml_git.config import get_sample_config_spec, get_sample_spec
+from ml_git.constants import DATASET_SPEC_KEY, MODEL_SPEC_KEY
 from ml_git.file_system.cache import Cache
 from ml_git.file_system.hashfs import MultihashFS
 from ml_git.file_system.index import MultihashIndex, Status, FullIndex
@@ -22,7 +23,7 @@ from ml_git.file_system.objects import Objects
 from ml_git.sample import SampleValidate, SampleValidateException
 from ml_git.storages.s3_storage import S3Storage
 from ml_git.utils import yaml_load, yaml_save, ensure_path_exists, set_write_read
-from tests.unit.conftest import DATASETS, MODELS, STRICT, S3
+from tests.unit.conftest import MODELS, STRICT, S3
 
 hs = {
     'zdj7WWsMkELZSGQGgpm5VieCWV8NxY5n5XEP73H4E7eeDMA3A',
@@ -439,15 +440,15 @@ class LocalRepositoryTestCases(unittest.TestCase):
         spec_path = os.path.join(self.tmp_dir, 'model-ex.spec')
         shutil.copy('hdata/dataset-ex.spec', spec_path)
         spec_file = yaml_load(spec_path)
-        model = spec_file[DATASETS].copy()
-        del spec_file[DATASETS]
-        spec_file[MODELS] = model
+        model = spec_file[DATASET_SPEC_KEY].copy()
+        del spec_file[DATASET_SPEC_KEY]
+        spec_file[MODEL_SPEC_KEY] = model
         yaml_save(spec_file, spec_path)
         local_repo.add_metrics(spec_path, (('metric_a', '10'), ('metric_b', '9')), None)
 
         test_spec_file = yaml_load(spec_path)
-        self.assertTrue(test_spec_file[MODELS]['metrics'].get('metric_a', '') == 10.0)
-        self.assertTrue(test_spec_file[MODELS]['metrics'].get('metric_b', '') == 9.0)
+        self.assertTrue(test_spec_file[MODEL_SPEC_KEY]['metrics'].get('metric_a', '') == 10.0)
+        self.assertTrue(test_spec_file[MODEL_SPEC_KEY]['metrics'].get('metric_b', '') == 9.0)
 
     def test_add_metrics_wrong_entity(self):
         hashfs_path = os.path.join(self.tmp_dir, 'objectsfs')
@@ -457,7 +458,7 @@ class LocalRepositoryTestCases(unittest.TestCase):
         shutil.copy('hdata/dataset-ex.spec', spec_path)
         local_repo.add_metrics(spec_path, (('metric_a', '10'), ('metric_b', '9')), None)
         test_spec_file = yaml_load(spec_path)
-        self.assertFalse('metrics' in test_spec_file[DATASETS])
+        self.assertFalse('metrics' in test_spec_file[DATASET_SPEC_KEY])
 
     def test_add_metrics_with_none_metrics_options(self):
         hashfs_path = os.path.join(self.tmp_dir, 'objectsfs')
@@ -466,14 +467,14 @@ class LocalRepositoryTestCases(unittest.TestCase):
         spec_path = os.path.join(self.tmp_dir, 'model-ex.spec')
         shutil.copy('hdata/dataset-ex.spec', spec_path)
         spec_file = yaml_load(spec_path)
-        model = spec_file[DATASETS].copy()
-        del spec_file[DATASETS]
-        spec_file[MODELS] = model
+        model = spec_file[DATASET_SPEC_KEY].copy()
+        del spec_file[DATASET_SPEC_KEY]
+        spec_file[MODEL_SPEC_KEY] = model
         yaml_save(spec_file, spec_path)
         local_repo.add_metrics(spec_path, (), None)
 
         test_spec_file = yaml_load(spec_path)
-        self.assertFalse('metrics' in test_spec_file[MODELS])
+        self.assertFalse('metrics' in test_spec_file[MODEL_SPEC_KEY])
 
     @pytest.mark.usefixtures('create_csv_file')
     def test_add_metrics_file(self):
@@ -483,17 +484,17 @@ class LocalRepositoryTestCases(unittest.TestCase):
         spec_path = os.path.join(self.tmp_dir, 'model-ex.spec')
         shutil.copy('hdata/dataset-ex.spec', spec_path)
         spec_file = yaml_load(spec_path)
-        model = spec_file[DATASETS].copy()
-        del spec_file[DATASETS]
-        spec_file[MODELS] = model
+        model = spec_file[DATASET_SPEC_KEY].copy()
+        del spec_file[DATASET_SPEC_KEY]
+        spec_file[MODEL_SPEC_KEY] = model
         yaml_save(spec_file, spec_path)
         metrics_file_path = os.path.join(self.tmp_dir, 'metrics.csv')
         self.create_csv_file(metrics_file_path, {'metric_a': 10, 'metric_b': 9})
         local_repo.add_metrics(spec_path, (), metrics_file_path)
 
         test_spec_file = yaml_load(spec_path)
-        self.assertEqual(test_spec_file[MODELS]['metrics'].get('metric_a', ''), 10.0)
-        self.assertEqual(test_spec_file[MODELS]['metrics'].get('metric_b', ''), 9.0)
+        self.assertEqual(test_spec_file[MODEL_SPEC_KEY]['metrics'].get('metric_a', ''), 10.0)
+        self.assertEqual(test_spec_file[MODEL_SPEC_KEY]['metrics'].get('metric_b', ''), 9.0)
 
     def check_delete(self, s3, testbucketname):
         try:

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -13,8 +13,8 @@ import pytest
 from git import GitError, Repo
 from prettytable import PrettyTable
 
-from ml_git.constants import STORAGE_KEY, DATE, PERFORMANCE_KEY, TAG, RELATED_DATASET_TABLE_INFO, \
-    RELATED_LABELS_TABLE_INFO
+from ml_git.constants import DATE, PERFORMANCE_KEY, TAG, RELATED_DATASET_TABLE_INFO, \
+    RELATED_LABELS_TABLE_INFO, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY
 from ml_git.metadata import Metadata
 from ml_git.repository import Repository
 from ml_git.utils import clear, yaml_load_str, yaml_load
@@ -48,7 +48,7 @@ config = {
     },
 
 
-    STORAGE_KEY: {
+    STORAGE_CONFIG_KEY: {
         S3: {
             'mlgit-datasets': {
                 'region': 'us-east-1',
@@ -65,7 +65,7 @@ metadata_config = {
         'categories': 'images',
         'manifest': {
             'files': 'MANIFEST.yaml',
-            STORAGE_KEY: 's3h://ml-git-datasets'
+            STORAGE_SPEC_KEY: 's3h://ml-git-datasets'
         },
         'name': 'dataset_ex',
         'version': 1

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -14,7 +14,7 @@ from git import GitError, Repo
 from prettytable import PrettyTable
 
 from ml_git.constants import DATE, PERFORMANCE_KEY, TAG, RELATED_DATASET_TABLE_INFO, \
-    RELATED_LABELS_TABLE_INFO, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY
+    RELATED_LABELS_TABLE_INFO, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY, DATASET_SPEC_KEY, MODEL_SPEC_KEY
 from ml_git.metadata import Metadata
 from ml_git.repository import Repository
 from ml_git.utils import clear, yaml_load_str, yaml_load
@@ -61,7 +61,7 @@ config = {
 }
 
 metadata_config = {
-    DATASETS: {
+    DATASET_SPEC_KEY: {
         'categories': 'images',
         'manifest': {
             'files': 'MANIFEST.yaml',
@@ -243,9 +243,9 @@ class MetadataTestCases(unittest.TestCase):
         shutil.copy('hdata/dataset-ex.spec', spec_metadata_path)
 
         spec_file = yaml_load(spec_metadata_path)
-        spec_file[repo_type] = deepcopy(spec_file[DATASETS])
-        del spec_file[DATASETS]
-        spec_file[repo_type]['metrics'] = {'metric_1': 0, 'metric_2': 1}
+        spec_file[MODEL_SPEC_KEY] = deepcopy(spec_file[DATASET_SPEC_KEY])
+        del spec_file[DATASET_SPEC_KEY]
+        spec_file[MODEL_SPEC_KEY]['metrics'] = {'metric_1': 0, 'metric_2': 1}
         yaml_save(spec_file, spec_metadata_path)
 
         tag = 'vision-computer__images__model-ex__1'
@@ -277,8 +277,8 @@ class MetadataTestCases(unittest.TestCase):
         shutil.copy('hdata/dataset-ex.spec', spec_metadata_path)
 
         spec_file = yaml_load(spec_metadata_path)
-        spec_file[repo_type] = deepcopy(spec_file[DATASETS])
-        del spec_file[DATASETS]
+        spec_file[MODEL_SPEC_KEY] = deepcopy(spec_file[DATASET_SPEC_KEY])
+        del spec_file[DATASET_SPEC_KEY]
         yaml_save(spec_file,  spec_metadata_path)
 
         tag = 'vision-computer__images__model-ex__1'

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -9,7 +9,8 @@ import unittest
 
 import pytest
 
-from ml_git.constants import EntityType, StorageType, SPEC_EXTENSION, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY
+from ml_git.constants import EntityType, StorageType, SPEC_EXTENSION, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY, \
+    DATASET_SPEC_KEY
 from ml_git.spec import yaml_load, incr_version, is_valid_version, search_spec_file, SearchSpecException, spec_parse, \
     get_spec_file_dir, increment_version_in_spec, get_root_path, get_version, update_storage_spec, validate_bucket_name, \
     set_version_in_spec, get_entity_dir
@@ -26,10 +27,10 @@ class SpecTestCases(unittest.TestCase):
         file = os.path.join(testdir, 'sample.spec')
         spec_hash = yaml_load(file)
         yaml_save(spec_hash, tmpfile)
-        version = spec_hash[DATASETS]['version']
+        version = spec_hash[DATASET_SPEC_KEY]['version']
         incr_version(tmpfile)
         incremented_hash = yaml_load(tmpfile)
-        self.assertEqual(incremented_hash[DATASETS]['version'], version + 1)
+        self.assertEqual(incremented_hash[DATASET_SPEC_KEY]['version'], version + 1)
 
         incr_version('non-existent-file')
 
@@ -126,27 +127,26 @@ class SpecTestCases(unittest.TestCase):
 
         update_storage_spec(DATASETS, 'dataex', S3H, 'fakestorage')
         spec1 = yaml_load(spec_path)
-        self.assertEqual(spec1[DATASETS]['manifest'][STORAGE_SPEC_KEY], 's3h://fakestorage')
+        self.assertEqual(spec1[DATASET_SPEC_KEY]['manifest'][STORAGE_SPEC_KEY], 's3h://fakestorage')
 
         update_storage_spec(DATASETS, 'dataex', S3H, 'some-bucket-name')
         spec2 = yaml_load(spec_path)
-        self.assertEqual(spec2[DATASETS]['manifest'][STORAGE_SPEC_KEY], 's3h://some-bucket-name')
+        self.assertEqual(spec2[DATASET_SPEC_KEY]['manifest'][STORAGE_SPEC_KEY], 's3h://some-bucket-name')
 
     def test_validate_bucket_name(self):
-        repo_type = DATASETS
         config = yaml_load(os.path.join(os.getcwd(), '.ml-git', 'config.yaml'))
         spec_with_wrong_bucket_name = yaml_load(os.path.join(testdir, 'invalid4.spec'))
-        self.assertFalse(validate_bucket_name(spec_with_wrong_bucket_name[repo_type], config))
+        self.assertFalse(validate_bucket_name(spec_with_wrong_bucket_name[DATASET_SPEC_KEY], config))
 
         spec_bucket_name_not_in_config = yaml_load(os.path.join(testdir, 'valid.spec'))
-        self.assertFalse(validate_bucket_name(spec_bucket_name_not_in_config[repo_type], config))
+        self.assertFalse(validate_bucket_name(spec_bucket_name_not_in_config[DATASET_SPEC_KEY], config))
 
         storage = config[STORAGE_CONFIG_KEY][S3]
         del config[STORAGE_CONFIG_KEY][S3]
         config[STORAGE_CONFIG_KEY][S3H] = storage
 
         spec_with_bucket_in_config = yaml_load(os.path.join(testdir, 'valid2.spec'))
-        self.assertTrue(validate_bucket_name(spec_with_bucket_in_config[repo_type], config))
+        self.assertTrue(validate_bucket_name(spec_with_bucket_in_config[DATASET_SPEC_KEY], config))
 
     def test_set_version_in_spec(self):
         tmpfile = os.path.join(self.tmp_dir, 'sample.spec')
@@ -155,7 +155,7 @@ class SpecTestCases(unittest.TestCase):
         yaml_save(spec_hash, tmpfile)
         set_version_in_spec(3, tmpfile, DATASETS)
         spec_hash = yaml_load(tmpfile)
-        self.assertEqual(spec_hash[EntityType.DATASETS.value]['version'], 3)
+        self.assertEqual(spec_hash[DATASET_SPEC_KEY]['version'], 3)
 
     def test_update_storage_spec_with_entity_dir(self):
         entity_name = 'dataex'
@@ -169,8 +169,8 @@ class SpecTestCases(unittest.TestCase):
 
         update_storage_spec(entity_type, entity_name, StorageType.S3H.value, 'fakestorage', entity_dir)
         spec = yaml_load(spec_path)
-        self.assertEqual(spec[entity_type]['manifest'][STORAGE_SPEC_KEY], 's3h://fakestorage')
+        self.assertEqual(spec[DATASET_SPEC_KEY]['manifest'][STORAGE_SPEC_KEY], 's3h://fakestorage')
 
         update_storage_spec(entity_type, entity_name, StorageType.S3H.value, 'some-bucket-name', entity_dir)
         spec = yaml_load(spec_path)
-        self.assertEqual(spec[entity_type]['manifest'][STORAGE_SPEC_KEY], 's3h://some-bucket-name')
+        self.assertEqual(spec[DATASET_SPEC_KEY]['manifest'][STORAGE_SPEC_KEY], 's3h://some-bucket-name')

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -9,7 +9,7 @@ import unittest
 
 import pytest
 
-from ml_git.constants import EntityType, StorageType, STORAGE_KEY, SPEC_EXTENSION
+from ml_git.constants import EntityType, StorageType, SPEC_EXTENSION, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY
 from ml_git.spec import yaml_load, incr_version, is_valid_version, search_spec_file, SearchSpecException, spec_parse, \
     get_spec_file_dir, increment_version_in_spec, get_root_path, get_version, update_storage_spec, validate_bucket_name, \
     set_version_in_spec, get_entity_dir
@@ -126,11 +126,11 @@ class SpecTestCases(unittest.TestCase):
 
         update_storage_spec(DATASETS, 'dataex', S3H, 'fakestorage')
         spec1 = yaml_load(spec_path)
-        self.assertEqual(spec1[DATASETS]['manifest'][STORAGE_KEY], 's3h://fakestorage')
+        self.assertEqual(spec1[DATASETS]['manifest'][STORAGE_SPEC_KEY], 's3h://fakestorage')
 
         update_storage_spec(DATASETS, 'dataex', S3H, 'some-bucket-name')
         spec2 = yaml_load(spec_path)
-        self.assertEqual(spec2[DATASETS]['manifest'][STORAGE_KEY], 's3h://some-bucket-name')
+        self.assertEqual(spec2[DATASETS]['manifest'][STORAGE_SPEC_KEY], 's3h://some-bucket-name')
 
     def test_validate_bucket_name(self):
         repo_type = DATASETS
@@ -141,9 +141,9 @@ class SpecTestCases(unittest.TestCase):
         spec_bucket_name_not_in_config = yaml_load(os.path.join(testdir, 'valid.spec'))
         self.assertFalse(validate_bucket_name(spec_bucket_name_not_in_config[repo_type], config))
 
-        storage = config[STORAGE_KEY][S3]
-        del config[STORAGE_KEY][S3]
-        config[STORAGE_KEY][S3H] = storage
+        storage = config[STORAGE_CONFIG_KEY][S3]
+        del config[STORAGE_CONFIG_KEY][S3]
+        config[STORAGE_CONFIG_KEY][S3H] = storage
 
         spec_with_bucket_in_config = yaml_load(os.path.join(testdir, 'valid2.spec'))
         self.assertTrue(validate_bucket_name(spec_with_bucket_in_config[repo_type], config))
@@ -169,8 +169,8 @@ class SpecTestCases(unittest.TestCase):
 
         update_storage_spec(entity_type, entity_name, StorageType.S3H.value, 'fakestorage', entity_dir)
         spec = yaml_load(spec_path)
-        self.assertEqual(spec[entity_type]['manifest'][STORAGE_KEY], 's3h://fakestorage')
+        self.assertEqual(spec[entity_type]['manifest'][STORAGE_SPEC_KEY], 's3h://fakestorage')
 
         update_storage_spec(entity_type, entity_name, StorageType.S3H.value, 'some-bucket-name', entity_dir)
         spec = yaml_load(spec_path)
-        self.assertEqual(spec[entity_type]['manifest'][STORAGE_KEY], 's3h://some-bucket-name')
+        self.assertEqual(spec[entity_type]['manifest'][STORAGE_SPEC_KEY], 's3h://some-bucket-name')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,7 +14,7 @@ import humanize
 import pytest
 import yaml
 
-from ml_git.constants import ROOT_FILE_NAME, V1_STORAGE_KEY, STORAGE_KEY, V1_DATASETS_KEY, V1_MODELS_KEY
+from ml_git.constants import ROOT_FILE_NAME, V1_STORAGE_KEY, V1_DATASETS_KEY, V1_MODELS_KEY, STORAGE_CONFIG_KEY
 from ml_git.utils import json_load, yaml_load, yaml_save, RootPathException, get_root_path, change_mask_for_routine, \
     ensure_path_exists, yaml_load_str, get_yaml_str, run_function_per_group, unzip_files_in_directory, \
     remove_from_workspace, group_files_by_path, remove_other_files, remove_unnecessary_files, change_keys_in_config, \
@@ -38,16 +38,16 @@ class UtilsTestCases(unittest.TestCase):
         self.assertFalse(bool(yal))
         yal = yaml_load('./udata/data.yaml')
         self.assertTrue(bool(yal))
-        self.assertEqual(yal[STORAGE_KEY][S3]['mlgit-datasets']['region'], 'us-east-1')
+        self.assertEqual(yal[STORAGE_CONFIG_KEY][S3]['mlgit-datasets']['region'], 'us-east-1')
 
     def test_yaml_load_str(self):
         obj = yaml_load_str(self.yaml_str_sample)
-        self.assertEqual(obj[STORAGE_KEY][S3H]['bucket_test']['aws-credentials']['profile'], 'profile_test')
-        self.assertEqual(obj[STORAGE_KEY][S3H]['bucket_test']['region'], 'region_test')
+        self.assertEqual(obj[STORAGE_CONFIG_KEY][S3H]['bucket_test']['aws-credentials']['profile'], 'profile_test')
+        self.assertEqual(obj[STORAGE_CONFIG_KEY][S3H]['bucket_test']['region'], 'region_test')
 
     def test_get_yaml_str(self):
-        self.assertEqual(self.yaml_obj_sample[STORAGE_KEY][S3H]['bucket_test']['aws-credentials']['profile'], 'profile_test')
-        self.assertEqual(self.yaml_obj_sample[STORAGE_KEY][S3H]['bucket_test']['region'], 'region_test')
+        self.assertEqual(self.yaml_obj_sample[STORAGE_CONFIG_KEY][S3H]['bucket_test']['aws-credentials']['profile'], 'profile_test')
+        self.assertEqual(self.yaml_obj_sample[STORAGE_CONFIG_KEY][S3H]['bucket_test']['region'], 'region_test')
         self.assertEqual(get_yaml_str(self.yaml_obj_sample), self.yaml_str_sample)
 
     def test_yaml_save(self):
@@ -210,13 +210,13 @@ class UtilsTestCases(unittest.TestCase):
            git: fake_git_repository
         model:
            git: fake_git_repository
-        %s:
+        store:
             s3:
                 mlgit-datasets:
                     aws-credentials:
                         profile: mlgit
                     region: us-east-1
-        """ % STORAGE_KEY
+        """
         config_path = os.path.join(self.tmp_dir, ROOT_FILE_NAME, 'config.yaml')
         os.makedirs(os.path.join(self.tmp_dir, ROOT_FILE_NAME), exist_ok=True)
         with open(config_path, 'w') as config_yaml:
@@ -228,7 +228,7 @@ class UtilsTestCases(unittest.TestCase):
         self.assertNotIn(V1_MODELS_KEY, conf)
         self.assertIn(MODELS, conf)
         self.assertNotIn(V1_STORAGE_KEY, conf)
-        self.assertIn(STORAGE_KEY, conf)
+        self.assertIn(STORAGE_CONFIG_KEY, conf)
 
     def test_update_directories_to_plural(self):
         data_path = os.path.join(self.tmp_dir, V1_DATASETS_KEY)
@@ -256,11 +256,11 @@ class UtilsTestCases(unittest.TestCase):
                         profile: mlgit
                     region: us-east-1
         """
-        self.assertTrue(validate_config_keys(yaml.safe_load(config % (DATASETS, MODELS, STORAGE_KEY))))
+        self.assertTrue(validate_config_keys(yaml.safe_load(config % (DATASETS, MODELS, STORAGE_CONFIG_KEY))))
         self.assertFalse(validate_config_keys(yaml.safe_load(config % (V1_DATASETS_KEY, V1_MODELS_KEY, V1_STORAGE_KEY))))
         self.assertFalse(validate_config_keys(yaml.safe_load(config % (DATASETS, MODELS, V1_STORAGE_KEY))))
-        self.assertFalse(validate_config_keys(yaml.safe_load(config % (DATASETS, V1_MODELS_KEY, STORAGE_KEY))))
-        self.assertFalse(validate_config_keys(yaml.safe_load(config % (V1_DATASETS_KEY, MODELS, STORAGE_KEY))))
+        self.assertFalse(validate_config_keys(yaml.safe_load(config % (DATASETS, V1_MODELS_KEY, STORAGE_CONFIG_KEY))))
+        self.assertFalse(validate_config_keys(yaml.safe_load(config % (V1_DATASETS_KEY, MODELS, STORAGE_CONFIG_KEY))))
 
     def test_create_csv_file(self):
         csv_file_path = os.path.join(self.tmp_dir, 'metrics-file.csv')


### PR DESCRIPTION
Some keys in the specification files (config and specs) have been changed to better match their content.

**config.yaml example:**
```
datasets:
  git: 'https://github.com/user/mlgit-datasets.git'
labels:
  git: 'https://github.com/user/mlgit-labels.git'
models:
  git: 'https://github.com/user/mlgit-models.git'
storages: <- Changed from 'storage' to 'storages' here
  s3:
    mlgit-datasets:
      aws-credentials:
        profile: default
      region: us-east-1
```

**.spec example:**
```
model: <- Changed to use singular (model and dataset instead of models and datasets)
  categories:
  - test
  dataset: <- Changed to use singular 
    sha: ed638cf8a29f5a88a0a0e2497c82c709f353a976
    tag: test__dataset-ex__1
  labels:
    sha: 3b753fb443ffce89badec0f8c2cf1a8edda53bb1
    tag: test__labels-ex__1
  manifest:
    amount: 1
    files: MANIFEST.yaml
    size: 0 Bytes
    storage: s3h://mlgit-datasets
  mutability: strict
  name: model-ex
  version: 1
```


**bugfix:** 

With these changes, a reported bug has also been fixed. When trying to checkout a labels/models with a related dataset (which have been versioned with the ml-git version 1 schema), ml-git cannot find the tag of the related entity to download:

```
WARNING - MLGit: Repository: the datasets does not exist for related download.
```

This error is caused by a difference between the keys that were stored in the specifications file. In version 1, we stored `dataset`, in version 2 `datasets`. After these changes, both versions have the same key (`dataset`).