### PR TITLE
Updating docs to teach how to configure MinIO

### DIFF
--- a/docs/aws_s3_configuration.md
+++ b/docs/aws_s3_configuration.md
@@ -6,7 +6,7 @@ This section explains how to configure the settings that the ML-Git uses to inte
 2. Access Key ID
 3. Secret Access Key
 4. Region Name
-3. Output Format
+5. Output Format
 
 The _Access Key ID_ and _Secret Access Key_ are your credentials. The _Region Name_ identifies the AWS Region whose servers you want to send your requests. The _Output Format_ specifies how the results are formatted.
 
@@ -77,7 +77,7 @@ You can configure the AWS in three ways (environment variables, through the cons
 
 3 - AWS CLI
 
-   For general use, the *aws configure* command is the fastest way to set up, but requires the AWS CLI installed. For install and configure type the following commands:
+   For general use, the *aws configure* command is the fastest way to set up but requires the AWS CLI installed. To install and configure type the following commands:
 
    ```
    $ pip install awscli
@@ -93,10 +93,3 @@ You can configure the AWS in three ways (environment variables, through the cons
 - Demonstrating AWS Configure
   
   [![asciicast](https://asciinema.org/a/371052.svg)](https://asciinema.org/a/371052)
-   
-## MinIO ##
-
-[MinIO](https://min.io/) is a cloud storage server compatible with Amazon S3. That said, you can configure it in the same way as described above by placing Access Key and Secret Access Key of your MinIO bucket.
-
-
-

--- a/docs/first_project.md
+++ b/docs/first_project.md
@@ -79,7 +79,7 @@ $ ml-git datasets init
 
 #### <a name="config-s3">Setting up an ML-Git project with S3 </a> ####
 
-Similar to the MinIO setup, in addition to creating the bucket in S3, it is necessary to configure the settings that the ML-Git uses to interact with your bucket, see [how to configure a S3 bucket](s3_configurations.md) for more details.
+Similar to the MinIO setup, in addition to creating the bucket in S3, it is necessary to configure the settings that the ML-Git uses to interact with your bucket, see [how to configure a S3 bucket](aws_s3_configuration.md) for more details.
 
 For a basic ML-Git repository, you need to add a remote repository for metadata and a S3 bucket configuration.
 

--- a/docs/minio_s3_configuration.md
+++ b/docs/minio_s3_configuration.md
@@ -23,7 +23,7 @@ This section explains how to configure the settings that the ML-Git uses to inte
 1. Profile Name
 2. Access Key ID
 3. Secret Access Key
-5. Output Format
+4. Output Format
 
 The _Access Key ID_ and _Secret Access Key_ are the credentials for your MinIO user. The _Output Format_ specifies how the results are formatted.
 

--- a/docs/minio_s3_configuration.md
+++ b/docs/minio_s3_configuration.md
@@ -1,0 +1,104 @@
+## MinIO ##
+
+[MinIO](https://min.io/) is a cloud storage server compatible with Amazon S3. The following sections will explain how to properly set up so ML-Git can work by using the Access Key and Secret Access Key of your MinIO user.
+
+### Running MinIO locally ###
+
+In case you want to run MinIO locally for testing purposes, it's possible to run a docker container using the following command:
+```
+$ docker run --name=minio --network=host minio/minio server --console-address ":9001" /data
+```
+The command will start the MinIO API and Console servers in ports 9000 and 9001, respectively. 
+
+Once you have successfully started the container, you can access the Console URL (usually http://127.0.0.1:9001) using the default user (username: minioadmin, password: minioadmin) to create a new user (setting up its Access Key and Secret Access Key) or create new buckets.
+
+After you finish creating a new user, remember that you'll need the proper local URL for the API to be used in the --endpoint-url parameter of the storage creation command, it'll usually be `http://127.0.0.1:9000`.
+
+`Note:` In case you decide to work with a deployed MinIO server instead, just remember to use the proper URL when creating new storage and to have your MinIO user's Access Key and Secret Access Key in hand for the following setup.
+
+# Credentials configuration #
+
+This section explains how to configure the settings that the ML-Git uses to interact with your bucket. This requires that you have the following data:
+
+1. Profile Name
+2. Access Key ID
+3. Secret Access Key
+5. Output Format
+
+The _Access Key ID_ and _Secret Access Key_ are the credentials for your MinIO user. The _Output Format_ specifies how the results are formatted.
+
+Internally ML-Git uses [Boto3](https://github.com/boto/boto3) to communicate with the MinIO API. Even though Boto3 is the Amazon Web Services (AWS) SDK for Python, we can still use it to communicate with the MinIO services.
+
+Boto3 looks at various configuration locations until it finds configuration values. The following lookup order is used searching through sources for configuration values:
+
+* Environment variables
+* The ~/.aws/config file
+
+```Note:``` 
+If, when creating a storage, you define a specific profile to be used, Boto3 will only search for that profile in the ~/.aws/config file.
+
+You can configure the credentials in three ways (environment variables, through the console or with the [AWS Command Line Interface](https://aws.amazon.com/cli/?nc1=h_ls)). These are described in the following sections.
+
+
+1 - Environment Variables
+
+   **Linux or macOS**:
+
+    ```
+    $ export AWS_ACCESS_KEY_ID=your-access-key
+    $ export AWS_SECRET_ACCESS_KEY=your-secret-access-key
+    ```
+
+   **Windows**:
+    
+    ```
+    C:\> setx AWS_ACCESS_KEY_ID your-access-key
+    C:\> setx AWS_SECRET_ACCESS_KEY your-secret-access-key
+    ```
+
+2 -  Console 
+   
+   From the home directory (UserProfile) execute:   
+            
+   ```
+   $ mkdir .aws
+   ```
+   
+   You need to create two files to store the sensitive credential information (~/.aws/credentials) separated from the less sensitive configuration options (~/.aws/config). To create these two files type the following commands:
+        
+   For config file:
+        
+   ```
+   $ echo "
+   [your-profile-name]
+   output=json 
+   " > .aws/config
+   ```
+
+   For credentials file:
+   ```
+   $ echo "
+   [your-profile-name]
+   aws_access_key_id = your-access-key
+   aws_secret_access_key = your-secret-access-key     
+   " > .aws/credentials
+   ```
+
+3 - AWS CLI
+
+   For general use, the *aws configure* command is the fastest way to set up but requires the AWS CLI installed. To install and configure type the following commands:
+
+   ```
+   $ pip install awscli
+   $ aws configure
+   AWS Access Key ID [None]: your-access-key
+   AWS Secret Access Key [None]: your-secret-access-key
+   Default region name [None]: 
+   Default output format [None]: json
+   ```
+
+   These commands will create the files ~/.aws/credentials and ~/.aws/config.
+
+- Demonstrating AWS Configure
+  
+  [![asciicast](https://asciinema.org/a/371052.svg)](https://asciinema.org/a/371052)

--- a/docs/minio_s3_configuration.md
+++ b/docs/minio_s3_configuration.md
@@ -6,9 +6,9 @@
 
 In case you want to run MinIO locally for testing purposes, it's possible to run a docker container using the following command:
 ```
-$ docker run --name=minio --network=host minio/minio server --console-address ":9001" /data
+$ docker run -v path/to/your/dir:/data --name=minio --network=host minio/minio server --console-address ":9001" /data
 ```
-The command will start the MinIO API and Console servers in ports 9000 and 9001, respectively. 
+The command will start the MinIO API and Console servers in ports 9000 and 9001, respectively.
 
 Once you have successfully started the container, you can access the Console URL (usually http://127.0.0.1:9001) using the default user (username: minioadmin, password: minioadmin) to create a new user (setting up its Access Key and Secret Access Key) or create new buckets.
 

--- a/docs/minio_s3_configuration.md
+++ b/docs/minio_s3_configuration.md
@@ -6,7 +6,7 @@
 
 In case you want to run MinIO locally for testing purposes, it's possible to run a docker container using the following command:
 ```
-$ docker run -v path/to/your/dir:/data --name=minio --network=host minio/minio server --console-address ":9001" /data
+$ docker run -v /path/to/your/dir:/data --name=minio --network=host minio/minio server --console-address ":9001" /data
 ```
 The command will start the MinIO API and Console servers in ports 9000 and 9001, respectively.
 

--- a/docs/storage_configurations.md
+++ b/docs/storage_configurations.md
@@ -5,8 +5,8 @@ Currently, ML-Git supports five types of storage (S3, MinIO, Azure, GoogleDrive 
 
 
 
-1. [S3](aws_s3_configuration.md)
-2. [MinIO](minio_s3_configuration.md)
+1. [MinIO](minio_s3_configuration.md)
+2. [S3](aws_s3_configuration.md)
 3. [Azure](azure_configurations.md)
 4. [Google Drive](gdrive_configurations.md)
 5. [SFTP](sftp_configurations.md)

--- a/docs/storage_configurations.md
+++ b/docs/storage_configurations.md
@@ -5,8 +5,8 @@ Currently, ML-Git supports five types of storage (S3, MinIO, Azure, GoogleDrive 
 
 
 
-1. [S3](s3_configurations.md)
-2. [MinIO](s3_configurations.md)
+1. [S3](aws_s3_configuration.md)
+2. [MinIO](minio_s3_configuration.md)
 3. [Azure](azure_configurations.md)
 4. [Google Drive](gdrive_configurations.md)
 5. [SFTP](sftp_configurations.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,8 @@ nav:
       - Working With Tabular Data: tabular_data/tabular_data.md
     - Supported Storages:
       - Configurations: storage_configurations.md
-      - S3 and MinIO: s3_configurations.md
+      - MinIO: minio_s3_configuration.md
+      - S3: aws_s3_configuration.md
       - Azure: azure_configurations.md
       - Google Drive: gdrive_configurations.md
     - Commands:


### PR DESCRIPTION
Separating the documentation of how to set up S3 in two different files, one for AWS S3 and one for MinIO.