### PR TITLE
Adding range validator to --version parameter of the create command

### DIFF
--- a/ml_git/commands/descriptor.py
+++ b/ml_git/commands/descriptor.py
@@ -470,7 +470,7 @@ commands = [
                 'type': click.Choice(StorageType.to_list()),
                 'help': help_msg.STORAGE_TYPE, 'default': StorageType.S3H.value
             },
-            '--version': {'help': help_msg.VERSION_NUMBER, 'default': 1},
+            '--version': {'type': click.IntRange(0, int(8 * '9')), 'help': help_msg.VERSION_NUMBER, 'default': 1},
             '--import': {'help': help_msg.IMPORT_OPTION,
                          'cls': MutuallyExclusiveOption, 'mutually_exclusive': ['import_url', 'credentials_path']},
             '--wizard-config': {'is_flag': True, 'help': help_msg.WIZARD_CONFIG},

--- a/tests/integration/test_19_create.py
+++ b/tests/integration/test_19_create.py
@@ -220,3 +220,12 @@ class CreateAcceptanceTests(unittest.TestCase):
                                                      + ' --entity-dir=' + entity_dir))
         folder_data = os.path.join(self.tmp_dir, DATASETS, entity_dir, DATASET_NAME, 'data')
         self.assertTrue(os.path.exists(folder_data))
+
+    @pytest.mark.usefixtures('switch_to_tmp_dir')
+    def test_17_create_with_invalid_version_number(self):
+        entity_type = DATASETS
+        self.assertIn(output_messages['INFO_INITIALIZED_PROJECT_IN'] % self.tmp_dir, check_output(MLGIT_INIT))
+        result = check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex') + ' --version=-2 --category=imgs'
+                              + ' --mutability=' + STRICT)
+        expected_error_message = '-2 is not in the valid range of 0 to 99999999.'
+        self.assertIn(expected_error_message, result)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23001961/133478659-96e0a422-d49c-4f7f-a0a3-c9ae05b31c51.png)
Now anything outside of the defined range will be throwing the error presented in the image.