### PR TITLE
Fixing the user's git credential input

### DIFF
--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -9,7 +9,6 @@ import re
 import time
 
 from git import Repo, Git, InvalidGitRepositoryError, GitError
-from halo import Halo
 from prettytable import PrettyTable
 
 from ml_git import log
@@ -128,7 +127,6 @@ class MetadataRepo(object):
         repo = Repo(self.__path)
         return repo.create_tag(tag, message='Automatic tag "{0}"'.format(tag))
 
-    @Halo(text='Pushing metadata to the git repository', spinner='dots')
     def push(self):
         log.debug(output_messages['DEBUG_PUSH'] % self.__path, class_name=METADATA_MANAGER_CLASS_NAME)
         self.validate_blank_remote_url()

--- a/ml_git/git_client.py
+++ b/ml_git/git_client.py
@@ -18,7 +18,7 @@ class GitClient(object):
         self._path = path
 
     def _check_output(self, proc):
-        if proc.returncode == 0:
+        if proc.returncode == 0 or not proc.stdout or proc.stdout == '':
             return
 
         output = proc.stdout
@@ -31,6 +31,8 @@ class GitClient(object):
             raise GitError(output_messages['ERROR_PATH_ALREAD_EXISTS'] % self._path)
         elif 'Authentication failed' in output:
             raise GitError(output_messages['ERROR_GIT_REMOTE_AUTHENTICATION_FAILED'])
+        elif 'Permission denied (publickey)' in output:
+            raise GitError(output_messages['ERROR_KEY_PERMISSION_DENIED'])
         elif 'Permission denied' in output:
             raise GitError(output_messages['ERROR_FOLDER_PERMISSION_DENIED'])
         else:
@@ -42,6 +44,8 @@ class GitClient(object):
             cwd = self._path
         proc = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                               universal_newlines=True, shell=True, cwd=cwd)
+        if 'Permission denied (publickey)' in proc.stdout:
+            proc = subprocess.run(command, stdout=subprocess.PIPE, universal_newlines=True, cwd=cwd)
 
         log.debug(output_messages['DEBUG_EXECUTING_COMMAND'] % command, class_name=GIT_CLIENT_CLASS_NAME)
         self._check_output(proc)

--- a/ml_git/git_client.py
+++ b/ml_git/git_client.py
@@ -44,7 +44,8 @@ class GitClient(object):
             cwd = self._path
         proc = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                               universal_newlines=True, shell=True, cwd=cwd)
-        if 'Permission denied (publickey)' in proc.stdout:
+        if 'Permission denied (publickey)' in proc.stdout or \
+                '/dev/tty: No such device or address' in proc.stdout:
             proc = subprocess.run(command, stdout=subprocess.PIPE, universal_newlines=True, cwd=cwd)
 
         log.debug(output_messages['DEBUG_EXECUTING_COMMAND'] % command, class_name=GIT_CLIENT_CLASS_NAME)

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -268,6 +268,8 @@ output_messages = {
     'ERROR_UNABLE_TO_FIND': 'Unable to find %s. Check the remote repository used.',
     'ERROR_UNABLE_TO_FIND_REMOTE_REPOSITORY': 'Unable to find remote repository. Add the remote first.',
     'ERROR_FOLDER_PERMISSION_DENIED': 'Permission denied in folder',
+    'ERROR_KEY_PERMISSION_DENIED': 'Permission denied (publickey). Please make sure you have '
+                                   'the correct access rights and the repository exists.',
     'ERROR_AMOUNT_PARAMETER_SHOULD_BE_SMALLER_GROUP_SIZE': 'The amount parameter should be smaller than the group size.',
     'ERROR_GROUP_SIZE_PARAMETER_SHOULD_BE_SMALLER_LIST_SIZE': 'The group size parameter should be smaller than the file list size.',
     'ERROR_START_PARAMETER_SHOULD_BE_SMALLER_THAN_STOP': 'The start parameter should be smaller than the stop.',


### PR DESCRIPTION
It has been observed that in some scenarios (listed below) ml-git is not able to forward git's request for user credentials. This PR adjusts the behavior to allow the user to enter the necessary credentials.

The following error scenarios were observed:
- Windows user in CMD or PowerShell, using ssh key protected with passphrase, and did not configure ssh-agent to store the key.
- Windows user in CMD or PowerShell, using https without having the credential manager configured.

**Observed behavior:**
```
$ ml-git datasets push dataset-ex
INFO - Metadata Manager: Metadata init [...] @ [...]
ERROR - Repository: Permission denied (publickey). Please make sure you have the correct access rights and the repository exists.
A complete log of this run can be found in: ml-git_execution.log
```

**Fixed behavior:**
```
$ ml-git datasets push dataset-ex
INFO - Metadata Manager: Metadata init [...] @ [...]
Cloning into 'D:\Virtus\mlgit-config\.ml-git\datasets\metadata'...
Enter passphrase for key '/c/Users/Lucas Cabral/.ssh/id_ed25519':
```

