### PR TITLE
Fixing invalid directory handling in status command

### DIFF
--- a/ml_git/file_system/local.py
+++ b/ml_git/file_system/local.py
@@ -739,8 +739,9 @@ class LocalRepository(MultihashFS):
                 log.error(e, class_name=REPOSITORY_CLASS_NAME)
 
         if status_directory and not os.path.exists(os.path.join(path, status_directory)):
-            log.error(output_messages['ERROR_INVALID_STATUS_DIRECTORY'], class_name=REPOSITORY_CLASS_NAME)
-            return
+            if tag:
+                metadata.checkout()
+            raise Exception(output_messages['ERROR_INVALID_STATUS_DIRECTORY'])
 
         # All files in MANIFEST.yaml in the index AND all files in datapath which stats links == 1
         idx = MultihashIndex(spec, index_path, objects_path)


### PR DESCRIPTION
It was observed that when the user passes an invalid directory to the `ml-git status` command, the system displays an error and all subsequent commands related to the entity also display an error.  This PR fixes this issue.

**Observed behavior:**
```
$ ml-git datasets status dataset-ex wrong-dir
INFO - Repository: datasets: status of ml-git index for [dataset-ex]
ERROR - Repository: The directory informed is invalid.
A complete log of this run can be found in: ml-git_execution.log
ERROR - Repository: 'NoneType' object is not iterable
A complete log of this run can be found in: ml-git_execution.log


$ ml-git datasets status dataset-ex data
ERROR - Repository: HEAD is a detached symbolic reference as it points to '3ff98394823ae923e84bc'
A complete log of this run can be found in: ml-git_execution.log

```

**Fixed behavior:**
```
$ ml-git datasets status dataset-ex wrong-dir
INFO - Repository: datasets: status of ml-git index for [dataset-ex]
ERROR - Repository: The directory informed is invalid.
A complete log of this run can be found in: ml-git_execution.log


$ ml-git datasets status dataset-ex data
INFO - Repository: datasets: status of ml-git index for [dataset-ex]
Your dataset-ex has no commits to be published.

Untracked files:
  (use "ml-git datasets add dataset-ex <file>..." to include in what will be committed)
        data\test.txt

```