### PR TITLE
Fixing issue when ml-git tries to clone ml entities repository and there are blank spaces in the project folder path

### DIFF
--- a/ml_git/git_client.py
+++ b/ml_git/git_client.py
@@ -70,5 +70,6 @@ class GitClient(object):
     def clone(self):
         if self._git == '':
             raise GitError(output_messages['ERROR_UNABLE_TO_FIND_REMOTE_REPOSITORY'])
-        clone_command = 'git clone {} {}'.format(self._git, self._path)
+        path = '"{}"'.format(self._path) if self._path else ''
+        clone_command = 'git clone {} {}'.format(self._git, path)
         self._execute(clone_command, change_dir=False)

--- a/tests/integration/test_04_init_entity.py
+++ b/tests/integration/test_04_init_entity.py
@@ -20,17 +20,18 @@ from tests.integration.helper import check_output
 @pytest.mark.usefixtures('tmp_dir')
 class InitEntityAcceptanceTests(unittest.TestCase):
 
-    def set_up_init(self, entity_type, git=GIT_PATH):
-        self.assertIn(output_messages['INFO_INITIALIZED_PROJECT_IN'] % self.tmp_dir, check_output(MLGIT_INIT))
+    def set_up_init(self, entity_type, git, project_path=None):
+        self.assertIn(output_messages['INFO_INITIALIZED_PROJECT_IN'] % (project_path if project_path else self.tmp_dir), check_output(MLGIT_INIT))
         self.assertIn(output_messages['INFO_ADD_REMOTE'] % (git, entity_type), check_output(MLGIT_REMOTE_ADD % (entity_type, git)))
         self.assertIn(output_messages['INFO_ADD_STORAGE'] % (STORAGE_TYPE, BUCKET_NAME, PROFILE),
                       check_output(MLGIT_STORAGE_ADD % (BUCKET_NAME, PROFILE)))
 
-    def _initialize_entity(self, entity_type):
+    def _initialize_entity(self, entity_type, project_path=None):
+        project_path = project_path if project_path else self.tmp_dir
         self.assertIn(output_messages['INFO_METADATA_INIT']
-                      % (os.path.join(self.tmp_dir, GIT_PATH), os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'metadata')),
+                      % (os.path.join(self.tmp_dir, GIT_PATH), os.path.join(project_path, ML_GIT_DIR, entity_type, 'metadata')),
                       check_output(MLGIT_ENTITY_INIT % entity_type))
-        metadata_path = os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'metadata')
+        metadata_path = os.path.join(project_path, ML_GIT_DIR, entity_type, 'metadata')
         self.assertTrue(os.path.exists(metadata_path))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
@@ -77,3 +78,27 @@ class InitEntityAcceptanceTests(unittest.TestCase):
     def test_07_initialize_model(self):
         self.set_up_init(MODELS, os.path.join(self.tmp_dir, GIT_PATH))
         self._initialize_entity(MODELS)
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_08_initialize_datasets_from_folder_with_blank_spaces_in_name(self):
+        project_path_blank_spaces = os.path.join(self.tmp_dir, 'folder name with blank spaces')
+        os.mkdir(project_path_blank_spaces)
+        os.chdir(project_path_blank_spaces)
+        self.set_up_init(DATASETS, os.path.join(self.tmp_dir, GIT_PATH), project_path_blank_spaces)
+        self._initialize_entity(DATASETS, project_path_blank_spaces)
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_09_initialize_labels_from_folder_with_blank_spaces_in_name(self):
+        project_path_blank_spaces = os.path.join(self.tmp_dir, 'folder name with blank spaces')
+        os.mkdir(project_path_blank_spaces)
+        os.chdir(project_path_blank_spaces)
+        self.set_up_init(LABELS, os.path.join(self.tmp_dir, GIT_PATH), project_path_blank_spaces)
+        self._initialize_entity(LABELS, project_path_blank_spaces)
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_10_initialize_models_from_folder_with_blank_spaces_in_name(self):
+        project_path_blank_spaces = os.path.join(self.tmp_dir, 'folder name with blank spaces')
+        os.mkdir(project_path_blank_spaces)
+        os.chdir(project_path_blank_spaces)
+        self.set_up_init(MODELS, os.path.join(self.tmp_dir, GIT_PATH), project_path_blank_spaces)
+        self._initialize_entity(MODELS, project_path_blank_spaces)

--- a/tests/integration/test_04_init_entity.py
+++ b/tests/integration/test_04_init_entity.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2021 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 

--- a/tests/integration/test_04_init_entity.py
+++ b/tests/integration/test_04_init_entity.py
@@ -33,6 +33,8 @@ class InitEntityAcceptanceTests(unittest.TestCase):
                       check_output(MLGIT_ENTITY_INIT % entity_type))
         metadata_path = os.path.join(project_path, ML_GIT_DIR, entity_type, 'metadata')
         self.assertTrue(os.path.exists(metadata_path))
+        metadata_path_is_not_empty = len(os.listdir(metadata_path)) > 0
+        self.assertTrue(metadata_path_is_not_empty)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_initialize_dataset(self):


### PR DESCRIPTION
When the user tries to run commands like **ml-git datasets init** or **ml-git repository graph** inside a project folder with blank spaces in its name and there are no entities initialized yet, it's displayed a repository error.

![image](https://user-images.githubusercontent.com/18489870/132009326-5df5dce6-68f7-4e65-831d-0ef409357cb9.png)

The problem is related with the internal git clone command 
