### PR TITLE
Adding support to password-protected ssh keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test.integration:
 ifeq ($(detected_OS),Windows)
 	.\scripts\run_integration_tests.bat
 else
-	./scripts/run_integration_tests.sh test_19_create.py
+	./scripts/run_integration_tests.sh
 endif
 
 .PHONY: test.integration.gdrive

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test.integration:
 ifeq ($(detected_OS),Windows)
 	.\scripts\run_integration_tests.bat
 else
-	./scripts/run_integration_tests.sh
+	./scripts/run_integration_tests.sh test_19_create.py
 endif
 
 .PHONY: test.integration.gdrive

--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -527,9 +527,7 @@ class MetadataRepo(object):
         repo = Repo(self.__path)
         for url in repo.remote().urls:
             if url == blank_url:
-                git_error = GitError()
-                git_error.stderr = output_messages['ERROR_REMOTE_NOT_FOUND']
-                raise git_error
+                raise Exception(output_messages['ERROR_REMOTE_NOT_FOUND'])
 
     def delete_git_reference(self):
         try:

--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -9,6 +9,7 @@ import re
 import time
 
 from git import Repo, Git, InvalidGitRepositoryError, GitError
+from halo import Halo
 from prettytable import PrettyTable
 
 from ml_git import log
@@ -127,6 +128,7 @@ class MetadataRepo(object):
         repo = Repo(self.__path)
         return repo.create_tag(tag, message='Automatic tag "{0}"'.format(tag))
 
+    @Halo(text='Pushing metadata to the git repository', spinner='dots')
     def push(self):
         log.debug(output_messages['DEBUG_PUSH'] % self.__path, class_name=METADATA_MANAGER_CLASS_NAME)
         self.validate_blank_remote_url()

--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -8,8 +8,7 @@ import os
 import re
 import time
 
-from git import Repo, Git, InvalidGitRepositoryError, GitError, PushInfo
-from halo import Halo
+from git import Repo, Git, InvalidGitRepositoryError, GitError
 from prettytable import PrettyTable
 
 from ml_git import log
@@ -18,6 +17,7 @@ from ml_git.constants import METADATA_MANAGER_CLASS_NAME, HEAD_1, RGX_ADDED_FILE
     RGX_AMOUNT_FILES, TAG, AUTHOR, EMAIL, DATE, MESSAGE, ADDED, SIZE, AMOUNT, DELETED, SPEC_EXTENSION, \
     DEFAULT_BRANCH_FOR_EMPTY_REPOSITORY, PERFORMANCE_KEY, EntityType, FileType, RELATED_DATASET_TABLE_INFO, \
     RELATED_LABELS_TABLE_INFO, DATASET_SPEC_KEY, LABELS_SPEC_KEY
+from ml_git.git_client import GitClient
 from ml_git.manifest import Manifest
 from ml_git.ml_git_message import output_messages
 from ml_git.spec import get_entity_dir, spec_parse, get_spec_key
@@ -34,6 +34,7 @@ class MetadataRepo(object):
             self.__path = os.path.join(root_path, path)
             self.__git = git
             ensure_path_exists(self.__path)
+            self.__git_client = GitClient(self.__git, self.__path)
         except RootPathException as e:
             log.error(e, class_name=METADATA_MANAGER_CLASS_NAME)
             raise e
@@ -45,21 +46,8 @@ class MetadataRepo(object):
             return
 
     def init(self):
-        try:
-            log.info(output_messages['INFO_METADATA_INIT'] % (self.__git, self.__path), class_name=METADATA_MANAGER_CLASS_NAME)
-            Repo.clone_from(self.__git, self.__path)
-        except GitError as g:
-            if 'fatal: repository \'\' does not exist' in g.stderr:
-                raise GitError(output_messages['ERROR_UNABLE_TO_FIND_REMOTE_REPOSITORY'])
-            elif 'Repository not found' in g.stderr:
-                raise GitError(output_messages['ERROR_UNABLE_TO_FIND'] % self.__git)
-            elif 'already exists and is not an empty directory' in g.stderr:
-                raise GitError(output_messages['ERROR_PATH_ALREAD_EXISTS'] % self.__path)
-            elif 'Authentication failed' in g.stderr:
-                raise GitError(output_messages['ERROR_GIT_REMOTE_AUTHENTICATION_FAILED'])
-            else:
-                raise GitError(g.stderr)
-            return
+        log.info(output_messages['INFO_METADATA_INIT'] % (self.__git, self.__path), class_name=METADATA_MANAGER_CLASS_NAME)
+        self.__git_client.clone()
 
     def init_local_repo(self):
         if os.path.exists(os.path.join(self.__path, '.git')):
@@ -126,10 +114,8 @@ class MetadataRepo(object):
 
     def update(self):
         log.info(output_messages['INFO_MLGIT_PULL'] % self.__path, class_name=METADATA_MANAGER_CLASS_NAME)
-        repo = Repo(self.__path)
         self.validate_blank_remote_url()
-        o = repo.remotes.origin
-        o.pull('--tags')
+        self.__git_client.pull()
 
     def commit(self, file, msg):
         log.info(output_messages['INFO_COMMIT_REPO'] % (self.__path, file), class_name=METADATA_MANAGER_CLASS_NAME)
@@ -141,40 +127,19 @@ class MetadataRepo(object):
         repo = Repo(self.__path)
         return repo.create_tag(tag, message='Automatic tag "{0}"'.format(tag))
 
-    @Halo(text='Pushing metadata to the git repository', spinner='dots')
     def push(self):
         log.debug(output_messages['DEBUG_PUSH'] % self.__path, class_name=METADATA_MANAGER_CLASS_NAME)
-        repo = Repo(self.__path)
-        try:
-            self.validate_blank_remote_url()
-            for i in repo.remotes.origin.push(tags=True):
-                if (i.flags & PushInfo.ERROR) == PushInfo.ERROR:
-                    raise RuntimeError(output_messages['ERROR_PUSH_METADATA'])
-
-            for i in repo.remotes.origin.push():
-                if (i.flags & PushInfo.ERROR) == PushInfo.ERROR:
-                    raise RuntimeError(output_messages['ERROR_PUSH_METADATA'])
-        except GitError as e:
-            err = e.stderr
-            match = re.search("stderr: 'fatal:((?:.|\\s)*)'", err)
-            if match:
-                err = match.group(1)
-                raise GitError(err)
+        self.validate_blank_remote_url()
+        self.__git_client.push(tags=True)
+        self.__git_client.push(tags=False)
 
     def fetch(self):
         try:
             log.debug(output_messages['DEBUG_FETCH'] % self.__path, class_name=METADATA_MANAGER_CLASS_NAME)
-            repo = Repo(self.__path)
             self.validate_blank_remote_url()
-            repo.remotes.origin.fetch()
-        except GitError as e:
-            err = e.stderr
-            match = re.search('stderr: \'fatal:(.*)\'', err)
-            if match:
-                err = match.group(1)
-                log.error(err, class_name=METADATA_MANAGER_CLASS_NAME)
-            else:
-                log.error(err, class_name=METADATA_MANAGER_CLASS_NAME)
+            self.__git_client.fetch()
+        except Exception as e:
+            log.error(str(e), class_name=METADATA_MANAGER_CLASS_NAME)
             return False
 
     def list_tags(self, spec, full_info=False):

--- a/ml_git/admin.py
+++ b/ml_git/admin.py
@@ -5,11 +5,12 @@ SPDX-License-Identifier: GPL-2.0-only
 
 import os
 
-from git import Repo, GitCommandError
+from git import GitCommandError
 
 from ml_git import log
 from ml_git.config import mlgit_config_save, get_global_config_path
 from ml_git.constants import ROOT_FILE_NAME, CONFIG_FILE, ADMIN_CLASS_NAME, StorageType, STORAGE_CONFIG_KEY
+from ml_git.git_client import GitClient
 from ml_git.ml_git_message import output_messages
 from ml_git.storages.store_utils import get_bucket_region
 from ml_git.utils import get_root_path, create_or_update_gitignore
@@ -178,7 +179,9 @@ def clone_config_repository(url, folder, untracked):
             log.error(output_messages['ERROR_PATH_NOT_EMPTY']
                       % project_dir, class_name=ADMIN_CLASS_NAME)
             return False
-        Repo.clone_from(url, project_dir)
+
+        git_client = GitClient(url, project_dir)
+        git_client.clone()
     except Exception as e:
         error_msg = handle_clone_exception(e, folder, project_dir)
         log.error(error_msg, class_name=ADMIN_CLASS_NAME)

--- a/ml_git/constants.py
+++ b/ml_git/constants.py
@@ -74,6 +74,7 @@ MODEL_SPEC_KEY = 'model'
 STORAGE_SPEC_KEY = 'storage'
 STORAGE_CONFIG_KEY = 'storages'
 MLGIT_IGNORE_FILE_NAME = '.mlgitignore'
+GIT_CLIENT_CLASS_NAME = 'GitClient'
 
 
 class MutabilityType(Enum):

--- a/ml_git/git_client.py
+++ b/ml_git/git_client.py
@@ -40,15 +40,14 @@ class GitClient(object):
     def _execute(self, command, change_dir=True):
         if 'clone' not in command:
             log.debug(output_messages['DEBUG_EXECUTING_COMMAND'] % command, class_name=GIT_CLIENT_CLASS_NAME)
-        if change_dir:
-            current_dir = os.getcwd()
-            os.chdir(self._path)
-        proc = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                              universal_newlines=True, shell=True)
-        if change_dir:
-            os.chdir(current_dir)
-        self._check_output(proc)
 
+        cwd = None
+        if change_dir:
+            cwd = self._path
+        proc = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                              universal_newlines=True, shell=True, cwd=cwd)
+
+        self._check_output(proc)
         return proc
 
     def _get_origin(self):

--- a/ml_git/git_client.py
+++ b/ml_git/git_client.py
@@ -41,21 +41,23 @@ class GitClient(object):
         self._check_output(proc)
         return proc
 
-    def push(self, porcelain=True, tags=True):
+    def _get_origin(self):
         repo = Repo(self._path)
         origin = repo.remotes.origin
+        return origin
+
+    def push(self, porcelain=True, tags=True):
+        origin = self._get_origin()
         push_command = 'git push {} {} {}'.format(origin, '--porcelain' if porcelain else '', '--tags' if tags else '')
         self._execute(push_command)
 
     def pull(self, tags=True):
-        repo = Repo(self._path)
-        origin = repo.remotes.origin
+        origin = self._get_origin()
         pull_command = 'git pull {} {}'.format(origin, '--tags' if tags else '')
         self._execute(pull_command)
 
     def fetch(self):
-        repo = Repo(self._path)
-        origin = repo.remotes.origin
+        origin = self._get_origin()
         fetch_command = 'git fetch {}'.format(origin)
         self._execute(fetch_command)
 

--- a/ml_git/git_client.py
+++ b/ml_git/git_client.py
@@ -1,0 +1,64 @@
+"""
+© Copyright 2021 HP Development Company, L.P.
+SPDX-License-Identifier: GPL-2.0-only
+"""
+
+import subprocess
+
+from git import GitError, Repo
+
+from ml_git import log
+from ml_git.constants import GIT_CLIENT_CLASS_NAME
+from ml_git.ml_git_message import output_messages
+
+
+class GitClient(object):
+
+    def __init__(self, git_url, path=None):
+        self._git = git_url
+        self._path = path
+
+    def _check_output(self, proc):
+        if proc.returncode == 0:
+            return
+
+        output = proc.stdout
+        if 'fatal: repository \'\' does not exist' in output:
+            raise GitError(output_messages['ERROR_UNABLE_TO_FIND_REMOTE_REPOSITORY'])
+        elif 'Repository not found' in output:
+            raise GitError(output_messages['ERROR_UNABLE_TO_FIND'] % self._git)
+        elif 'already exists and is not an empty directory' in output:
+            raise GitError(output_messages['ERROR_PATH_ALREAD_EXISTS'] % self._path)
+        elif 'Authentication failed' in output:
+            raise GitError(output_messages['ERROR_GIT_REMOTE_AUTHENTICATION_FAILED'])
+        else:
+            raise GitError(output)
+
+    def _execute(self, command):
+        log.debug(output_messages['DEBUG_EXECUTING_COMMAND'] % command, class_name=GIT_CLIENT_CLASS_NAME)
+        proc = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                              universal_newlines=True, shell=True, cwd=self._path)
+        self._check_output(proc)
+        return proc
+
+    def push(self, porcelain=True, tags=True):
+        repo = Repo(self._path)
+        origin = repo.remotes.origin
+        push_command = 'git push {} {} {}'.format(origin, '--porcelain' if porcelain else '', '--tags' if tags else '')
+        self._execute(push_command)
+
+    def pull(self, tags=True):
+        repo = Repo(self._path)
+        origin = repo.remotes.origin
+        pull_command = 'git pull {} {}'.format(origin, '--tags' if tags else '')
+        self._execute(pull_command)
+
+    def fetch(self):
+        repo = Repo(self._path)
+        origin = repo.remotes.origin
+        fetch_command = 'git fetch {}'.format(origin)
+        self._execute(fetch_command)
+
+    def clone(self):
+        clone_command = 'git clone {} {}'.format(self._git, self._path)
+        self._execute(clone_command)

--- a/ml_git/git_client.py
+++ b/ml_git/git_client.py
@@ -2,7 +2,6 @@
 © Copyright 2021 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
-import os
 import subprocess
 
 from git import GitError, Repo
@@ -38,15 +37,13 @@ class GitClient(object):
             raise GitError(output)
 
     def _execute(self, command, change_dir=True):
-        if 'clone' not in command:
-            log.debug(output_messages['DEBUG_EXECUTING_COMMAND'] % command, class_name=GIT_CLIENT_CLASS_NAME)
-
         cwd = None
         if change_dir:
             cwd = self._path
         proc = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                               universal_newlines=True, shell=True, cwd=cwd)
 
+        log.debug(output_messages['DEBUG_EXECUTING_COMMAND'] % command, class_name=GIT_CLIENT_CLASS_NAME)
         self._check_output(proc)
         return proc
 

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -74,6 +74,7 @@ output_messages = {
     'DEBUG_BLOB_ALREADY_EXISTS': 'The specified blob [%s] already exists.',
     'DEBUG_ALREADY_IN_GIT_REPOSITORY': 'There is already a git repository initialized in the project root [%s]',
     'DEBUG_BUCKET_REGION_NOT_FIND': 'Could not find bucket region entered',
+    'DEBUG_EXECUTING_COMMAND': 'Executing git command: %s',
 
     'INFO_INITIALIZED_PROJECT_IN': 'Initialized empty ml-git repository in %s',
     'INFO_ADD_REMOTE': 'Add remote repository [%s] for [%s]',

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -76,6 +76,7 @@ output_messages = {
     'DEBUG_BUCKET_REGION_NOT_FIND': 'Could not find bucket region entered',
     'DEBUG_RATE_LIMIT': 'Remaining {} rate limit: [{}]. It will reset after [{}s]',
     'DEBUG_EXECUTING_COMMAND': 'Executing git command: %s',
+    'DEBUG_GIT_COMMAND_EXECUTION': 'Git command output: %s',
 
     'INFO_INITIALIZED_PROJECT_IN': 'Initialized empty ml-git repository in %s',
     'INFO_ADD_REMOTE': 'Add remote repository [%s] for [%s]',

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,10 +23,9 @@ def tmp_dir(request, tmp_path):
 
 @pytest.fixture()
 def switch_to_tmp_dir(tmp_path):
-    cwd = os.getcwd()
     os.chdir(tmp_path)
     yield
-    os.chdir(cwd)
+    os.chdir(PATH_TEST)
 
 
 @pytest.fixture()


### PR DESCRIPTION
Added the correction of ssh key password support for the problem found when using ml-git in repositories configured with ssh that need a password, in this case, a popup should be displayed for the user to inform the password to his ssh key, only in the terminals of windows (CMD and Powershell) these passwords were not requested, making it impossible for ml-git to perform any iteration with it.