### PR TITLE
Removing files created during an aborted command execution

### DIFF
--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -1060,7 +1060,7 @@ class Repository(object):
                 unzip_files_in_directory(data_path)
             message_key = 'INFO_{}_CREATED'.format(self.__repo_type.upper())
             log.info(output_messages[message_key], CLASS_NAME=REPOSITORY_CLASS_NAME)
-        except Exception as e:
+        except BaseException as e:
             if not isinstance(e, PermissionError):
                 clear(os.path.join(repo_type, artifact_name))
             if isinstance(e, KeyboardInterrupt):


### PR DESCRIPTION
In the create command the user has the possibility to use the wizard option to be asked interactively about the configurations that need to be used in the entity. If, during the input process, the user aborts the command (CTRL+C or something like that), the files that have already been created during execution remain in the user's workspace. 

This PR aims to correct this behavior by removing these files from the workspace, as it considers them to be garbage.