### PR TITLE
Adding support for defining the .mlgitignore file

### DIFF
--- a/ml_git/constants.py
+++ b/ml_git/constants.py
@@ -73,6 +73,7 @@ LABELS_SPEC_KEY = 'labels'
 MODEL_SPEC_KEY = 'model'
 STORAGE_SPEC_KEY = 'storage'
 STORAGE_CONFIG_KEY = 'storages'
+MLGIT_IGNORE_FILE_NAME = '.mlgitignore'
 
 
 class MutabilityType(Enum):

--- a/ml_git/file_system/index.py
+++ b/ml_git/file_system/index.py
@@ -2,6 +2,7 @@
 © Copyright 2020 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
+
 import os
 import shutil
 import time
@@ -80,13 +81,13 @@ class MultihashIndex(object):
             return False
         return True
 
-    def _add_dir(self, dirpath, manifestpath, file_path='', ignore_rules=None):
-        self.manifestfiles = yaml_load(manifestpath)
+    def _add_dir(self, dir_path, manifest_path, file_path='', ignore_rules=None):
+        self.manifestfiles = yaml_load(manifest_path)
         f_index_file = self._full_idx.get_index()
         all_files = []
-        for root, dirs, files in os.walk(os.path.join(dirpath, file_path)):
-            base_path = root[:len(dirpath) + 1:]
-            relative_path = root[len(dirpath) + 1:]
+        for root, dirs, files in os.walk(os.path.join(dir_path, file_path)):
+            base_path = root[:len(dir_path) + 1:]
+            relative_path = root[len(dir_path) + 1:]
             if '.' == root[0] or should_ignore_file(ignore_rules, '{}/'.format(relative_path)):
                 continue
             for file in files:
@@ -94,7 +95,7 @@ class MultihashIndex(object):
                 if ignore_rules is None or not should_ignore_file(ignore_rules, file_path):
                     all_files.append(file_path)
             self.wp.progress_bar_total_inc(len(all_files))
-            args = {'wp': self.wp, 'basepath': base_path, 'f_index_file': f_index_file, 'all_files': all_files, 'dirpath': dirpath}
+            args = {'wp': self.wp, 'basepath': base_path, 'f_index_file': f_index_file, 'all_files': all_files, 'dirpath': dir_path}
             result = run_function_per_group(range(len(all_files)), 10000, function=self._adding_dir_work, arguments=args)
             if not result:
                 return False

--- a/ml_git/file_system/index.py
+++ b/ml_git/file_system/index.py
@@ -2,7 +2,6 @@
 © Copyright 2020 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
-import fnmatch
 import os
 import shutil
 import time
@@ -10,13 +9,14 @@ from builtins import FileNotFoundError
 from enum import Enum
 
 from ml_git import log
-from ml_git.constants import MULTI_HASH_CLASS_NAME, MutabilityType, SPEC_EXTENSION, INDEX_FILE
+from ml_git.constants import MULTI_HASH_CLASS_NAME, MutabilityType, SPEC_EXTENSION, INDEX_FILE, MLGIT_IGNORE_FILE_NAME
 from ml_git.file_system.cache import Cache
 from ml_git.file_system.hashfs import MultihashFS
 from ml_git.manifest import Manifest
 from ml_git.ml_git_message import output_messages
 from ml_git.pool import pool_factory
-from ml_git.utils import ensure_path_exists, yaml_load, posix_path, set_read_only, get_file_size, run_function_per_group
+from ml_git.utils import ensure_path_exists, yaml_load, posix_path, set_read_only, get_file_size, \
+    run_function_per_group, get_ignore_rules, should_ignore_file
 
 
 class MultihashIndex(object):
@@ -38,20 +38,22 @@ class MultihashIndex(object):
 
     def add(self, path, manifestpath, files=[]):
         self.wp = pool_factory(pb_elts=0, pb_desc='files')
+        ignore_rules = get_ignore_rules(path)
         if len(files) > 0:
             single_files = filter(lambda x: os.path.isfile(os.path.join(path, x)), files)
             self.wp.progress_bar_total_inc(len(list(single_files)))
             for f in files:
                 fullpath = os.path.join(path, f)
                 if os.path.isdir(fullpath):
-                    self._add_dir(path, manifestpath, f)
+                    self._add_dir(path, manifestpath, f, ignore_rules=ignore_rules)
                 elif os.path.isfile(fullpath):
-                    self._add_single_file(path, manifestpath, f)
+                    if not should_ignore_file(ignore_rules, path):
+                        self._add_single_file(path, manifestpath, f)
                 else:
                     log.warn(output_messages['WARN_NOT_FOUND'] % fullpath, class_name=MULTI_HASH_CLASS_NAME)
         else:
             if os.path.isdir(path):
-                self._add_dir(path, manifestpath)
+                self._add_dir(path, manifestpath, ignore_rules=ignore_rules)
         self.wp.progress_bar_close()
 
     def _adding_dir_work_future_process(self, futures, wp):
@@ -63,7 +65,7 @@ class MultihashIndex(object):
     def _adding_dir_work(self, files, args):
         for k in files:
             file_path = args['all_files'][k]
-            if (SPEC_EXTENSION in file_path) or (file_path == 'README.md'):
+            if (SPEC_EXTENSION in file_path) or (file_path == 'README.md') or (file_path == MLGIT_IGNORE_FILE_NAME):
                 args['wp'].progress_bar_total_inc(-1)
                 self.add_metadata(args['basepath'], file_path)
             else:
@@ -78,27 +80,21 @@ class MultihashIndex(object):
             return False
         return True
 
-    def _should_ignore_file(self, ignore_rules, file_path):
-        for ignore in ignore_rules:
-            if fnmatch.fnmatch(file_path, ignore):
-                return True
-        return False
-
     def _add_dir(self, dirpath, manifestpath, file_path='', ignore_rules=None):
         self.manifestfiles = yaml_load(manifestpath)
         f_index_file = self._full_idx.get_index()
         all_files = []
         for root, dirs, files in os.walk(os.path.join(dirpath, file_path)):
-            if '.' == root[0]:
+            base_path = root[:len(dirpath) + 1:]
+            relative_path = root[len(dirpath) + 1:]
+            if '.' == root[0] or should_ignore_file(ignore_rules, '{}/'.format(relative_path)):
                 continue
-            basepath = root[:len(dirpath) + 1:]
-            relativepath = root[len(dirpath) + 1:]
             for file in files:
-                ignore_rules = ['data/', 'data/0110 - Copia.png']
-                if ignore_rules is None or not self._should_ignore_file(ignore_rules, os.path.join(relativepath, file)):
-                    all_files.append(os.path.join(relativepath, file))
+                file_path = os.path.join(relative_path, file)
+                if ignore_rules is None or not should_ignore_file(ignore_rules, file_path):
+                    all_files.append(file_path)
             self.wp.progress_bar_total_inc(len(all_files))
-            args = {'wp': self.wp, 'basepath': basepath, 'f_index_file': f_index_file, 'all_files': all_files, 'dirpath': dirpath}
+            args = {'wp': self.wp, 'basepath': base_path, 'f_index_file': f_index_file, 'all_files': all_files, 'dirpath': dirpath}
             result = run_function_per_group(range(len(all_files)), 10000, function=self._adding_dir_work, arguments=args)
             if not result:
                 return False
@@ -109,7 +105,7 @@ class MultihashIndex(object):
         self.manifestfiles = yaml_load(manifestpath)
 
         f_index_file = self._full_idx.get_index()
-        if (SPEC_EXTENSION in file_path) or ('README' in file_path):
+        if (SPEC_EXTENSION in file_path) or ('README' in file_path) or (MLGIT_IGNORE_FILE_NAME in file_path):
             self.wp.progress_bar_total_inc(-1)
             self.add_metadata(base_path, file_path)
         else:

--- a/ml_git/file_system/local.py
+++ b/ml_git/file_system/local.py
@@ -14,7 +14,6 @@ from asyncio import CancelledError
 from pathlib import Path
 
 from botocore.client import ClientError
-from ml_git.error_handler import error_handler
 from tqdm import tqdm
 
 from ml_git import log
@@ -22,7 +21,8 @@ from ml_git.config import get_index_path, get_objects_path, get_refs_path, get_i
     get_metadata_path, get_batch_size, get_push_threads_count
 from ml_git.constants import LOCAL_REPOSITORY_CLASS_NAME, STORAGE_FACTORY_CLASS_NAME, REPOSITORY_CLASS_NAME, \
     MutabilityType, StorageType, SPEC_EXTENSION, MANIFEST_FILE, INDEX_FILE, EntityType, PERFORMANCE_KEY, \
-    STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY
+    STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY, MLGIT_IGNORE_FILE_NAME
+from ml_git.error_handler import error_handler
 from ml_git.file_system.cache import Cache
 from ml_git.file_system.hashfs import MultihashFS
 from ml_git.file_system.index import MultihashIndex, FullIndex, Status
@@ -34,7 +34,8 @@ from ml_git.sample import SampleValidate
 from ml_git.spec import spec_parse, search_spec_file, get_entity_dir, get_spec_key
 from ml_git.storages.store_utils import storage_factory
 from ml_git.utils import yaml_load, ensure_path_exists, convert_path, normalize_path, \
-    posix_path, set_write_read, change_mask_for_routine, run_function_per_group, get_root_path, yaml_save
+    posix_path, set_write_read, change_mask_for_routine, run_function_per_group, get_root_path, yaml_save, \
+    get_ignore_rules, should_ignore_file
 
 
 class LocalRepository(MultihashFS):
@@ -348,7 +349,7 @@ class LocalRepository(MultihashFS):
 
     @staticmethod
     def _update_metadata(full_md_path, ws_path, spec_name):
-        for md in ['README.md', spec_name + SPEC_EXTENSION]:
+        for md in ['README.md', spec_name + SPEC_EXTENSION, MLGIT_IGNORE_FILE_NAME]:
             md_path = os.path.join(full_md_path, md)
             if os.path.exists(md_path) is False:
                 continue
@@ -751,6 +752,7 @@ class LocalRepository(MultihashFS):
         bare_mode = os.path.exists(os.path.join(index_metadata_path, spec, 'bare'))
         new_files, deleted_files, all_files, corrupted_files = self._get_index_files_status(bare_mode, idx_yaml_mf,
                                                                                             path, status_directory)
+
         if path is not None:
             changed_files, untracked_files = \
                 self._get_workspace_files_status(all_files, full_metadata_path, idx_yaml_mf,
@@ -765,15 +767,20 @@ class LocalRepository(MultihashFS):
                                     new_files, status_directory=''):
         changed_files = []
         untracked_files = []
+        ignore_rules = get_ignore_rules(path)
         for root, dirs, files in os.walk(path):
             base_path = root[len(path) + 1:]
             base_path_with_separator = base_path + os.path.sep
 
-            if status_directory and not base_path_with_separator.startswith(status_directory + os.path.sep):
+            if (status_directory and not base_path_with_separator.startswith(status_directory + os.path.sep)) \
+                    or should_ignore_file(ignore_rules, '{}/'.format(base_path)):
                 continue
 
             for file in files:
                 file_path = convert_path(base_path, file)
+                if should_ignore_file(ignore_rules, file_path):
+                    continue
+
                 if file_path in all_files:
                     full_file_path = os.path.join(root, file)
                     stat = os.stat(full_file_path)
@@ -782,7 +789,7 @@ class LocalRepository(MultihashFS):
                             file_in_index['hash']:
                         bisect.insort(changed_files, file_path)
                 else:
-                    is_metadata_file = SPEC_EXTENSION in file or file_path == 'README.md'
+                    is_metadata_file = SPEC_EXTENSION in file or file_path == 'README.md' or file_path == MLGIT_IGNORE_FILE_NAME
 
                     if not is_metadata_file:
                         bisect.insort(untracked_files, file_path)

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -205,7 +205,7 @@ output_messages = {
     'ERROR_INVALID_ENTERED_ENTITY_TYPE': 'The type of entity entered is invalid. Valid types are: [repository, dataset, labels or model]',
     'ERROR_METADATA_MESSAGE': '\t%s',
     'ERROR_NO_MANIFEST_FILE_FOUND': 'No manifest file found in [%s]',
-    'ERROR_COULD_NOT_FIND_README': 'Could not find file README.md. Entity repository must have README.md file',
+    'ERROR_COULD_NOT_FIND_FILE': 'Could not find file {}. Entity repository must have {} file',
     'ERROR_ENTITY_NEEDS_CATATEGORY': 'You must place at least one category in the entity .spec file',
     'ERROR_INVALID_DATASET_SPEC': 'Error: invalid dataset spec (Missing name). It should look something like this:\n%s',
     'ERROR_REPOSITORY_NOT_FOUND': 'No repositories found, verify your configurations!',

--- a/ml_git/utils.py
+++ b/ml_git/utils.py
@@ -4,6 +4,7 @@ SPDX-License-Identifier: GPL-2.0-only
 """
 import bisect
 import csv
+import fnmatch
 import itertools
 import json
 import os
@@ -21,7 +22,7 @@ from ruamel.yaml.compat import StringIO
 
 from ml_git import log
 from ml_git.constants import SPEC_EXTENSION, CONFIG_FILE, EntityType, ROOT_FILE_NAME, V1_STORAGE_KEY, V1_DATASETS_KEY, \
-    V1_MODELS_KEY, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY
+    V1_MODELS_KEY, STORAGE_SPEC_KEY, STORAGE_CONFIG_KEY, MLGIT_IGNORE_FILE_NAME
 from ml_git.ml_git_message import output_messages
 from ml_git.pool import pool_factory
 
@@ -389,3 +390,24 @@ def create_or_update_gitignore():
         file.write('\n')
         for remaining_file in ignored_files:
             file.write(remaining_file + '\n')
+
+
+def should_ignore_file(ignore_rules, file_path):
+    if not ignore_rules:
+        return False
+    for ignore in ignore_rules:
+        if fnmatch.fnmatch(file_path, ignore):
+            return True
+    return False
+
+
+def get_ignore_rules(path):
+    mlgit_ignore_file = os.path.join(path, MLGIT_IGNORE_FILE_NAME)
+    if os.path.exists(mlgit_ignore_file):
+        ignore_rules = []
+        with open(mlgit_ignore_file) as fp:
+            rules = fp.read().splitlines()
+            for rule in rules:
+                ignore_rules.append(rule)
+        return ignore_rules
+    return None

--- a/ml_git/utils.py
+++ b/ml_git/utils.py
@@ -395,8 +395,8 @@ def create_or_update_gitignore():
 def should_ignore_file(ignore_rules, file_path):
     if not ignore_rules:
         return False
-    for ignore in ignore_rules:
-        if fnmatch.fnmatch(file_path, ignore):
+    for rule in ignore_rules:
+        if fnmatch.fnmatch(file_path, rule):
             return True
     return False
 

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -15,7 +15,7 @@ from zipfile import ZipFile
 from ruamel.yaml import YAML
 
 from ml_git.constants import GLOBAL_ML_GIT_CONFIG, MutabilityType, StorageType, EntityType, STORAGE_SPEC_KEY, \
-    STORAGE_CONFIG_KEY, FileType
+    STORAGE_CONFIG_KEY, FileType, MLGIT_IGNORE_FILE_NAME
 from ml_git.ml_git_message import output_messages
 from ml_git.spec import get_spec_key
 from ml_git.utils import ensure_path_exists
@@ -345,3 +345,11 @@ def move_entity_to_dir(tmp_dir, artifact_name, entity_type):
     ensure_path_exists(workspace_with_dir)
     shutil.move(workspace, workspace_with_dir)
     return entity_dir, workspace, workspace_with_dir
+
+
+def create_ignore_file(dir, ignore_rules=None):
+    if not ignore_rules:
+        ignore_rules = ['data/*.png\n', 'ignored-folder/']
+    file = os.path.join(dir, MLGIT_IGNORE_FILE_NAME)
+    with open(file, 'wt') as file:
+        file.writelines(ignore_rules)

--- a/tests/integration/test_05_add_files.py
+++ b/tests/integration/test_05_add_files.py
@@ -9,12 +9,13 @@ from stat import S_IWUSR, S_IREAD
 
 import pytest
 
+from ml_git.constants import MLGIT_IGNORE_FILE_NAME
 from ml_git.ml_git_message import output_messages
 from ml_git.spec import get_spec_key
 from ml_git.utils import ensure_path_exists
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_PUSH, MLGIT_CHECKOUT
 from tests.integration.helper import ML_GIT_DIR, create_spec, init_repository, ERROR_MESSAGE, MLGIT_ADD, \
-    create_file, DATASETS, DATASET_NAME, MODELS, LABELS
+    create_file, DATASETS, DATASET_NAME, MODELS, LABELS, create_ignore_file
 from tests.integration.helper import clear, check_output, add_file, entity_init, yaml_processor
 
 
@@ -236,3 +237,29 @@ class AddFilesAcceptanceTests(unittest.TestCase):
         index_file = os.path.join(metadata, 'INDEX.yaml')
         self.assertTrue(os.path.exists(metadata_file))
         self.assertTrue(os.path.exists(index_file))
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_14_add_with_ignore_file(self):
+        entity_init(DATASETS, self)
+        workspace = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME)
+        os.mkdir(os.path.join(workspace, 'data'))
+        os.mkdir(os.path.join(workspace, 'ignored-folder'))
+        create_file(workspace, 'image.png', '0')
+        create_file(workspace, 'image2.jpg', '1', file_path='ignored-folder')
+        create_file(workspace, 'file1', '0')
+        create_file(workspace, 'file2', '1')
+
+        create_ignore_file(workspace)
+
+        output = check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, ''))
+        self.assertIn(output_messages['INFO_ADDING_PATH'] % DATASETS, output)
+        self.assertNotIn(ERROR_MESSAGE, output)
+
+        metadata = os.path.join(self.tmp_dir, ML_GIT_DIR, DATASETS, 'index', 'metadata', DATASET_NAME)
+        metadata_file = os.path.join(metadata, 'MANIFEST.yaml')
+        index_file = os.path.join(metadata, 'INDEX.yaml')
+        ignore_file = os.path.join(metadata, MLGIT_IGNORE_FILE_NAME)
+        self.assertTrue(os.path.exists(metadata_file))
+        self.assertTrue(os.path.exists(ignore_file))
+        self.assertTrue(os.path.exists(index_file))
+        self._check_index(index_file, ['data/file1', 'data/file2'], ['data/image.png', 'ignored-folder/image2.jpg'])

--- a/tests/integration/test_09_status_command.py
+++ b/tests/integration/test_09_status_command.py
@@ -117,17 +117,17 @@ class StatusAcceptanceTests(unittest.TestCase):
         create_file(workspace, 'file1', '0')
 
         self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
-                         r'Changes to be committed:\n\nUntracked files:\n\tdata\\file1\n\tdata\\image.png\n\tdatasets-ex.spec')
+                         r'Changes to be committed:\s+Untracked files:\s+data(?:\\|/)file1\s+data(?:\\|/)image.png\s+datasets-ex.spec')
 
         create_ignore_file(workspace)
         self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
-                         r'Changes to be committed:\n\nUntracked files:\n\t.mlgitignore\n\tdata\\file1\n\tdatasets-ex.spec')
+                         r'Changes to be committed:\s+Untracked files:\s+.mlgitignore\s+data(?:\\|/)file1\s+datasets-ex.spec')
 
         self.assertIn(output_messages['INFO_ADDING_PATH'] % DATASETS,
                       check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion')))
         self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)),
-                         r'Changes to be committed:\n\tNew file: .mlgitignore\n\tNew file: data/file1'
-                         r'\n\tNew file: datasets-ex.spec\n\nUntracked files:\n\n')
+                         r'Changes to be committed:\s+New file: .mlgitignore\s+'
+                         r'New file: data(?:\\|/)file1\s+New file: datasets-ex.spec\s+Untracked files:\s+')
 
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '')))
-        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)), r'Changes to be committed:\n\nUntracked files:\n\n')
+        self.assertRegex(check_output(MLGIT_STATUS % (DATASETS, DATASET_NAME)), r'Changes to be committed:\s+Untracked files:\s+')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,11 +15,12 @@ import pytest
 import yaml
 
 from ml_git.constants import ROOT_FILE_NAME, V1_STORAGE_KEY, V1_DATASETS_KEY, V1_MODELS_KEY, STORAGE_CONFIG_KEY, \
-    EntityType
+    EntityType, MLGIT_IGNORE_FILE_NAME
 from ml_git.utils import json_load, yaml_load, yaml_save, RootPathException, get_root_path, change_mask_for_routine, \
     ensure_path_exists, yaml_load_str, get_yaml_str, run_function_per_group, unzip_files_in_directory, \
     remove_from_workspace, group_files_by_path, remove_other_files, remove_unnecessary_files, change_keys_in_config, \
-    update_directories_to_plural, validate_config_keys, create_csv_file, create_or_update_gitignore
+    update_directories_to_plural, validate_config_keys, create_csv_file, create_or_update_gitignore, should_ignore_file, \
+    get_ignore_rules
 from tests.unit.conftest import DATASETS, MODELS, S3H, S3
 
 
@@ -306,3 +307,25 @@ class UtilsTestCases(unittest.TestCase):
                 for line in file:
                     formatted_line = line.rstrip('\n')
                     self.assertTrue(formatted_line in ignored_files)
+
+    def test_should_ignore_file(self):
+        ignore_rules = ['data/*.png', 'ignored-folder/', '*.jpg', 'data/file-ignored.txt']
+        self.assertTrue(should_ignore_file(ignore_rules, 'data/file.png'))
+        self.assertTrue(should_ignore_file(ignore_rules, 'data/file.jpg'))
+        self.assertTrue(should_ignore_file(ignore_rules, 'file.jpg'))
+        self.assertFalse(should_ignore_file(ignore_rules, 'data/file.txt'))
+        self.assertTrue(should_ignore_file(ignore_rules, 'ignored-folder/'))
+        self.assertTrue(should_ignore_file(ignore_rules, 'data/file-ignored.txt'))
+        self.assertFalse(should_ignore_file(ignore_rules, 'file.txt'))
+        self.assertFalse(should_ignore_file(None, 'file.txt'))
+
+    def test_get_ignore_rules(self):
+        ignore_rules = ['data/*.png\n', 'ignored-folder/']
+        file = os.path.join(self.tmp_dir, MLGIT_IGNORE_FILE_NAME)
+        with open(file, 'wt') as file:
+            file.writelines(ignore_rules)
+        result = get_ignore_rules(self.tmp_dir)
+        expected_rules = ['data/*.png', 'ignored-folder/']
+        self.assertEqual(result, expected_rules)
+        self.assertEqual(None, get_ignore_rules('wrong-path'))
+

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -328,4 +328,3 @@ class UtilsTestCases(unittest.TestCase):
         expected_rules = ['data/*.png', 'ignored-folder/']
         self.assertEqual(result, expected_rules)
         self.assertEqual(None, get_ignore_rules('wrong-path'))
-

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -309,7 +309,8 @@ class UtilsTestCases(unittest.TestCase):
                     self.assertTrue(formatted_line in ignored_files)
 
     def test_should_ignore_file(self):
-        ignore_rules = ['data/*.png', 'ignored-folder/', '*.jpg', 'data/file-ignored.txt']
+        ignore_rules = ['data/*.png', 'ignored-folder/', '*.jpg', 'data/file-ignored.txt',
+                        'data/**/*.tx*', '**/*.test*', '**/access.[0-2].log', 'access.[a-c]*']
         self.assertTrue(should_ignore_file(ignore_rules, 'data/file.png'))
         self.assertTrue(should_ignore_file(ignore_rules, 'data/file.jpg'))
         self.assertTrue(should_ignore_file(ignore_rules, 'file.jpg'))
@@ -318,6 +319,13 @@ class UtilsTestCases(unittest.TestCase):
         self.assertTrue(should_ignore_file(ignore_rules, 'data/file-ignored.txt'))
         self.assertFalse(should_ignore_file(ignore_rules, 'file.txt'))
         self.assertFalse(should_ignore_file(None, 'file.txt'))
+        self.assertTrue(should_ignore_file(ignore_rules, 'data/other-folder/file.txt'))
+        self.assertFalse(should_ignore_file(ignore_rules, 'data/other-folder/file.tsc'))
+        self.assertTrue(should_ignore_file(ignore_rules, 'data/file.test.ts'))
+        self.assertTrue(should_ignore_file(ignore_rules, 'data/access.0.log'))
+        self.assertFalse(should_ignore_file(ignore_rules, 'data/access.3.log'))
+        self.assertTrue(should_ignore_file(ignore_rules, 'access.b.log'))
+        self.assertFalse(should_ignore_file(ignore_rules, 'access.d.log'))
 
     def test_get_ignore_rules(self):
         ignore_rules = ['data/*.png\n', 'ignored-folder/']


### PR DESCRIPTION
Inside an entity's directory it is possible that the user has files that he does not want to version. With that in mind, this PR adds support for defining the `.mlgitignore` file which should define rules to indicate which files should be ignored.

The `.mlgitignore` file must be defined in the entity root folder. This means that each entity can have its `.mlgitignore` file, and the defined rules will only be valid for files inside the entity dir.

workspace structure example:
```
project/
├── datasets
│      └── dataset-ex
│          └── data
│              └── file.png
│              └── file.txt
│              └── file2.txt
│              └── augmented
│                  └── file.png
│          └── dataset-ex.spec
│          └── .mlgitignore <- HERE
├── .ml-git
│    ├── datasets
└──  └── config
```

The `.mlgitignore` rules provides support for Unix shell-style wildcards, this rules are similar to the standard `.gitignore` rules. Example of `.mlgitignore` for the worksapce structure above:

```
# Ignore all PNG files inside data directory
data/*.png 

# Ignore specific file
data/file2.txt

# Ignore all JPG files in the entitiy
*.jpg

# Ignore all files inside a folder
data/augmented/
```

The rules defined inside `.mlgitignore`, besides determining which files should not be versioned, also cause these files not to be presented in the status command.