### PR TITLE
Improve GitHub api access in ML-Git API

### DIFF
--- a/ml_git/relationship/entity_manager.py
+++ b/ml_git/relationship/entity_manager.py
@@ -48,6 +48,9 @@ class EntityManager:
                 spec_yaml = yaml_load_str(self._manager.get_file_content(repository, spec_path))
                 entity = Entity(repository, spec_yaml)
                 entities.append(entity)
+
+        self._manager.alert_rate_limits()
+
         return entities
 
     def _get_entities_from_config(self, config_path):
@@ -111,6 +114,7 @@ class EntityManager:
         """
         if config_repo_name:
             return self._get_entities_from_repo(config_repo_name)
+
         return self._get_entities_from_config(config_path)
 
     def _get_entity_versions(self, name, spec_path, repository):
@@ -152,6 +156,8 @@ class EntityManager:
         """
         repository = self._manager.find_repository(metadata_repo_name)
         spec_path = self._get_entity_spec_path(repository, name)
+        self._manager.alert_rate_limits()
+
         return self._get_entity_versions(name, spec_path, repository)
 
     def _get_linked_entities(self, name, version, spec_path, repository):
@@ -192,6 +198,8 @@ class EntityManager:
         """
         repository = self._manager.find_repository(metadata_repo_name)
         spec_path = self._get_entity_spec_path(repository, name)
+
+        self._manager.alert_rate_limits()
         return self._get_linked_entities(name, version, spec_path, repository)
 
     def get_entity_relationships(self, name, metadata_repo_name, export_type=FileType.JSON.value, export_path=None):
@@ -221,6 +229,8 @@ class EntityManager:
 
         if export_type == FileType.CSV.value:
             relationships = export_relationships_to_csv([entity_versions[0]], relationships, export_path)
+
+        self._manager.alert_rate_limits()
         return relationships
 
     def get_project_entities_relationships(self, config_repo_name, export_type=FileType.JSON.value, export_path=None):
@@ -251,4 +261,5 @@ class EntityManager:
         if export_type == FileType.CSV.value:
             all_relationships = export_relationships_to_csv(project_entities, all_relationships, export_path)
 
+        self._manager.alert_rate_limits()
         return all_relationships

--- a/ml_git/relationship/github_manager.py
+++ b/ml_git/relationship/github_manager.py
@@ -3,6 +3,7 @@
 SPDX-License-Identifier: GPL-2.0-only
 """
 import github
+from github import UnknownObjectException
 
 
 class GithubManager:
@@ -19,7 +20,13 @@ class GithubManager:
         :param: repository_name (str). The name of repository.
         :return: :class: github.Repository.Repository
         """
-        return next(iter(self.__client.search_repositories(repository_name)), None)
+        try:
+            return self.__client.get_repo(repository_name)
+        except UnknownObjectException as e:
+            if e.status == 404:
+                raise RuntimeError('Repository not found: {}'.format(repository_name))
+            else:
+                raise e
 
     @staticmethod
     def file_exists(repository, file_path):

--- a/ml_git/relationship/github_manager.py
+++ b/ml_git/relationship/github_manager.py
@@ -70,8 +70,8 @@ class GithubManager:
     def alert_rate_limits(self):
         search_rem, search_reset, core_rem, core_reset = self.__retrieve_rate_limit()
         if search_rem <= self.NUMBER_OF_LIMIT_TO_WARN:
-            log.warn('Remaining {} rate limit: [{}]. It will reset after [{}s]'.
+            log.debug('Remaining {} rate limit: [{}]. It will reset after [{}s]'.
                      format('SEARCH', search_rem, search_reset))
         if core_rem <= self.NUMBER_OF_LIMIT_TO_WARN:
-            log.warn('Remaining {} rate limit: [{}]. It will reset after [{}s]'.
+            log.debug('Remaining {} rate limit: [{}]. It will reset after [{}s]'.
                      format('CORE', core_rem, core_reset))

--- a/ml_git/relationship/github_manager.py
+++ b/ml_git/relationship/github_manager.py
@@ -2,14 +2,21 @@
 © Copyright 2021 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
+
+from datetime import datetime
+
 import github
 from github import UnknownObjectException
+
+from ml_git import log
 
 
 class GithubManager:
     """
     Class to manage github operations
     """
+
+    NUMBER_OF_LIMIT_TO_WARN = 10
 
     def __init__(self, github_token, url):
         self.__client = github.Github(github_token, base_url=url)
@@ -21,7 +28,8 @@ class GithubManager:
         :return: :class: github.Repository.Repository
         """
         try:
-            return self.__client.get_repo(repository_name)
+            repo = self.__client.get_repo(repository_name)
+            return repo
         except UnknownObjectException as e:
             if e.status == 404:
                 raise RuntimeError('Repository not found: {}'.format(repository_name))
@@ -47,3 +55,23 @@ class GithubManager:
         files = self.__client.search_code(query='repo:{} extension:{}'.format(repository.full_name, extension))
         for file in files:
             yield file.path
+
+    def __retrieve_rate_limit(self):
+        rate_limit = self.__client.get_rate_limit()
+        search_remaining_limit = rate_limit.search.remaining
+        core_remaining_limit = rate_limit.core.remaining
+        search_reset = rate_limit.search.reset
+        core_reset = rate_limit.core.reset
+        search_request_time = datetime.strptime(rate_limit.raw_headers['date'], '%a, %d %b %Y %H:%M:%S %Z')
+        search_seconds_to_reset = (search_reset - search_request_time).total_seconds()
+        core_seconds_to_reset = (core_reset - search_request_time).total_seconds()
+        return search_remaining_limit, search_seconds_to_reset, core_remaining_limit, core_seconds_to_reset
+
+    def alert_rate_limits(self):
+        search_rem, search_reset, core_rem, core_reset = self.__retrieve_rate_limit()
+        if search_rem <= self.NUMBER_OF_LIMIT_TO_WARN:
+            log.warn('Remaining {} rate limit: [{}]. It will reset after [{}s]'.
+                     format('SEARCH', search_rem, search_reset))
+        if core_rem <= self.NUMBER_OF_LIMIT_TO_WARN:
+            log.warn('Remaining {} rate limit: [{}]. It will reset after [{}s]'.
+                     format('CORE', core_rem, core_reset))

--- a/ml_git/relationship/models/config.py
+++ b/ml_git/relationship/models/config.py
@@ -3,7 +3,8 @@
 SPDX-License-Identifier: GPL-2.0-only
 """
 
-from ml_git.constants import STORAGE_CONFIG_KEY, V1_STORAGE_KEY, EntityType, V1_DATASETS_KEY, V1_MODELS_KEY
+from ml_git.constants import STORAGE_CONFIG_KEY, V1_STORAGE_KEY, EntityType, V1_DATASETS_KEY, V1_MODELS_KEY, \
+    LABELS_SPEC_KEY
 from ml_git.relationship.utils import get_repo_name_from_url, format_storages
 
 
@@ -35,11 +36,11 @@ class Config:
         return storage_config_key, dataset_key, model_key
 
     def get_entity_type_remote(self, entity_type):
-        _, dataset_key, model_key = self._get_config_keys()
-        if entity_type == V1_DATASETS_KEY:
-            return self.remotes[dataset_key]
-        elif entity_type == V1_MODELS_KEY:
-            return self.remotes[model_key]
-        elif entity_type == EntityType.LABELS.value:
-            return self.remotes[EntityType.LABELS.value]
+        e_types = {
+            V1_DATASETS_KEY: EntityType.DATASETS.value,
+            LABELS_SPEC_KEY: EntityType.LABELS.value,
+            V1_MODELS_KEY: EntityType.MODELS.value
+        }
+        if entity_type in e_types:
+            return self.remotes[e_types.get(entity_type)]
         raise RuntimeError('Invalid entity type')

--- a/ml_git/relationship/models/spec_version.py
+++ b/ml_git/relationship/models/spec_version.py
@@ -30,7 +30,7 @@ class SpecVersion:
         self.name = spec_tag_yaml[self.type]['name']
         self.version = spec_tag_yaml[self.type]['version']
         self.tag = self.__get_tag(spec_tag_yaml)
-        self.mutability = spec_tag_yaml[self.type]['mutability']
+        self.mutability = spec_tag_yaml[self.type].get('mutability', 'strict')
         self.categories = self.__format_categories()
         self.storage = self.__get_storage_info()
         self.total_versioned_files = spec_tag_yaml[self.type]['manifest']['amount']

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -32,40 +32,36 @@ dummy_config = {
     },
 }
 
-search_repo_url = '{}/search/repositories?q=dummy%2Fdummy_{}_repo'  # dummy_api_github_url
+search_repo_url = '{}/repos/dummy/dummy_{}_repo'  # dummy_api_github_url
 search_code_url = '{}/search/code?q=repo%3Adummy_{}+extension%3A.spec'  # dummy_api_github_url
 entity_content_url = '{}/repos/dummy_{}_repo/contents/{}-ex/{}-ex.spec'
 get_repo_url = '{}/dummy_{}_repo'  # dummy_api_github_url.replace("api.","")
 get_tags_from_repo_url = '{}/repos/dummy_{}_repo/tags'
 get_spec_content_url = '{}/repos/dummy/dummy_{}_repo/contents/{}-ex/{}-ex.spec?ref=test__{}-ex__1'
 
-dummy_config_remote_url = f'{dummy_api_github_url}/search/repositories?q=dummy%2Fdummy_config'
+dummy_config_remote_url = f'{dummy_api_github_url}/repos/dummy/dummy_config'
 dummy_config_content_url = f'{dummy_api_github_url}/repos/dummy/dummy_config/contents//.ml-git/config.yaml'
 
 
 def get_search_repo_response(type):
     return {
-        'items': [
-            {
-                'id': 310705171,
-                'name': 'dummy_{}'.format(type),
-                'full_name': 'dummy_{}'.format(type),
-                'private': False,
-                'owner': {
-                    'login': 'dummy',
-                    'id': 24386872,
-                    'url': 'https://github.com/dummy_{}_repo'.format(type),
-                    'html_url': 'https://github.com/dummy_{}_repo'.format(type),
-                    'type': 'User',
-                    'site_admin': False
-                },
+            'id': 310705171,
+            'name': 'dummy_{}'.format(type),
+            'full_name': 'dummy_{}'.format(type),
+            'private': False,
+            'owner': {
+                'login': 'dummy',
+                'id': 24386872,
+                'url': 'https://github.com/dummy_{}_repo'.format(type),
                 'html_url': 'https://github.com/dummy_{}_repo'.format(type),
-                'url': 'https://api.github.com/repos/dummy_{}_repo'.format(type),
-                'git_url': 'git://github.com/dummy_{}.git'.format(type),
-                'ssh_url': 'git@github.com:dummy/dummy_{}.git'.format(type),
-            }
-        ]
-    }
+                'type': 'User',
+                'site_admin': False
+            },
+            'html_url': 'https://github.com/dummy_{}_repo'.format(type),
+            'url': 'https://api.github.com/repos/dummy_{}_repo'.format(type),
+            'git_url': 'git://github.com/dummy_{}.git'.format(type),
+            'ssh_url': 'git@github.com:dummy/dummy_{}.git'.format(type),
+        }
 
 
 def get_search_code_response(type):
@@ -151,26 +147,22 @@ def get_content_from_tag(type):
 
 
 config_repo_response = {
-    'items': [
-        {
-            'id': 310705171,
-            'name': 'dummy_config',
-            'full_name': 'dummy_config',
-            'private': False,
-            'owner': {
-                'login': 'dummy',
-                'id': 24386872,
-                'url': 'https://github.com/dummy/dummy_config',
-                'html_url': 'https://github.com/dummy/dummy_config',
-                'type': 'User',
-                'site_admin': False
-            },
-            'html_url': 'https://github.com/dummy/dummy_config',
-            'url': 'https://api.github.com/repos/dummy/dummy_config',
-            'git_url': 'git://github.com/dummy/dummy_config.git',
-            'ssh_url': 'git@github.com:dummy/dummy/dummy_config.git',
-        }
-    ]
+    'id': 310705171,
+    'name': 'dummy_config',
+    'full_name': 'dummy_config',
+    'private': False,
+    'owner': {
+        'login': 'dummy',
+        'id': 24386872,
+        'url': 'https://github.com/dummy/dummy_config',
+        'html_url': 'https://github.com/dummy/dummy_config',
+        'type': 'User',
+        'site_admin': False
+    },
+    'html_url': 'https://github.com/dummy/dummy_config',
+    'url': 'https://api.github.com/repos/dummy/dummy_config',
+    'git_url': 'git://github.com/dummy/dummy_config.git',
+    'ssh_url': 'git@github.com:dummy/dummy/dummy_config.git',
 }
 
 config_content_response = {

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -42,6 +42,8 @@ get_spec_content_url = '{}/repos/dummy/dummy_{}_repo/contents/{}-ex/{}-ex.spec?r
 dummy_config_remote_url = f'{dummy_api_github_url}/repos/dummy/dummy_config'
 dummy_config_content_url = f'{dummy_api_github_url}/repos/dummy/dummy_config/contents//.ml-git/config.yaml'
 
+rate_limit_url = '{}/rate_limit'  # dummy_rate_limit_github_url
+
 
 def get_search_repo_response(type):
     return {
@@ -175,7 +177,49 @@ config_content_response = {
     'encoding': 'base64',
 }
 
+rate_limit_response = {
+    'resources': {
+        'core': {
+          'limit': 10,
+          'remaining': 4999,
+          'reset': 1372700873,
+          'used': 1
+        },
+        'search': {
+          'limit': 10,
+          'remaining': 18,
+          'reset': 1372697452,
+          'used': 12
+        },
+        'graphql': {
+          'limit': 5000,
+          'remaining': 4993,
+          'reset': 1372700389,
+          'used': 7
+        },
+        'integration_manifest': {
+          'limit': 5000,
+          'remaining': 4999,
+          'reset': 1551806725,
+          'used': 1
+        },
+        'code_scanning_upload': {
+          'limit': 500,
+          'remaining': 499,
+          'reset': 1551806725,
+          'used': 1
+        }
+    },
+    'rate': {
+        'limit': 5000,
+        'remaining': 4999,
+        'reset': 1372700873,
+        'used': 1
+    }
+}
+
 HEADERS = {
+    'date': 'Fri, 12 Oct 2012 23:33:14 GMT',
     'access-control-allow-origin': '*',
     'access-control-expose-headers': 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit,'
                                      ' X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes,'
@@ -206,13 +250,15 @@ class ApiTestCases(unittest.TestCase):
         self.requests_mock.get(
             entity_content_url.format(dummy_api_github_url, type, type, type, type),
             status_code=200, headers=HEADERS, json=get_spec_entity_content(type))
-        self.requests_mock.get(get_repo_url.format(dummy_api_github_url.replace("api.", ""), type),
+        self.requests_mock.get(get_repo_url.format(dummy_api_github_url.replace('api.', ''), type),
                                status_code=200, headers=HEADERS, json=repo)
         self.requests_mock.get(get_tags_from_repo_url.format(dummy_api_github_url, type), status_code=200,
                                headers=HEADERS, json=get_repo_tags(type))
         self.requests_mock.get(
             get_spec_content_url.format(dummy_api_github_url, type, type, type, type),
             status_code=200, headers=HEADERS, json=get_content_from_tag(type))
+        self.requests_mock.get(rate_limit_url.format(dummy_api_github_url), status_code=200,
+                               headers=HEADERS, json=rate_limit_response)
 
     def setUp(self):
         from ml_git import api


### PR DESCRIPTION
Changes:
- **find_repository**: Modified to use the core quote, that is bigger than search quote.
- **get_entity_relationships**: Modified to reuse repository search and specification file search methods.
- **_get_linked_entities**: Created method to reuse repository search and spec path search.
- **_get_entity_versions**: Created method to reuse repository search and spec path search.
- **alert_rate_limits**:  Displays when the quota is reaching the limit.