### PR TITLE
Fixing wrong message when resources initialization script fails

### DIFF
--- a/scripts/resources_initialization/resources_initialization.bat
+++ b/scripts/resources_initialization/resources_initialization.bat
@@ -75,15 +75,13 @@ GOTO :END
       FOR /F %%a IN ('curl -s -o ../../%OUTPUT_FILE% -w "%%{http_code}" -H "Authorization: token %GITHUB_TOKEN%" "%GITHUB_API_URL%%REPO_OWNER%" -d "{""name"": ""%REPO_NAME%""}"') do set HTTP_CODE=%%a
 
       SET USERNAME=
-      FOR /F "tokens=2 delims=:" %%a in ('findstr \"login\"^: ..\..\%OUTPUT_FILE%') do SET USERNAME=%%a
+      FOR /F "tokens=2 delims=: " %%a in ('findstr \"login\"^: ..\..\%OUTPUT_FILE%') do SET USERNAME=%%a
       SET USERNAME=%USERNAME:"=%
-      SET USERNAME=%USERNAME: =%
       SET USERNAME=%USERNAME:,=%
       
       SET REPO_NAME=
-      FOR /F "tokens=2 delims=:" %%a in ('findstr \"name\"^: ..\..\%OUTPUT_FILE%') do SET REPO_NAME=%%a
+      FOR /F "tokens=2 delims=: " %%a in ('findstr \"name\"^: ..\..\%OUTPUT_FILE%') do SET REPO_NAME=%%a
       SET REPO_NAME=%REPO_NAME:"=%
-      SET REPO_NAME=%REPO_NAME: =%
       SET REPO_NAME=%REPO_NAME:,=%
 
       SET REPO_LINK=%GITHUB_BASE_URL%/%USERNAME%/%REPO_NAME%
@@ -182,16 +180,14 @@ GOTO :END
    FOR /F %%a IN ('curl -s -o ../../%OUTPUT_FILE% -w "%%{http_code}" -H "Authorization: token %GITHUB_TOKEN%" "%GITHUB_API_URL%%REPO_OWNER%" -d "{""name"": ""%REPO_NAME%""}"') do set HTTP_CODE=%%a
 
    SET USERNAME=
-   FOR /F "tokens=2 delims=:" %%a in ('findstr \"login\"^: ..\..\%OUTPUT_FILE%') do SET USERNAME=%%a
+   FOR /F "tokens=2 delims=: " %%a in ('findstr \"login\"^: ..\..\%OUTPUT_FILE%') do SET USERNAME=%%a
    SET USERNAME=%USERNAME:"=%
-   SET USERNAME=%USERNAME: =%
    SET USERNAME=%USERNAME:,=%
 
    SET REPO_NAME=
-   FOR /F "tokens=2 delims=:" %%a in ('findstr \"name\"^: ..\..\%OUTPUT_FILE%') do SET REPO_NAME=%%a
+   FOR /F "tokens=2 delims=: " %%a in ('findstr \"name\"^: ..\..\%OUTPUT_FILE%') do SET REPO_NAME=%%a
    SET REPO_NAME=%REPO_NAME:"=%
-   SET USERNAME=%USERNAME: =%
-   SET USERNAME=%USERNAME:,=%
+   SET REPO_NAME=%REPO_NAME:,=%
 
    IF "%ORGANIZATION_NAME%"=="%OLD_USERNAME%" (
       SET ORGANIZATION_NAME=%USERNAME%
@@ -207,9 +203,10 @@ GOTO :END
       git branch -M main
       git remote add origin %GITHUB_REPOSITORY_URL%
       git push --set-upstream origin main
-      IF %ERRORLEVEL% EQU 0 (
-         ECHO Repository creation done. Go to %REPO_LINK% to see.
+
+      IF !ERRORLEVEL! EQU 0 (
          ECHO.
+         ECHO Repository creation done. Go to %REPO_LINK% to see.
          ECHO If you want to start an ml-git project with these settings you can use:
          ECHO.
          ECHO ml-git clone %REPO_LINK%

--- a/scripts/resources_initialization/resources_initialization.bat
+++ b/scripts/resources_initialization/resources_initialization.bat
@@ -73,13 +73,19 @@ GOTO :END
       
       SET HTTP_CODE=
       FOR /F %%a IN ('curl -s -o ../../%OUTPUT_FILE% -w "%%{http_code}" -H "Authorization: token %GITHUB_TOKEN%" "%GITHUB_API_URL%%REPO_OWNER%" -d "{""name"": ""%REPO_NAME%""}"') do set HTTP_CODE=%%a
-      
+
       SET USERNAME=
       FOR /F "tokens=2 delims=:" %%a in ('findstr \"login\"^: ..\..\%OUTPUT_FILE%') do SET USERNAME=%%a
       SET USERNAME=%USERNAME:"=%
+      SET USERNAME=%USERNAME: =%
+      SET USERNAME=%USERNAME:,=%
+      
       SET REPO_NAME=
       FOR /F "tokens=2 delims=:" %%a in ('findstr \"name\"^: ..\..\%OUTPUT_FILE%') do SET REPO_NAME=%%a
       SET REPO_NAME=%REPO_NAME:"=%
+      SET REPO_NAME=%REPO_NAME: =%
+      SET REPO_NAME=%REPO_NAME:,=%
+
       SET REPO_LINK=%GITHUB_BASE_URL%/%USERNAME%/%REPO_NAME%
       
       IF "!HTTP_CODE!"=="201" (
@@ -176,12 +182,16 @@ GOTO :END
    FOR /F %%a IN ('curl -s -o ../../%OUTPUT_FILE% -w "%%{http_code}" -H "Authorization: token %GITHUB_TOKEN%" "%GITHUB_API_URL%%REPO_OWNER%" -d "{""name"": ""%REPO_NAME%""}"') do set HTTP_CODE=%%a
 
    SET USERNAME=
-   FOR /F "tokens=2 delims=:" %%a in ('findstr \"login\"^: %OUTPUT_FILE%') do SET USERNAME=%%a
+   FOR /F "tokens=2 delims=:" %%a in ('findstr \"login\"^: ..\..\%OUTPUT_FILE%') do SET USERNAME=%%a
    SET USERNAME=%USERNAME:"=%
+   SET USERNAME=%USERNAME: =%
+   SET USERNAME=%USERNAME:,=%
 
    SET REPO_NAME=
-   FOR /F "tokens=2 delims=:" %%a in ('findstr \"name\"^: %OUTPUT_FILE%') do SET REPO_NAME=%%a
+   FOR /F "tokens=2 delims=:" %%a in ('findstr \"name\"^: ..\..\%OUTPUT_FILE%') do SET REPO_NAME=%%a
    SET REPO_NAME=%REPO_NAME:"=%
+   SET USERNAME=%USERNAME: =%
+   SET USERNAME=%USERNAME:,=%
 
    IF "%ORGANIZATION_NAME%"=="%OLD_USERNAME%" (
       SET ORGANIZATION_NAME=%USERNAME%

--- a/scripts/resources_initialization/resources_initialization.bat
+++ b/scripts/resources_initialization/resources_initialization.bat
@@ -114,7 +114,7 @@ GOTO :END
       ECHO     %BUCKET_NAME%: >> config.yaml
 
       aws s3api create-bucket --bucket %BUCKET_NAME% --region us-east-1
-      SET BUCKET_CREATION_RETURN_CODE=%ERRORLEVEL%
+      SET BUCKET_CREATION_RETURN_CODE=!ERRORLEVEL!
       ECHO       aws-credentials: >> config.yaml
       ECHO         profile: default >> config.yaml
    ) ELSE IF ["%STORE_TYPE%"]==["minio"] (
@@ -124,7 +124,7 @@ GOTO :END
       ECHO     %BUCKET_NAME%: >> config.yaml
 
       aws --endpoint-url !ENDPOINT! s3 mb s3://%BUCKET_NAME%
-      SET BUCKET_CREATION_RETURN_CODE=%ERRORLEVEL%
+      SET BUCKET_CREATION_RETURN_CODE=!ERRORLEVEL!
       ECHO       aws-credentials: >> config.yaml
       ECHO         profile: default >> config.yaml
       ECHO       endpoint-url: !ENDPOINT! >> config.yaml
@@ -133,7 +133,7 @@ GOTO :END
       ECHO     %BUCKET_NAME%: >> config.yaml
       IF ["%STORE_TYPE%"]==["azureblobh"] (
          az storage container create -n %BUCKET_NAME%
-         SET BUCKET_CREATION_RETURN_CODE=%ERRORLEVEL%
+         SET BUCKET_CREATION_RETURN_CODE=!ERRORLEVEL!
          ECHO       credentials: None >> config.yaml
       ) ELSE (
          ECHO Please enter a valid storage type.

--- a/scripts/resources_initialization/resources_initialization.sh
+++ b/scripts/resources_initialization/resources_initialization.sh
@@ -25,11 +25,11 @@ create_new_github_repository()
               fi
               OUTPUT_FILE=log_${ENTITY_TYPE}_repository
               HTTP_CODE=$(curl -s -o ../../${OUTPUT_FILE} -w "%{http_code}" -H "Authorization: token ${GITHUB_TOKEN}" ${GITHUB_API_URL}${REPO_OWNER} -d "{\"name\": \"${REPONAME:-${REPO_NAME}}\"}")
+              REPO_LINK=$(grep -Po -m2 html_url.+:.+ ../../$OUTPUT_FILE | tail -n1 | cut -d '"' -f 3)
               if [[ HTTP_CODE -ne 201 ]]; then
                  echo "Could not create the repository, please see ${OUTPUT_FILE} for more information."
                  clear_workspace_and_exit
               else
-                 REPO_LINK=${GITHUB_BASE_URL}/${USERNAME}/${REPO_NAME}
                  echo "Repository creation done. Go to ${REPO_LINK} to see."
                  echo "${ENTITY_TYPE}:" >> config.yaml
                  echo "  git: ${REPO_LINK}" >> config.yaml
@@ -44,7 +44,7 @@ create_new_bucket()
 {
    read -p "What type of storage do you want to configure? [s3h, azureblobh, minio]: " STORE_TYPE
    read -p "What name do you want to give to your bucket? " BUCKET_NAME
-   
+   BUCKET_CREATION_RETURN_CODE=0
    {
    if [ "${STORE_TYPE}" == "s3h" ];
    then
@@ -52,6 +52,7 @@ create_new_bucket()
       echo "    ${BUCKET_NAME}:" >> config.yaml
 
       aws s3api create-bucket --bucket ${BUCKET_NAME} --region us-east-1
+      BUCKET_CREATION_RETURN_CODE=$?
       echo "      aws-credentials:" >> config.yaml
       echo "        profile: default" >> config.yaml
    elif [ "${STORE_TYPE}" == "minio" ];
@@ -62,6 +63,7 @@ create_new_bucket()
       echo "    ${BUCKET_NAME}:" >> config.yaml
 
       aws --endpoint-url ${ENDPOINT} s3 mb s3://${BUCKET_NAME}
+      BUCKET_CREATION_RETURN_CODE=$?
       echo "      aws-credentials:" >> config.yaml
       echo "        profile: default" >> config.yaml
       echo "      endpoint-url: " ${ENDPOINT} >> config.yaml
@@ -71,12 +73,18 @@ create_new_bucket()
       echo "    ${BUCKET_NAME}:" >> config.yaml
 
       az storage container create -n ${BUCKET_NAME}
+      BUCKET_CREATION_RETURN_CODE=$?
       echo "      credentials: None" >> config.yaml
    else
       echo "Please enter a valid storage type."
       create_new_bucket
    fi
    } > log.txt
+   if [ $BUCKET_CREATION_RETURN_CODE -eq 0 ]; then
+     echo "Bucket successfully created"
+   else
+     echo "The bucket could not be created"
+   fi
 }
 
 
@@ -86,11 +94,10 @@ create_new_bucket_wizard()
 
    if [ -z "${yn}" ]
    then
-      yn="Yes"
+     yn="Yes"
    fi
    case ${yn} in
       [Yy]* ) create_new_bucket;
-              echo "Bucket successfully created"
               create_new_bucket_wizard;;
       [Nn]* ) return;;
       * ) echo "Please answer Yes or no."; create_new_bucket_wizard;;
@@ -116,22 +123,27 @@ push_config_repository()
    read -p "What name do you want to give for the repository with these configurations? [default: ${REPO_NAME}] " INPUT_REPO_NAME;
    git add config.yaml
    git commit -m "Initial commit with .ml-git configured"
+   git branch -M main
    if ! [ -z "${INPUT_REPO_NAME}" ]
    then
      REPO_NAME=${INPUT_REPO_NAME}
    fi
    OUTPUT_FILE=log_clone_repository
    HTTP_CODE=$(curl -s -o ../../$OUTPUT_FILE -w "%{http_code}" -H "Authorization: token ${GITHUB_TOKEN}" ${GITHUB_API_URL}${REPO_OWNER} -d "{\"name\": \"${REPONAME:-$REPO_NAME}\"}")
+   REPO_LINK=$(grep -Po -m2 html_url.+:.+ ../../$OUTPUT_FILE | tail -n1 | cut -d '"' -f 3)
    if [[ HTTP_CODE -ne 201 ]]; then
       echo "Could not create the repository, please see $OUTPUT_FILE for more information."
       clear_workspace_and_exit
    else
       GITHUB_REPOSITORY_URL="https://${USERNAME}:${GITHUB_TOKEN}@${GITHUB_BASE_URL//'https://'}/${ORGANIZATION_NAME}/${REPO_NAME}.git"
       git remote add origin ${GITHUB_REPOSITORY_URL}
-      git branch -M main
       git push --set-upstream origin main
-      REPO_LINK=${GITHUB_BASE_URL}/${USERNAME}/${REPO_NAME}
-      echo "Repository creation done. Go to $REPO_LINK to see."
+      if [ $? -eq 0 ]; then
+        echo "Repository creation done. Go to $REPO_LINK to see."
+        echo -e "\nIf you want to start an ml-git project with these settings you can use:\n\tml-git clone $REPO_LINK"
+      else
+        echo "Something went wrong, verify your $REPO_LINK"
+      fi
    fi
 }
 
@@ -180,7 +192,6 @@ create_new_bucket_wizard
 
 echo -e "\n## CREATE REPOSITORY WITH CONFIGURATIONS ##"
 push_config_repository
-echo -e "\nIf you want to start an ml-git project with these settings you can use:\n\tml-git clone $REPO_LINK"
 
 clear_workspace_and_exit
 


### PR DESCRIPTION
When the script initialize and ask for username **(ex: user-mlgit)**, and the profile of this user is different from username **(ex: UserMlgit)**, the script is showing wrong message:

```
## CREATE REPOSITORY WITH CONFIGURATIONS ##
What name do you want to give for the repository with these configurations? [default: tests-scripts-mlgit-repository] 
[master (root-commit) 59a8e19] Initial commit with .ml-git configured
 1 file changed, 7 insertions(+)
 create mode 100644 .ml-git/config.yaml
remote: Repository not found.
fatal: repository 'https://github.com/user-mlgit/tests-scripts-mlgit-repository.git/' not found
Repository creation done. Go to https://github.com/user-mlgit/script-test-mlgit-repository to see.

If you want to start an ml-git project with these settings you can use:
	ml-git clone https://github.com/user-mlgit/script-test-mlgit-repository
```
After the fatal error, an empty repository is created at https://github.com/UserMlgit/script-test-mlgit-repository.