### PR TITLE
 Changing the message level in the list command

### DIFF
--- a/docs/mlgit_commands.md
+++ b/docs/mlgit_commands.md
@@ -893,7 +893,7 @@ To successfully execute the command it is necessary that it is in an ML-Git proj
 ```
 Usage: ml-git repository init [OPTIONS]
 
-  Initialiation of this ml-git repository
+  Initialization of this ML-Git repository
 
 Options:
   --help  Show this message and exit.

--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2021 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 import io

--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -258,7 +258,7 @@ class MetadataRepo(object):
         if output != (title + '\n'):
             print(output)
         else:
-            log.error(output_messages['ERROR_NONE_ENTITY_MANAGED'])
+            log.info(output_messages['INFO_NONE_ENTITY_MANAGED'])
 
     @staticmethod
     def metadata_print(metadata_file, spec_name):

--- a/ml_git/commands/repository.py
+++ b/ml_git/commands/repository.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2021 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 

--- a/ml_git/commands/repository.py
+++ b/ml_git/commands/repository.py
@@ -33,7 +33,7 @@ def config():
     pass
 
 
-@repository.command('init', help='Initialiation of this ml-git repository')
+@repository.command('init', help='Initialization of this ML-Git repository')
 def init():
     init_mlgit()
 

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -131,7 +131,7 @@ output_messages = {
     'INFO_FILES_SIZE': 'Files size: %s',
     'INFO_AMOUNT_SIZE': 'Amount of files: %s',
     'INFO_NOT_INITIALIZED': 'The %s doesn\'t have been initialized.',
-    'ERROR_NONE_ENTITY_MANAGED': 'You don\'t have any entity being managed.',
+    'INFO_NONE_ENTITY_MANAGED': 'You don\'t have any entity being managed.',
     'INFO_ENTITY_NAME_EXISTS': 'An entity with that name already exists.',
     'INFO_EXCLUSIVE_IMPORT_ARGUMENT': 'The argument `import` is mutually exclusive with argument',
     'INFO_EXCLUSIVE_CREDENTIALS_PATH_ARGUMENT': 'The argument `credentials_path` is required if `import-url` is used.',

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -457,8 +457,9 @@ class Repository(object):
         except GitError as g:
             error_message = g.stderr
             if 'did not match any file(s) known' in error_message:
-                error_message = 'You don\'t have any entity being managed.'
-            log.error(error_message, class_name=REPOSITORY_CLASS_NAME)
+                log.info(output_messages['INFO_NONE_ENTITY_MANAGED'], class_name=REPOSITORY_CLASS_NAME)
+            else:
+                log.error(error_message, class_name=REPOSITORY_CLASS_NAME)
             return
         except Exception as e:
             log.error(e, class_name=REPOSITORY_CLASS_NAME)

--- a/tests/integration/test_17_list.py
+++ b/tests/integration/test_17_list.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2021 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 

--- a/tests/integration/test_17_list.py
+++ b/tests/integration/test_17_list.py
@@ -36,7 +36,7 @@ class ListAcceptanceTests(unittest.TestCase):
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_INIT))
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_REMOTE_ADD % (DATASETS, GIT_PATH)))
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ENTITY_INIT % DATASETS))
-        self.assertIn(output_messages['ERROR_NONE_ENTITY_MANAGED'], check_output(MLGIT_LIST % DATASETS))
+        self.assertIn(output_messages['INFO_NONE_ENTITY_MANAGED'], check_output(MLGIT_LIST % DATASETS))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_list_without_initialize(self):


### PR DESCRIPTION
When the user uses the `list` command on a project that doesn't have any versioned entities, the command reports that there are no entities but treats this as an `ERROR`. The behavior has been changed to be an `INFO`.

**Command:**
```
$ ml-git datasets list
```

**Observed output:**
```
ERROR - Repository: You don't have any entity beign managed.
A complete log of this run can be found in: ml-git_execution.log.2021-08-30
```

**Fixed output:**
```
INFO - Repository: You don't have any entity beign managed.
```


Also in this branch a typo found in the help of the `repository init` command has been fixed.
