### PR TITLE
Fixing issue in S3 bucket region

### DIFF
--- a/ml_git/storages/store_utils.py
+++ b/ml_git/storages/store_utils.py
@@ -47,7 +47,7 @@ def get_bucket_region(bucket, credentials_profile=None):
     client = session.client(StorageType.S3.value)
     location = client.get_bucket_location(Bucket=bucket)
     if location['LocationConstraint'] is not None:
-        region = location
+        region = location['LocationConstraint']
     else:
         region = 'us-east-1'
     return region


### PR DESCRIPTION
During the process of adding remote storage through the command `ml-git repository storage add`, we noticed the `config.yml` file was being populated with extra information as shown below

```yaml
storages:
  s3:
    mlgit-datasets:
      aws-credentials:
        profile: default
      region: us-east-1
  s3h:
    sagemaker-mlgit-data:
      aws-credentials:
        profile: null
      endpoint-url: null
      region:
        LocationConstraint: us-west-1
        ResponseMetadata:
          HTTPHeaders:
            content-type: application/xml
            date: Wed, 19 May 2021 19:23:51 GMT
            server: AmazonS3
            transfer-encoding: chunked
            x-amz-id-2: [removed]
            x-amz-request-id: [removed]
          HTTPStatusCode: 200
          HostId: [removed]
          RequestId: [removed]
          RetryAttempts: 0
```

This fix makes the code use the `region['LocationConstraint']` instead of the `region` directly.