### PR TITLE
Remove metric options from add command for dataset and labels

### DIFF
--- a/ml_git/commands/descriptor.py
+++ b/ml_git/commands/descriptor.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2021 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
@@ -200,7 +200,26 @@ commands = [
     {
         'name': 'add',
         'callback': entity.add,
-        'groups': [entity.datasets, entity.models, entity.labels],
+        'groups': [entity.datasets, entity.labels],
+
+        'arguments': {
+            'ml-entity-name': {},
+            'file-path': {'nargs': -1, 'required': False}
+        },
+
+        'options': {
+            '--bumpversion': {'is_flag': True, 'help': help_msg.BUMP_VERSION},
+            '--fsck': {'is_flag': True, 'help': help_msg.FSCK_OPTION},
+        },
+
+        'help': 'Add %s change set ML_ENTITY_NAME to the local ml-git staging area.'
+
+    },
+
+    {
+        'name': 'add',
+        'callback': entity.add,
+        'groups': [entity.models],
 
         'arguments': {
             'ml-entity-name': {},

--- a/ml_git/commands/entity.py
+++ b/ml_git/commands/entity.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2021 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
@@ -119,8 +119,8 @@ def add(context, **kwargs):
     run_fsck = kwargs['fsck']
     file_path = kwargs['file_path']
     entity_name = kwargs['ml_entity_name']
-    metric = kwargs['metric']
-    metrics_file_path = kwargs['metrics_file']
+    metric = kwargs.get('metric')
+    metrics_file_path = kwargs.get('metrics_file')
     repositories[repo_type].add(entity_name, file_path, bump_version, run_fsck, metric, metrics_file_path)
 
 

--- a/tests/integration/test_05_add_files.py
+++ b/tests/integration/test_05_add_files.py
@@ -142,7 +142,8 @@ class AddFilesAcceptanceTests(unittest.TestCase):
 
         metrics_options = '--metric Accuracy 1 --metric Recall 2'
 
-        self.assertIn(output_messages['INFO_ADDING_PATH'] % repo_type, check_output(MLGIT_ADD % (repo_type, DATASET_NAME, metrics_options)))
+        self.assertIn(output_messages['ERROR_NO_SUCH_OPTION'] % '--metric',
+                      check_output(MLGIT_ADD % (repo_type, DATASET_NAME, metrics_options)))
         index = os.path.join(ML_GIT_DIR, repo_type, 'index', 'metadata', DATASET_NAME, 'INDEX.yaml')
         self._check_index(index, ['data/file1'], [])
 

--- a/tests/integration/test_05_add_files.py
+++ b/tests/integration/test_05_add_files.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2021 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
@@ -145,7 +145,7 @@ class AddFilesAcceptanceTests(unittest.TestCase):
         self.assertIn(output_messages['ERROR_NO_SUCH_OPTION'] % '--metric',
                       check_output(MLGIT_ADD % (repo_type, DATASET_NAME, metrics_options)))
         index = os.path.join(ML_GIT_DIR, repo_type, 'index', 'metadata', DATASET_NAME, 'INDEX.yaml')
-        self._check_index(index, ['data/file1'], [])
+        self.assertFalse(os.path.exists(index))
 
         with open(os.path.join(workspace, DATASET_NAME+'.spec')) as spec:
             spec_file = yaml_processor.load(spec)

--- a/tests/integration/test_29_log.py
+++ b/tests/integration/test_29_log.py
@@ -28,9 +28,16 @@ class LogTests(unittest.TestCase):
         metrics_options = ''
         if with_metrics:
             metrics_options = '--metric Accuracy 1 --metric Recall 2'
-        self.assertIn(output_messages['INFO_ADDING_PATH'] % repo_type, check_output(MLGIT_ADD % (repo_type, entity, metrics_options)))
-        self.assertIn(output_messages['INFO_COMMIT_REPO'] % (os.path.join(self.tmp_dir, ML_GIT_DIR, repo_type, 'metadata'), entity),
-                      check_output(MLGIT_COMMIT % (repo_type, entity, '-m ' + self.COMMIT_MESSAGE)))
+
+        add_output = check_output(MLGIT_ADD % (repo_type, entity, metrics_options))
+        if with_metrics and repo_type is not MODELS:
+            self.assertIn(output_messages['ERROR_NO_SUCH_OPTION'] % '--metric', add_output)
+            add_output = check_output(MLGIT_ADD % (repo_type, entity, ''))
+
+        self.assertIn(output_messages['INFO_ADDING_PATH'] % repo_type, add_output)
+        self.assertIn(output_messages['INFO_COMMIT_REPO'] % (
+                os.path.join(self.tmp_dir, ML_GIT_DIR, repo_type, 'metadata'), entity),
+                check_output(MLGIT_COMMIT % (repo_type, entity, '-m ' + self.COMMIT_MESSAGE)))
 
     @staticmethod
     def create_metrics_table():


### PR DESCRIPTION
The metrics option is only supported for models but displayed when inserting the command "ml-git datasets add --help" or "ml-git labels add --help".