### PR TITLE
Fixing the checkout by the API when using the entity name

### DIFF
--- a/ml_git/api.py
+++ b/ml_git/api.py
@@ -4,6 +4,7 @@ SPDX-License-Identifier: GPL-2.0-only
 """
 
 import os
+import re
 import shutil
 import tempfile
 
@@ -11,7 +12,7 @@ from ml_git import admin
 from ml_git import log
 from ml_git.admin import init_mlgit
 from ml_git.config import config_load
-from ml_git.constants import EntityType, StorageType, FileType
+from ml_git.constants import EntityType, StorageType, FileType, RGX_TAG_FORMAT
 from ml_git.log import init_logger
 from ml_git.ml_git_message import output_messages
 from ml_git.repository import Repository
@@ -79,8 +80,10 @@ def checkout(entity, tag, sampling=None, retries=2, force=False, dataset=False, 
     options['version'] = version
     repo.checkout(tag, sampling, options)
 
-    _, specname, _ = spec_parse(tag)
-    spec_path, _ = search_spec_file(entity, specname)
+    spec_name = tag
+    if re.search(RGX_TAG_FORMAT, tag):
+        _, spec_name, _ = spec_parse(tag)
+    spec_path, _ = search_spec_file(entity, spec_name)
     data_path = os.path.relpath(spec_path, get_root_path())
     if not os.path.exists(data_path):
         data_path = None

--- a/tests/integration/test_24_api.py
+++ b/tests/integration/test_24_api.py
@@ -467,3 +467,12 @@ class APIAcceptanceTests(unittest.TestCase):
         tag_values = '{},,,10.0,10.0'.format(model_tag)
         self.assertIn(header, data_output.getvalue())
         self.assertIn(tag_values, data_output.getvalue())
+
+    @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
+    def test_31_checkout_with_entity_name(self):
+        self.set_up_test()
+        data_path = api.checkout(DATASETS, DATASET_NAME)
+        self.assertEqual(self.data_path, data_path)
+        self.check_metadata()
+        self.assertTrue(os.path.exists(self.file1))
+        self.assertTrue(os.path.exists(self.file2))


### PR DESCRIPTION
An error is presented when an entity is checked out, through the API, passing the entity name in place of the tag.

**Observed behavior:**
```
>>> api.checkout('datasets', 'dataset-ex')
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "d:\virtus\public-hp\ml-git\ml_git\api.py", line 82, in checkout
    _, specname, _ = spec_parse(tag)
  File "d:\virtus\public-hp\ml-git\ml_git\spec.py", line 45, in spec_parse
    raise SearchSpecException(output_messages['ERROR_TAG_INVALID_FORMAT'] % specs)
ml_git.spec.SearchSpecException: Tag ['dataset-ex'] invalid format.
```

**Fixed behavior:**
```
>>> api.checkout('datasets', 'dataset-ex')
INFO - Metadata Manager: Pull [/api_scripts/.ml-git/datasets/metadata]
INFO - Metadata: Performing checkout on the entity's lastest tag (test__dataset-ex__1)
blobs: 100%|██████████| 2.00/2.00 [00:00<00:00, 186blobs/s]
chunks: 100%|██████████| 2.00/2.00 [00:00<00:00, 2.24chunks/s]
files into workspace: 100%|██████████| 2.00/2.00 [00:00<00:00, 12.6files into workspace/s]
```