### PR TITLE
Fixing help messages with ellipsis

### DIFF
--- a/ml_git/commands/descriptor.py
+++ b/ml_git/commands/descriptor.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2021 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 

--- a/ml_git/commands/descriptor.py
+++ b/ml_git/commands/descriptor.py
@@ -611,7 +611,9 @@ def define_command(descriptor):
     for group in descriptor['groups']:
         command_copy = copy.deepcopy(command)
         if '%s' in descriptor['help']:
-            command_copy.help = descriptor['help'] % group.name
+            command_copy.short_help = descriptor['help'] % group.name
+        else:
+            command_copy.short_help = descriptor['help']
         group.add_command(command_copy)
 
 

--- a/ml_git/commands/descriptor.py
+++ b/ml_git/commands/descriptor.py
@@ -589,7 +589,7 @@ commands = [
 def define_command(descriptor):
     callback = descriptor['callback']
 
-    command = click.command(name=descriptor['name'], help=descriptor['help'], cls=DeprecatedOptionsCommand)(click.pass_context(callback))
+    command = click.command(name=descriptor['name'], short_help=descriptor['help'], cls=DeprecatedOptionsCommand)(click.pass_context(callback))
 
     if 'arguments' in descriptor:
         for key, value in descriptor['arguments'].items():
@@ -612,8 +612,6 @@ def define_command(descriptor):
         command_copy = copy.deepcopy(command)
         if '%s' in descriptor['help']:
             command_copy.short_help = descriptor['help'] % group.name
-        else:
-            command_copy.short_help = descriptor['help']
         group.add_command(command_copy)
 
 


### PR DESCRIPTION
When the user types **ml-git datasets --help** command some help messages are displayed with ellipsis

**Note**: the same issue happens when executing the commands **ml-git models --help** and **ml-git labels --help**

Current output:

![image](https://user-images.githubusercontent.com/18489870/131145740-b3cac316-3ea2-4f04-b95c-0f4cc1c86a6a.png)

Expected output:

![image](https://user-images.githubusercontent.com/18489870/131145943-21930891-a350-4658-8054-3f270924d9d2.png)

There is an issue [here](https://github.com/pallets/click/issues/486) reporting the problem and the solution.




