### PR TITLE
Add error log message when using a minio endpoint that is not running

### DIFF
--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -260,7 +260,7 @@ output_messages = {
     'ERROR_DOWNLOAD_BLOG': 'error download blob [%s]',
     'ERROR_PATH_NOT_FOUND': 'Path %s not found',
     'ERROR_BUCKET_NOT_FOUND': 'Bucket [%s] not found.',
-    'ERROR_BUCKET_ENDPOINT_CONNECTION': 'There was an error checking if bucket \'%s\' exists. ERROR: %s. \n  '
+    'ERROR_BUCKET_ENDPOINT_CONNECTION': 'There was an error checking if bucket \'{}\' exists. ERROR: {}. \n  '
                                         'Please check if the storage service is up and running.',
     'ERROR_INVALID_URL': 'Invalid url: [%s]',
     'ERROR_INVALID_IPLD': 'Invalid IPLD [%s]',

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -260,6 +260,8 @@ output_messages = {
     'ERROR_DOWNLOAD_BLOG': 'error download blob [%s]',
     'ERROR_PATH_NOT_FOUND': 'Path %s not found',
     'ERROR_BUCKET_NOT_FOUND': 'Bucket [%s] not found.',
+    'ERROR_BUCKET_ENDPOINT_CONNECTION': 'There was an error checking if bucket \'%s\' exists. ERROR: %s. \n  '
+                                        'Please check if the storage service is up and running.',
     'ERROR_INVALID_URL': 'Invalid url: [%s]',
     'ERROR_INVALID_IPLD': 'Invalid IPLD [%s]',
     'ERROR_FILE_DOWNLOAD_FAILED': 'Failed to download file id: [%s]',

--- a/ml_git/storages/s3_storage.py
+++ b/ml_git/storages/s3_storage.py
@@ -53,7 +53,7 @@ class S3Storage(Storage):
             log.error(error_msg, class_name=STORAGE_FACTORY_CLASS_NAME)
             return False
         except EndpointConnectionError as e:
-            log.error(output_messages['ERROR_BUCKET_ENDPOINT_CONNECTION'] % (self._bucket, e), class_name=STORAGE_FACTORY_CLASS_NAME)
+            log.error(output_messages['ERROR_BUCKET_ENDPOINT_CONNECTION'].format(self._bucket, e), class_name=STORAGE_FACTORY_CLASS_NAME)
             return False
 
     def create_bucket_name(self, bucket_prefix):

--- a/ml_git/storages/s3_storage.py
+++ b/ml_git/storages/s3_storage.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2021 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
@@ -10,6 +10,7 @@ from pprint import pprint
 import boto3
 import multihash
 from botocore.client import ClientError, Config
+from botocore.exceptions import EndpointConnectionError
 from cid import CIDv1
 
 from ml_git import log
@@ -50,6 +51,9 @@ class S3Storage(Storage):
             elif e.response['Error']['Code'] == '403':
                 error_msg = output_messages['ERROR_AWS_KEY_NOT_EXIST']
             log.error(error_msg, class_name=STORAGE_FACTORY_CLASS_NAME)
+            return False
+        except EndpointConnectionError as e:
+            log.error(output_messages['ERROR_BUCKET_ENDPOINT_CONNECTION'] % (self._bucket, e), class_name=STORAGE_FACTORY_CLASS_NAME)
             return False
 
     def create_bucket_name(self, bucket_prefix):

--- a/tests/integration/test_07_push_files.py
+++ b/tests/integration/test_07_push_files.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2021 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 

--- a/tests/integration/test_07_push_files.py
+++ b/tests/integration/test_07_push_files.py
@@ -14,7 +14,7 @@ import pytest
 from ml_git.ml_git_message import output_messages
 from ml_git.utils import ensure_path_exists
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_PUSH
-from tests.integration.helper import ML_GIT_DIR, MINIO_BUCKET_PATH, GIT_PATH, DATASETS, LABELS, MODELS, DATASET_NAME
+from tests.integration.helper import BUCKET_NAME, ML_GIT_DIR, MINIO_BUCKET_PATH, GIT_PATH, DATASETS, LABELS, MODELS, DATASET_NAME
 from tests.integration.helper import check_output, clear, init_repository, add_file, ERROR_MESSAGE
 
 
@@ -143,3 +143,15 @@ class PushFilesAcceptanceTests(unittest.TestCase):
         metadata_path = os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'metadata')
         os.chdir(metadata_path)
         self.assertNotIn('computer-vision__images__' + entity_type + '-ex__2', check_output('git describe --tags'))
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    @mock.patch('tests.integration.helper.MINIO_ENDPOINT_URL', 'http://127.0.0.1:9100')
+    def test_11_push_with_wrong_minio_endpoint(self):
+        entity_type = DATASETS
+        artifact_name = DATASET_NAME
+        init_repository(entity_type, self)
+        add_file(self, entity_type, '--bumpversion', 'new')
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (entity_type,  artifact_name, '')))
+        output = check_output(MLGIT_PUSH % (entity_type, artifact_name))
+        self.assertIn(ERROR_MESSAGE, output)
+        self.assertIn('There was an error checking if bucket \'{}\' exists.'.format(BUCKET_NAME), output)


### PR DESCRIPTION
Currently if the user tries to execute the push command setting an endpoint-url to a minio service that is not running the following error is shown (this error is not logged by ml-git):

![image](https://user-images.githubusercontent.com/18489870/132349308-80ca56e8-75e3-4999-a2a3-bc3e518d9867.png)

This PR add an error log reporting the problem:

![image](https://user-images.githubusercontent.com/18489870/132349567-3d08f733-5a28-438c-8e0a-35a945a87fef.png)
