### PR TITLE
Adding DOT export in get project entitie relationships API method

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -314,7 +314,7 @@ class EntityManager:
 
         Args:
             config_repo_name (str): The repository name where the config file is located in GitHub.
-            export_type (str): Set the format of the return [default: json].
+            export_type (str): Set the format of the return (json, csv, dot) [default: json].
             export_path (str): Set the path to export metrics to a file.
 
         Returns:

--- a/ml_git/relationship/entity_manager.py
+++ b/ml_git/relationship/entity_manager.py
@@ -220,4 +220,7 @@ class EntityManager:
 
         if export_type == FileType.CSV.value:
             all_relationships = export_relationships_to_csv(project_entities, all_relationships, export_path)
+        elif export_type == FileType.DOT.value:
+            all_relationships = export_relationships_to_dot(project_entities, all_relationships, export_path)
+
         return all_relationships

--- a/ml_git/relationship/github_manager.py
+++ b/ml_git/relationship/github_manager.py
@@ -19,7 +19,7 @@ class GithubManager:
         :param: repository_name (str). The name of repository.
         :return: :class: github.Repository.Repository
         """
-        return next(iter(self.__client.search_repositories(repository_name)), None)
+        return self.__client.get_repo(repository_name)
 
     @staticmethod
     def file_exists(repository, file_path):

--- a/ml_git/relationship/utils.py
+++ b/ml_git/relationship/utils.py
@@ -133,5 +133,4 @@ def export_relationships_to_dot(entities, relationships, export_path):
         file_path = os.path.join(export_path, file_name)
         with open(file_path, 'w') as out:
             out.write(dot_data)
-        return
     return dot_data


### PR DESCRIPTION
**Depends on #127.**

Adding DOT export in get project entities relationships API method. This method uses the Github API.

```
    def get_project_entities_relationships(self, config_repo_name, export_type=FileType.JSON.value, export_path=None):
        """Get a list of relationships for all project entities.

        Args:
            config_repo_name (str): The repository name where the config is located in GitHub.
            export_type (str): Set the format of the return (json, csv, dot) [default: json].
            export_path (str): Set the path to export metrics to a file.

        Returns:
            list of EntityVersionRelationships.
        """
```



**Usage example:** 
```python
from ml_git import api
github_token = ''
api_url = 'https://api.github.com'
manager = api.init_entity_manager(github_token, api_url)

relationships = manager.manager.get_project_entities_relationships(config_repo_name='user/metadata_repository', 'dot')
```

The variable `relationships` should look something like:
```
digraph "Entities Graph" {
"models-ex (1)" [color="#d63638"];
"dataset-ex (1)" [color="#2271b1"];
"models-ex (1)" -> "dataset-ex (1)";
"models-ex (1)" [color="#d63638"];
"labels-ex (1)" [color="#996800"];
"models-ex (1)" -> "labels-ex (1)";
}
 
```