### PR TITLE
How to contribute documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request.md
@@ -1,0 +1,31 @@
+## Description
+
+Please include a summary of the change and which issue is fixed.
+Please also include relevant motivation and context.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## How has been tested?
+
+Please describe the tests that you ran to verify your changes.
+Please also list any relevant details for your test configuration.
+
+- [ ] Test A
+- [ ] Test B
+
+## Checklist:
+
+- [ ] I have run `flake8 .` on this repository
+- [ ] I have followed the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request.md
@@ -1,17 +1,15 @@
 ## Description
 
-Please include a summary of the change and which issue is fixed.
-Please also include relevant motivation and context.
+Please include a clear and concise description of the change, the relevant motivation and the context. If it is related to an issue remember to reference it. Whenever possible, add examples of executions.
 
 Fixes # (issue)
 
 ## Type of change
 
-Please delete options that are not relevant.
-
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
 
 ## How has been tested?
 
@@ -23,7 +21,7 @@ Please also list any relevant details for your test configuration.
 
 ## Checklist:
 
-- [ ] I have run `flake8 .` on this repository
+- [ ] I have run `flake8 .` on the project and my changes do not generate new warnings.
 - [ ] I have followed the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas

--- a/README.md
+++ b/README.md
@@ -207,10 +207,10 @@ Your contributions are always welcome!
 
 1. Fork the repository into your own GitHub
 2. Clone the repository to your local machine
-3. Create a new branch for your changes using the following pattern `(feature | bugfix | hotfix)/branch_name`. Example: `feature/ftp_storage_implementation`
+3. Create a new branch for your changes using the following pattern `(feature | bugfix | hotfix)/branch_name`. Example: `feature/sftp_storage_implementation`
 4. Make changes and [test](docs/developer_info.md)
 5. Push the changes to your repository
-6. Create a Pull Request from your repository back to the original one with comprehensive description of changes
+6. Create a Pull Request from your forked repository to the ML-Git repository with comprehensive description of changes
 
 Another way to contribute with the community is creating an issue to track your ideas, doubts, enhancements, tasks, or bugs found. 
 If an issue with the same topic already exists, discuss on the issue.

--- a/README.md
+++ b/README.md
@@ -205,9 +205,12 @@ Demonstration video:
 
 Your contributions are always welcome!
 
-1. Clone repository and create a new branch
-2. Make changes and [test](docs/developer_info.md)
-3. Submit Pull Request with comprehensive description of changes
+1. Fork the repository into your own GitHub
+2. Clone the repository to your local machine
+3. Create a new branch for your changes using the following pattern `(feature | bugfix | hotfix)/branch_name`. Example: `feature/ftp_storage_implementation`
+4. Make changes and [test](docs/developer_info.md)
+5. Push the changes to your repository
+6. Create a Pull Request from your repository back to the original one with comprehensive description of changes
 
 Another way to contribute with the community is creating an issue to track your ideas, doubts, enhancements, tasks, or bugs found. 
 If an issue with the same topic already exists, discuss on the issue.


### PR DESCRIPTION
Updated the readme documentation in the section on how to contribute, the correct contribution flow was added, forking it, creating a branch and socializing the PR.

Creation of a template for pull requests, when a pull request is created by default it becomes a template for the user to fill out and validate that all the steps for opening the PR have been carried out correctly.