### PR TITLE
Improvement in bumpversion option

### DIFF
--- a/ml_git/metadata.py
+++ b/ml_git/metadata.py
@@ -280,7 +280,7 @@ class Metadata(MetadataManager):
             tags = self.list_tags(entity)
             if len(tags) == 0:
                 raise RuntimeError(output_messages['ERROR_WITHOUT_TAG_FOR_THIS_ENTITY'])
-            target_tag = self._get_target_tag(tags, entity, version)
+            target_tag = self._get_target_tag(tags, version)
             if version == -1:
                 log.info(output_messages['INFO_CHECKOUT_LATEST_TAG'] % target_tag, class_name=METADATA_CLASS_NAME)
             else:
@@ -290,11 +290,22 @@ class Metadata(MetadataManager):
             log.error(e, class_name=METADATA_CLASS_NAME)
             return None
 
-    def _get_target_tag(self, tags, entity, target_version):
+    def get_last_tag_version(self, entity):
+        tags = self.list_tags(entity)
+        if len(tags) == 0:
+            return 0
+        last_version = -1
+        last_tag = self._get_target_tag(tags, last_version)
+        last_version = last_tag.split('__')[-1]
+        return int(last_version)
+
+    @staticmethod
+    def _get_target_tag(tags, target_version):
         tags_versions = {}
         for tag in tags:
             splitted_tag = tag.split('__')
             version = splitted_tag[-1]
+            entity = splitted_tag[-2]
             categories_path = splitted_tag[:-2]
             if (target_version == int(version)) or (target_version == -1):
                 tags_versions['__'.join(categories_path)] = entity + '__' + version

--- a/ml_git/spec.py
+++ b/ml_git/spec.py
@@ -54,7 +54,7 @@ def spec_parse(spec):
 """Increment the version number inside the given dataset specification file."""
 
 
-def incr_version(file, target_version, repo_type=DATASETS):
+def increment_version(file, target_version, repo_type=DATASETS):
     spec_hash = utils.yaml_load(file)
     entity_spec_key = get_spec_key(repo_type)
     if is_valid_version(spec_hash, entity_spec_key):
@@ -115,8 +115,8 @@ def increment_version_in_spec(spec_path, target_version, repotype=DATASETS):
         raise RuntimeError(output_messages['ERROR_NO_NAME_PROVIDED'] % repotype)
 
     if os.path.exists(spec_path):
-        increment_version = incr_version(spec_path, target_version, repotype)
-        if increment_version == -1:
+        new_version = increment_version(spec_path, target_version, repotype)
+        if new_version == -1:
             raise RuntimeError(output_messages['ERROR_INCREMENTING_VERSION'] % spec_path)
     else:
         raise RuntimeError(output_messages['ERROR_SPEC_FILE_NOT_FOUND'] % spec_path)

--- a/tests/integration/test_05_add_files.py
+++ b/tests/integration/test_05_add_files.py
@@ -11,12 +11,14 @@ import pytest
 
 from ml_git.ml_git_message import output_messages
 from ml_git.spec import get_spec_key
+from ml_git.utils import ensure_path_exists
+from tests.integration.commands import MLGIT_COMMIT, MLGIT_PUSH, MLGIT_CHECKOUT
 from tests.integration.helper import ML_GIT_DIR, create_spec, init_repository, ERROR_MESSAGE, MLGIT_ADD, \
     create_file, DATASETS, DATASET_NAME, MODELS, LABELS
 from tests.integration.helper import clear, check_output, add_file, entity_init, yaml_processor
 
 
-@pytest.mark.usefixtures('tmp_dir')
+@pytest.mark.usefixtures('tmp_dir', 'aws_session')
 class AddFilesAcceptanceTests(unittest.TestCase):
 
     def set_up_add(self, repo_type=DATASETS):
@@ -179,3 +181,40 @@ class AddFilesAcceptanceTests(unittest.TestCase):
             self.assertFalse(metrics == {})
             self.assertTrue(metrics['Accuracy'] == 1)
             self.assertTrue(metrics['Recall'] == 2)
+
+    def _push_tag_to_repositroy(self, entity, entity_path, file_name):
+        file_value = '1'
+        entity_name = '{}-ex'.format(entity)
+        create_file(entity_path, file_name, file_value, file_path='')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % (entity, entity_name, ' --bumpversion')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (entity, entity_name, '')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_PUSH % (entity, entity_name)))
+
+    def _check_spec_version(self, repo_type, expected_version):
+        entity_name = '{}-ex'.format(repo_type)
+        workspace = os.path.join(self.tmp_dir, DATASETS, entity_name)
+        with open(os.path.join(workspace, entity_name + '.spec')) as spec:
+            spec_file = yaml_processor.load(spec)
+            spec_key = get_spec_key(repo_type)
+            version = spec_file[spec_key].get('version', 0)
+            self.assertEquals(version, expected_version)
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_11_add_with_bumpversion_in_older_tag(self):
+        repo_type = DATASETS
+        entity_name = '{}-ex'.format(repo_type)
+        init_repository(repo_type, self)
+        entity_path = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME)
+        ensure_path_exists(entity_path)
+        self._push_tag_to_repositroy(repo_type, entity_path, 'first_tag')
+        self._push_tag_to_repositroy(repo_type, entity_path, 'second_tag')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (repo_type, entity_name + ' --version=1')))
+        self._check_spec_version(repo_type, 1)
+        add_file(self, repo_type, '--bumpversion', 'third_tag')
+        self._check_spec_version(repo_type, 3)
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_12_first_add_with_bumpversion(self):
+        init_repository(DATASETS, self)
+        add_file(self, DATASETS, '--bumpversion', 'new')
+        self._check_spec_version(DATASETS, 1)

--- a/tests/integration/test_06_commit_files.py
+++ b/tests/integration/test_06_commit_files.py
@@ -90,19 +90,19 @@ class CommitFilesAcceptanceTests(unittest.TestCase):
                       check_output(MLGIT_COMMIT % (LABELS, LABELS + '-ex', ' --version=9999999999')))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
-    def test_05_commit_tag_that_already_exists(self):
+    def test_07_commit_tag_that_already_exists(self):
         entity_type = DATASETS
         self._commit_entity(entity_type)
         with open(os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'newfile5'), 'wt') as z:
             z.write(str('0' * 100))
         self.assertIn(output_messages['INFO_ADDING_PATH'] % DATASETS, check_output(MLGIT_ADD % (entity_type, entity_type+'-ex', '')))
-        self.assertIn(output_messages['INFO_TAG_ALREADY_EXISTS'] % 'computer-vision__images__datasets-ex__2',
+        self.assertIn(output_messages['INFO_TAG_ALREADY_EXISTS'] % 'computer-vision__images__datasets-ex__1',
                       check_output(MLGIT_COMMIT % (entity_type, entity_type+'-ex', '')))
         head_path = os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'refs', entity_type + '-ex', 'HEAD')
         self.assertTrue(os.path.exists(head_path))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
-    def test_06_commit_entity_with_changed_dir(self):
+    def test_08_commit_entity_with_changed_dir(self):
         self._commit_entity(DATASETS)
         create_file(os.path.join(DATASETS, DATASET_NAME), 'newfile5', '0', '')
         move_entity_to_dir(self.tmp_dir, DATASET_NAME, DATASETS)

--- a/tests/integration/test_07_push_files.py
+++ b/tests/integration/test_07_push_files.py
@@ -40,7 +40,7 @@ class PushFilesAcceptanceTests(unittest.TestCase):
         os.chdir(metadata_path)
         self.assertTrue(os.path.exists(
             os.path.join(MINIO_BUCKET_PATH, 'zdj7WWjGAAJ8gdky5FKcVLfd63aiRUGb8fkc8We2bvsp9WW12')))
-        self.assertIn('computer-vision__images__' + entity_type + '-ex__2', check_output('git describe --tags'))
+        self.assertIn('computer-vision__images__' + entity_type + '-ex__1', check_output('git describe --tags'))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_push_files_to_dataset(self):

--- a/tests/integration/test_08_checkout_tag.py
+++ b/tests/integration/test_08_checkout_tag.py
@@ -307,7 +307,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         clear(os.path.join(self.tmp_dir, '.ml-git', LABELS))
         self.assertIn(output_messages['INFO_METADATA_INIT'] % (git_server, os.path.join(self.tmp_dir, '.ml-git', MODELS, 'metadata')),
                       check_output(MLGIT_ENTITY_INIT % MODELS))
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (MODELS, 'computer-vision__images__models-ex__2')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_CHECKOUT % (MODELS, 'computer-vision__images__models-ex__1')
                                                      + ' -d -l'))
         self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, MODELS)))
         self.assertTrue(os.path.exists(os.path.join(self.tmp_dir, DATASETS)))

--- a/tests/integration/test_11_list_tag.py
+++ b/tests/integration/test_11_list_tag.py
@@ -23,7 +23,7 @@ class ListTagAcceptanceTests(unittest.TestCase):
         self.assertIn(output_messages['INFO_COMMIT_REPO'] % (os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'metadata'), entity_type+'-ex'),
                       check_output(MLGIT_COMMIT % (entity_type, entity_type+'-ex', '')))
         check_output(MLGIT_PUSH % (entity_type, entity_type+'-ex'))
-        self.assertIn('computer-vision__images__' + entity_type + '-ex__2',
+        self.assertIn('computer-vision__images__' + entity_type + '-ex__1',
                       check_output(MLGIT_TAG_LIST % (entity_type, entity_type+'-ex')))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')

--- a/tests/integration/test_12_reset_command.py
+++ b/tests/integration/test_12_reset_command.py
@@ -17,7 +17,7 @@ from tests.integration.helper import check_output, init_repository, ERROR_MESSAG
 
 @pytest.mark.usefixtures('tmp_dir')
 class ResetAcceptanceTests(unittest.TestCase):
-    dataset_tag = 'computer-vision__images__datasets-ex__2'
+    dataset_tag = 'computer-vision__images__datasets-ex__1'
 
     def set_up_reset(self):
         init_repository(DATASETS, self)
@@ -62,7 +62,7 @@ class ResetAcceptanceTests(unittest.TestCase):
                       check_output(MLGIT_RESET % (DATASETS, DATASET_NAME) + ' --hard --reference=head'))
         self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
                          r'Changes to be committed:\n\tNew file: datasets-ex.spec\n\nUntracked files:\n\nCorrupted files:')
-        self._check_dir('computer-vision__images__datasets-ex__3')
+        self._check_dir('computer-vision__images__datasets-ex__2')
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_hard_with_HEAD1(self):

--- a/tests/integration/test_16_show.py
+++ b/tests/integration/test_16_show.py
@@ -22,7 +22,7 @@ class ShowAcceptanceTests(unittest.TestCase):
         self.assertIn(output_messages['INFO_COMMIT_REPO'] % (os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'metadata'), entity_type+'-ex'),
                       check_output(MLGIT_COMMIT % (entity_type, entity_type+'-ex', '')))
         expected_result = 'files: MANIFEST.yaml\n  size: 14.5 kB\n  storage: s3h://mlgit' \
-                          '\nmutability: strict\nname: %s-ex\nversion: %s\n\n' % (entity_type, 2)
+                          '\nmutability: strict\nname: %s-ex\nversion: %s\n\n' % (entity_type, 1)
         self.assertIn(expected_result, check_output(MLGIT_SHOW % (entity_type, entity_type+'-ex')))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')

--- a/tests/integration/test_24_api.py
+++ b/tests/integration/test_24_api.py
@@ -56,7 +56,7 @@ class APIAcceptanceTests(unittest.TestCase):
                 },
                 'mutability': STRICT,
                 'name': DATASET_NAME,
-                'version': 9
+                'version': 10
             }
         }
 
@@ -70,7 +70,7 @@ class APIAcceptanceTests(unittest.TestCase):
         self.create_file(workspace, 'file3', 'a')
         self.create_file(workspace, 'file4', 'b')
 
-        api.add(DATASETS, DATASET_NAME, bumpversion=True)
+        api.add(DATASETS, DATASET_NAME)
         api.commit(DATASETS, DATASET_NAME)
         api.push(DATASETS, DATASET_NAME)
 
@@ -243,10 +243,12 @@ class APIAcceptanceTests(unittest.TestCase):
     def test_11_add_files_with_bumpversion(self):
         self.set_up_add_test()
         self.check_entity_version(1)
-
+        api.add(DATASETS, DATASET_NAME, fsck=False, file_path=[])
+        api.commit(DATASETS, DATASET_NAME)
+        file_name = 'new-file-test'
+        self.create_file_in_ws(DATASETS, file_name, '0')
         api.add(DATASETS, DATASET_NAME, bumpversion=True, fsck=False, file_path=[])
-
-        self.check_add()
+        self.check_add(files=[file_name])
         self.check_entity_version(2)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
@@ -279,7 +281,7 @@ class APIAcceptanceTests(unittest.TestCase):
         HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, LABELS, 'refs', 'labels-ex', 'HEAD')
         self.assertTrue(os.path.exists(HEAD))
 
-        self.assertEqual('computer-vision__images__datasets-ex__2', spec[LABELS_SPEC_KEY][DATASET_SPEC_KEY]['tag'])
+        self.assertEqual('computer-vision__images__datasets-ex__11', spec[LABELS_SPEC_KEY][DATASET_SPEC_KEY]['tag'])
 
     def check_created_folders(self, entity_type, storage_type=S3H, version=1, bucket_name='fake_storage'):
         folder_data = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'data')

--- a/tests/integration/test_28_checkout_bare.py
+++ b/tests/integration/test_28_checkout_bare.py
@@ -167,7 +167,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
 
         self._clear_path()
 
-        self._checkout_entity(entity_type, tag='computer-vision__images__'+entity_type+'-ex__3', bare=False)
+        self._checkout_entity(entity_type, tag='computer-vision__images__'+entity_type+'-ex__2', bare=False)
 
         file_path = os.path.join(self.tmp_dir, entity_type, entity_type+'-ex', 'data')
         self.assertTrue(os.path.exists(os.path.join(file_path, 'file1')))

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -141,10 +141,10 @@ class MetadataTestCases(unittest.TestCase):
                 'computer__images__dataset-ex__2',
                 'computer__videos__dataset-ex__1']
         m = Metadata('', self.test_dir, config, DATASETS)
-        self.assertRaises(RuntimeError, lambda: m._get_target_tag(tags, 'dataset-ex', -1))
-        self.assertRaises(RuntimeError, lambda: m._get_target_tag(tags, 'dataset-ex', 1))
-        self.assertRaises(RuntimeError, lambda: m._get_target_tag(tags, 'dataset-wrong', 1))
-        self.assertEqual(m._get_target_tag(tags, 'dataset-ex', 2), 'computer__images__dataset-ex__2')
+        self.assertRaises(RuntimeError, lambda: m._get_target_tag(tags, -1))
+        self.assertRaises(RuntimeError, lambda: m._get_target_tag(tags, 1))
+        self.assertRaises(RuntimeError, lambda: m._get_target_tag(tags, 1))
+        self.assertEqual(m._get_target_tag(tags, 2), 'computer__images__dataset-ex__2')
         clear(m.path)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_test_dir')
@@ -343,3 +343,21 @@ class MetadataTestCases(unittest.TestCase):
         self.assertIn('{},{},{},{},accuracy'.format(DATE, TAG, RELATED_DATASET_TABLE_INFO, RELATED_LABELS_TABLE_INFO),
                       data.getvalue())
         self.assertIn(',,,,10.0', data.getvalue())
+
+    @pytest.mark.usefixtures('switch_to_test_dir')
+    def test_last_tag_version(self):
+        specpath = 'dataset-ex'
+        config['mlgit_path'] = self.test_dir
+        m = Metadata('', '', config, DATASETS)
+        m.init()
+
+        tag_list = ['computer__images__dataset-ex__1', 'computer__images__dataset-ex__2']
+        with mock.patch('ml_git.metadata.Metadata.list_tags', return_value=tag_list):
+            last_version = m.get_last_tag_version(specpath)
+        self.assertEqual(last_version, 2)
+
+        tag_list = []
+        with mock.patch('ml_git.metadata.Metadata.list_tags', return_value=tag_list):
+            last_version = m.get_last_tag_version(specpath)
+        self.assertEqual(last_version, 0)
+        clear(self.test_dir)

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -346,18 +346,18 @@ class MetadataTestCases(unittest.TestCase):
 
     @pytest.mark.usefixtures('switch_to_test_dir')
     def test_last_tag_version(self):
-        specpath = 'dataset-ex'
+        sepc_path = 'dataset-ex'
         config['mlgit_path'] = self.test_dir
         m = Metadata('', '', config, DATASETS)
         m.init()
 
         tag_list = ['computer__images__dataset-ex__1', 'computer__images__dataset-ex__2']
         with mock.patch('ml_git.metadata.Metadata.list_tags', return_value=tag_list):
-            last_version = m.get_last_tag_version(specpath)
+            last_version = m.get_last_tag_version(sepc_path)
         self.assertEqual(last_version, 2)
 
         tag_list = []
         with mock.patch('ml_git.metadata.Metadata.list_tags', return_value=tag_list):
-            last_version = m.get_last_tag_version(specpath)
+            last_version = m.get_last_tag_version(sepc_path)
         self.assertEqual(last_version, 0)
         clear(self.test_dir)

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -11,7 +11,7 @@ import pytest
 
 from ml_git.constants import EntityType, StorageType, SPEC_EXTENSION, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY, \
     DATASET_SPEC_KEY
-from ml_git.spec import yaml_load, incr_version, is_valid_version, search_spec_file, SearchSpecException, spec_parse, \
+from ml_git.spec import yaml_load, increment_version, is_valid_version, search_spec_file, SearchSpecException, spec_parse, \
     get_spec_file_dir, increment_version_in_spec, get_root_path, get_version, update_storage_spec, validate_bucket_name, \
     set_version_in_spec, get_entity_dir
 from ml_git.utils import yaml_save, ensure_path_exists
@@ -29,10 +29,10 @@ class SpecTestCases(unittest.TestCase):
         yaml_save(spec_hash, tmpfile)
         version = spec_hash[DATASET_SPEC_KEY]['version']
         new_version = version + 1
-        incr_version(tmpfile, new_version)
+        increment_version(tmpfile, new_version)
         incremented_hash = yaml_load(tmpfile)
         self.assertEqual(incremented_hash[DATASET_SPEC_KEY]['version'], new_version)
-        self.assertEquals(incr_version('non-existent-file', new_version), -1)
+        self.assertEquals(increment_version('non-existent-file', new_version), -1)
 
     def test_is_valid_version(self):
         self.assertFalse(is_valid_version(None))

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -28,11 +28,11 @@ class SpecTestCases(unittest.TestCase):
         spec_hash = yaml_load(file)
         yaml_save(spec_hash, tmpfile)
         version = spec_hash[DATASET_SPEC_KEY]['version']
-        incr_version(tmpfile)
+        new_version = version + 1
+        incr_version(tmpfile, new_version)
         incremented_hash = yaml_load(tmpfile)
-        self.assertEqual(incremented_hash[DATASET_SPEC_KEY]['version'], version + 1)
-
-        incr_version('non-existent-file')
+        self.assertEqual(incremented_hash[DATASET_SPEC_KEY]['version'], new_version)
+        self.assertEquals(incr_version('non-existent-file', new_version), -1)
 
     def test_is_valid_version(self):
         self.assertFalse(is_valid_version(None))
@@ -101,20 +101,22 @@ class SpecTestCases(unittest.TestCase):
         os.makedirs(os.path.join(self.tmp_dir, dir2))
         file1 = os.path.join(self.tmp_dir, dir1, '%s.spec' % dataset)
         file2 = os.path.join(self.tmp_dir, dir2, '%s.spec' % dataset)
+        target_version = 1
 
-        self.assertFalse(increment_version_in_spec(None))
-
-        self.assertFalse(increment_version_in_spec(os.path.join(get_root_path(), dataset)))
+        self.assertRaises(RuntimeError, lambda: increment_version_in_spec(None, target_version))
+        self.assertRaises(RuntimeError, lambda: increment_version_in_spec(os.path.join(get_root_path(), dataset),
+                                                                          target_version))
 
         spec = yaml_load(os.path.join(testdir, 'invalid2.spec'))
         yaml_save(spec, file1)
-        self.assertFalse(increment_version_in_spec(os.path.join(get_root_path(), dataset)))
+        self.assertRaises(RuntimeError, lambda: increment_version_in_spec(os.path.join(get_root_path(), dataset),
+                          target_version))
 
         spec = yaml_load(os.path.join(testdir, 'valid.spec'))
         yaml_save(spec, file1)
         os.link(file1, file2)
         self.assertTrue(increment_version_in_spec(
-            os.path.join(get_root_path(), self.tmp_dir, DATASETS, dataset, dataset + '.spec')))
+            os.path.join(get_root_path(), self.tmp_dir, DATASETS, dataset, dataset + '.spec'), target_version))
 
     def test_get_version(self):
         file = os.path.join(testdir, 'valid.spec')


### PR DESCRIPTION
In the add command the user has an option (--bumpversion) that allows to increase the version of the entity. This increment is accomplished by adding one to the value of the version the user is in.

In some scenarios, this increment of one causes an error, since a tag with that specific version already exists - the user checked out tag 1 and tags 2 and 3 already exist, the --bumpversion would take the spec to point to version 2, but there is already a version 2.

This improvement makes the option able to identify the last version and define the version in the spec as the last plus one. In the scenario described above, bumpversion would make the spec point to version 4.