### PR TITLE
 Fixing Python version in release workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -27,11 +27,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install pipenv
           pip install flake8 pytest
+
       - name: Build
         run: |
          pipenv --python 3.6
          chmod +x ./scripts/build/compile/build.sh
          make build
+
       - name: Define build name
         run: |
           echo -ne $(cat version.info | grep MAJOR_VERSION | cut -d"=" -f2). >> BUILD_UBUNTU_FILE
@@ -39,6 +41,7 @@ jobs:
           echo -ne $(cat version.info | grep PATCH_VERSION | cut -d"=" -f2) >> BUILD_UBUNTU_FILE
           BUILD_VERSION="$( cat BUILD_UBUNTU_FILE )"
           echo 'BUILD_NAME='${BUILD_VERSION} >> $GITHUB_ENV
+
       - name: Release Build
         uses: actions/upload-artifact@v2
         with:
@@ -69,6 +72,7 @@ jobs:
           pip install flake8 pytest
           pip install pywin32-ctypes
           pip freeze
+
       - name: Build
         run: |
          pipenv --python 3.6
@@ -113,6 +117,7 @@ jobs:
       - name: Lint with flake8
         run: |
           flake8 .
+
   unit-tests:
     name: Unit Tests
     needs: [build-linux, build-windows]
@@ -149,6 +154,7 @@ jobs:
           pipenv --python 3.6
           chmod +x ./scripts/run_unit_tests.sh
           make test.unit
+
       - name: Archive code coverage results of unit tests
         uses: actions/upload-artifact@v1
         with:
@@ -193,6 +199,7 @@ jobs:
           pipenv --python 3.6
           chmod +x ./scripts/run_integration_tests.sh
           make test.integration
+
       - name: Archive code coverage results of integration tests
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -17,22 +17,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.6
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.6
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pipenv
           pip install flake8 pytest
-
       - name: Build
         run: |
+         pipenv --python 3.6
          chmod +x ./scripts/build/compile/build.sh
          make build
-
       - name: Define build name
         run: |
           echo -ne $(cat version.info | grep MAJOR_VERSION | cut -d"=" -f2). >> BUILD_UBUNTU_FILE
@@ -40,7 +39,6 @@ jobs:
           echo -ne $(cat version.info | grep PATCH_VERSION | cut -d"=" -f2) >> BUILD_UBUNTU_FILE
           BUILD_VERSION="$( cat BUILD_UBUNTU_FILE )"
           echo 'BUILD_NAME='${BUILD_VERSION} >> $GITHUB_ENV
-
       - name: Release Build
         uses: actions/upload-artifact@v2
         with:
@@ -59,10 +57,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.6
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.6
 
       - name: Install dependencies
         run: |
@@ -71,9 +69,9 @@ jobs:
           pip install flake8 pytest
           pip install pywin32-ctypes
           pip freeze
-
       - name: Build
         run: |
+         pipenv --python 3.6
          .\scripts\build\compile\build.bat
         shell: cmd
 
@@ -102,21 +100,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.6
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.6
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pipenv
           pip install flake8 pytest
-
       - name: Lint with flake8
         run: |
           flake8 .
-
   unit-tests:
     name: Unit Tests
     needs: [build-linux, build-windows]
@@ -126,10 +122,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.6
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.6
 
       - name: Install dependencies
         run: |
@@ -150,9 +146,9 @@ jobs:
 
       - name: Unit Tests
         run: |
+          pipenv --python 3.6
           chmod +x ./scripts/run_unit_tests.sh
           make test.unit
-
       - name: Archive code coverage results of unit tests
         uses: actions/upload-artifact@v1
         with:
@@ -170,10 +166,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.6
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.6
 
       - name: Install dependencies
         run: |
@@ -194,9 +190,9 @@ jobs:
 
       - name: Integration Tests
         run: |
+          pipenv --python 3.6
           chmod +x ./scripts/run_integration_tests.sh
           make test.integration
-
       - name: Archive code coverage results of integration tests
         uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
The release workflow was using python 3.7, since the Pipfile points to version 3.6 the pipenv command returns an error for not having the desired version. The workflow was updated to be able to perform the steps in version 3.6.