### PR TITLE
Fixing the problem of configuring an sftp bucket with the wizard option

### DIFF
--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -406,7 +406,7 @@ def start_wizard_questions(repo_type):
 
     if selected.upper() == 'X':
         storage_type, bucket = _create_new_bucket()
-    elif selected.isnumeric() and int(selected) in range(1, len(valid_buckets)):
+    elif selected.isnumeric() and int(selected) in range(1, len(valid_buckets) + 1):
         storage_type, bucket = extract_storage_info_from_list(temp_map[int(selected)])
     else:
         raise Exception('Invalid option.')

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -369,7 +369,7 @@ def _create_new_bucket():
     if storage_type not in storages_types:
         raise RuntimeError(output_messages['ERROR_INVALID_STORAGE_TYPE'])
     bucket = input(USER_INPUT_MESSAGE.format('bucket name'))
-    if storage_type in StorageType.S3H.value:
+    if storage_type == StorageType.S3H.value:
         credential_profile = input(USER_INPUT_MESSAGE.format('credentials'))
         endpoint = input('If you are using MinIO inform the endpoint URL, otherwise press ENTER: ')
     elif storage_type == StorageType.GDRIVEH.value:

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -11,7 +11,8 @@ from halo import Halo
 
 from ml_git import spec
 from ml_git.constants import FAKE_STORAGE, BATCH_SIZE_VALUE, BATCH_SIZE, StorageType, GLOBAL_ML_GIT_CONFIG, \
-    PUSH_THREADS_COUNT, SPEC_EXTENSION, EntityType, STORAGE_CONFIG_KEY, STORAGE_SPEC_KEY, DATASET_SPEC_KEY
+    PUSH_THREADS_COUNT, SPEC_EXTENSION, EntityType, STORAGE_CONFIG_KEY, STORAGE_SPEC_KEY, DATASET_SPEC_KEY, \
+    MultihashStorageType
 from ml_git.ml_git_message import output_messages
 from ml_git.spec import get_spec_key
 from ml_git.utils import getOrElse, yaml_load, yaml_save, get_root_path, yaml_load_str, RootPathException
@@ -359,7 +360,7 @@ def _configure_metadata_remote(repo_type):
 
 
 def _create_new_bucket():
-    storages_types = [item.value for item in StorageType]
+    storages_types = [item.value for item in MultihashStorageType]
     storage_type = input(USER_INPUT_MESSAGE.format('storage type {}'.format(str(storages_types)))).lower()
 
     credential_profile = None

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2021 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
@@ -54,6 +54,8 @@ mlgit_config = {
     PUSH_THREADS_COUNT: push_threads
 
 }
+
+USER_INPUT_MESSAGE = 'Inform the {}: > '
 
 
 def config_verbose():
@@ -344,51 +346,71 @@ def create_workspace_tree_structure(repo_type, artifact_name, categories, storag
         return False
 
 
-def start_wizard_questions(repotype):
-    print('_ Current configured storages _')
-    print('   ')
-    storage = config_load()[STORAGE_CONFIG_KEY]
-    count = 1
-    # temporary map with number as key and a array with storage type and bucket as values
-    temp_map = {}
-    # list the buckets to the user choose one
-    for storage_type in storage:
-        for key in storage[storage_type].keys():
-            print('%s - %s - %s' % (str(count), storage_type, key))
-            temp_map[count] = [storage_type, key]
-            count += 1
-    print('X - New Data Storage')
-    print('   ')
-    selected = input('_Which storage do you want to use (a number or new data storage)? _ ')
-    profile = None
-    endpoint = None
-    git_repo = None
+def _configure_metadata_remote(repo_type):
     config = mlgit_config_load()
     try:
-        int(selected)  # the user select one storage from the list
-        has_new_storage = False
-        # extract necessary info from the storage in spec
+        git_repo = config[repo_type]['git']
+        if git_repo == '':
+            raise Exception('Need configure a remote repository.')
+    except Exception:
+        git_repo = input(USER_INPUT_MESSAGE.format('git repository for ml-git {} metadata'.format(repo_type))).lower()
+        from ml_git.admin import remote_add
+        remote_add(repo_type, git_repo)
+
+
+def _create_new_bucket():
+    storages_types = [item.value for item in StorageType]
+    storage_type = input(USER_INPUT_MESSAGE.format('storage type {}'.format(str(storages_types)))).lower()
+
+    credential_profile = None
+    endpoint = None
+    sftp_configs = None
+
+    if storage_type not in storages_types:
+        raise RuntimeError(output_messages['ERROR_INVALID_STORAGE_TYPE'])
+    bucket = input(USER_INPUT_MESSAGE.format('bucket name'))
+    if storage_type in (StorageType.S3.value, StorageType.S3H.value):
+        credential_profile = input(USER_INPUT_MESSAGE.format('credentials'))
+        endpoint = input('If you are using MinIO inform the endpoint URL, otherwise press ENTER: > ')
+    elif storage_type == StorageType.GDRIVEH.value:
+        credential_profile = input(USER_INPUT_MESSAGE.format('credentials path'))
+    elif storage_type == StorageType.SFTPH.value:
+        endpoint = input(USER_INPUT_MESSAGE.format('endpoint URL'))
+        sftp_configs = {'username': input(USER_INPUT_MESSAGE.format('username')),
+                        'private_key': input(USER_INPUT_MESSAGE.format('credentials path')),
+                        'port': int(input(USER_INPUT_MESSAGE.format('port')))}
+    from ml_git.admin import storage_add
+    storage_add(storage_type, bucket, credential_profile, endpoint, sftp_configs=sftp_configs)
+    return storage_type, bucket
+
+
+def _get_configured_buckets(configured_storages):
+    temp_map = {}
+    valid_buckets = []
+    for storage_type in configured_storages:
+        for storage_name in configured_storages[storage_type].keys():
+            valid_buckets.append(storage_name)
+            print('[%s] - %s - %s' % (str(len(valid_buckets)), storage_type, storage_name))
+            temp_map[len(valid_buckets)] = [storage_type, storage_name]
+    return valid_buckets, temp_map
+
+
+def start_wizard_questions(repo_type):
+    print('Current configured storages:\n   ')
+    configured_storages = config_load()[STORAGE_CONFIG_KEY]
+
+    valid_buckets, temp_map = _get_configured_buckets(configured_storages)
+    print('[X] - Create new data storage\n   ')
+    selected = input(USER_INPUT_MESSAGE.format('storage do you want to use'))
+
+    if selected.upper() == 'X':
+        storage_type, bucket = _create_new_bucket()
+    elif selected.isnumeric() and int(selected) in range(1, len(valid_buckets)):
         storage_type, bucket = extract_storage_info_from_list(temp_map[int(selected)])
-    except Exception:  # the user select create a new data storage
-        has_new_storage = True
-        storages_types = [item.value for item in StorageType]
-        storage_type = input('Please specify the storage type ' + str(storages_types) + ': _ ').lower()
-        if storage_type not in storages_types:
-            raise RuntimeError(output_messages['ERROR_INVALID_STORAGE_TYPE'])
-        bucket = input('Please specify the bucket name: _ ').lower()
-        if storage_type in (StorageType.S3.value, StorageType.S3H.value):
-            profile = input('Please specify the credentials: _ ').lower()
-            endpoint = input('If you are using S3 compatible storage (ex. minio), please specify the endpoint URL,'
-                             ' otherwise press ENTER: _ ').lower()
-        elif storage_type == StorageType.GDRIVEH.value:
-            profile = input('Please specify the credentials path: _ ').lower()
-        git_repo = input('Please specify the git repository for ml-git %s metadata: _ ' % repotype).lower()
-    if git_repo is None:
-        try:
-            git_repo = config[repotype]['git']
-        except Exception:
-            git_repo = ''
-    return has_new_storage, storage_type, bucket, profile, endpoint, git_repo
+    else:
+        raise Exception('Invalid option.')
+    _configure_metadata_remote(repo_type)
+    return storage_type, bucket
 
 
 def extract_storage_info_from_list(array):

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -56,7 +56,7 @@ mlgit_config = {
 
 }
 
-USER_INPUT_MESSAGE = 'Inform the {}: > '
+USER_INPUT_MESSAGE = 'Inform the {}: '
 
 
 def config_verbose():
@@ -350,8 +350,7 @@ def create_workspace_tree_structure(repo_type, artifact_name, categories, storag
 def _configure_metadata_remote(repo_type):
     config = mlgit_config_load()
     try:
-        git_repo = config[repo_type]['git']
-        if git_repo == '':
+        if not config[repo_type]['git']:
             raise Exception('Need configure a remote repository.')
     except Exception:
         git_repo = input(USER_INPUT_MESSAGE.format('git repository for ml-git {} metadata'.format(repo_type))).lower()
@@ -370,9 +369,9 @@ def _create_new_bucket():
     if storage_type not in storages_types:
         raise RuntimeError(output_messages['ERROR_INVALID_STORAGE_TYPE'])
     bucket = input(USER_INPUT_MESSAGE.format('bucket name'))
-    if storage_type in (StorageType.S3.value, StorageType.S3H.value):
+    if storage_type in StorageType.S3H.value:
         credential_profile = input(USER_INPUT_MESSAGE.format('credentials'))
-        endpoint = input('If you are using MinIO inform the endpoint URL, otherwise press ENTER: > ')
+        endpoint = input('If you are using MinIO inform the endpoint URL, otherwise press ENTER: ')
     elif storage_type == StorageType.GDRIVEH.value:
         credential_profile = input(USER_INPUT_MESSAGE.format('credentials path'))
     elif storage_type == StorageType.SFTPH.value:
@@ -404,9 +403,10 @@ def start_wizard_questions(repo_type):
     print('[X] - Create new data storage\n   ')
     selected = input(USER_INPUT_MESSAGE.format('storage do you want to use'))
 
+    valid_buckets_options = range(1, len(valid_buckets) + 1)
     if selected.upper() == 'X':
         storage_type, bucket = _create_new_bucket()
-    elif selected.isnumeric() and int(selected) in range(1, len(valid_buckets) + 1):
+    elif selected.isnumeric() and int(selected) in valid_buckets_options:
         storage_type, bucket = extract_storage_info_from_list(temp_map[int(selected)])
     else:
         raise Exception('Invalid option.')

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -13,7 +13,7 @@ from halo import Halo
 
 from ml_git import log
 from ml_git._metadata import MetadataRepo
-from ml_git.admin import remote_add, storage_add, clone_config_repository, init_mlgit, remote_del
+from ml_git.admin import remote_add, clone_config_repository, init_mlgit, remote_del
 from ml_git.config import get_index_path, get_objects_path, get_cache_path, get_metadata_path, get_refs_path, \
     validate_config_spec_hash, validate_spec_hash, get_sample_config_spec, get_sample_spec_doc, \
     get_index_metadata_path, create_workspace_tree_structure, start_wizard_questions, config_load, \
@@ -1045,11 +1045,8 @@ class Repository(object):
             create_workspace_tree_structure(repo_type, artifact_name, categories, storage_type, bucket_name,
                                             version, imported_dir, kwargs['mutability'], kwargs['entity_dir'])
             if start_wizard:
-                has_new_storage, storage_type, bucket, profile, endpoint_url, git_repo = start_wizard_questions(repo_type)
-                if has_new_storage:
-                    storage_add(storage_type, bucket, profile, endpoint_url)
+                storage_type, bucket = start_wizard_questions(repo_type)
                 update_storage_spec(repo_type, artifact_name, storage_type, bucket, kwargs['entity_dir'])
-                remote_add(repo_type, git_repo)
             if import_url:
                 self.create_config_storage(StorageType.GDRIVE.value, credentials_path)
                 local = LocalRepository(self.__config, get_objects_path(self.__config, repo_type))

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2021 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 import csv
@@ -24,6 +24,7 @@ AZUREBLOBH = StorageType.AZUREBLOBH.value
 S3H = StorageType.S3H.value
 S3 = StorageType.S3.value
 GDRIVEH = StorageType.GDRIVEH.value
+SFTPH = StorageType.SFTPH.value
 DATASETS = EntityType.DATASETS.value
 MODELS = EntityType.MODELS.value
 LABELS = EntityType.LABELS.value


### PR DESCRIPTION
Was observed that an error was being returned ('NoneType' object is not subscriptable) when trying to configure an sftp bucket using the `--wizard-config` option of the create command. This PR fixes this issue. In addition, a refactoring was performed on the wizard methods to decouple code and structure user input.

**Observed behavior:**
```
$ ml-git models create models-ex --categories=test --mutability=strict --wizard-config
_ Current configured storages _
   
1 - s3h - test-bucket
X - New Data Storage
   
_Which storage do you want to use (a number or new data storage)? _ x
Please specify the storage type ['s3', 's3h', 'azureblobh', 'gdriveh', 'gdrive', 'sftph']: _ sftph
Please specify the bucket name: _ sftph
Please specify the git repository for ml-git models metadata: _ sftph-repository
INFO - Admin: Add storage [sftph://sftph]
ERROR - MLGit: 'NoneType' object is not subscriptable
A complete log of this run can be found in: ml-git_execution.log
```

**Behavior after adjustment:**
```
$ ml-git models create models-ex --categories=test --mutability=strict --wizard-config
Current configured storages:

[1] - s3h - test-bucket
[X] - Create new data storage

Inform the storage do you want to use: x
Inform the storage type ['s3h', 'azureblobh', 'gdriveh', 'sftph']: sftph
Inform the bucket name: sftp_dir
Inform the endpoint URL: <endpoint-url>
Inform the username: lucasncabral
Inform the credentials path: <path-to-credentials>
Inform the port: 9000
INFO - Admin: Add storage [sftph://sftp_dir]
INFO - MLGit: Model artifact created.
```
