### PR TITLE
Removing special character from commands documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ pip uninstall ml-git
 1 - As ML-Git leverages git to manage ML entities metadata, it is necessary to configure user name and email address:
 
 ```
-$ git config --global user.name "Your User"
-$ git config --global user.email "your_email@example.com"
+git config --global user.name "Your User"
+git config --global user.email "your_email@example.com"
 ```
 
 2 - Storage:
@@ -61,7 +61,7 @@ To configure it you can use the basic steps to configure the project described i
 ### Usage
 
 ```
-$ ml-git --help
+ml-git --help
 Usage: ml-git [OPTIONS] COMMAND [ARGS]...
 
 Options:
@@ -82,24 +82,24 @@ Commands:
 <br>
 
 ```
-$ mkdir my-project
-$ cd my-project
-$ ml-git clone https://github.com/user/ml_git_configuration_file_example.git
+mkdir my-project
+cd my-project
+ml-git clone https://github.com/user/ml_git_configuration_file_example.git
 ```
 
 If you prefer not to create the directory:
 
 ```
-$ ml-git clone https://github.com/user/ml_git_configuration_file_example.git --folder=my-project
+ml-git clone https://github.com/user/ml_git_configuration_file_example.git --folder=my-project
 ```
 
 
 If you prefer keep git tracking files in the project:
 
 ```
-$ mkdir my-project
-$ cd my-project
-$ ml-git clone https://github.com/user/ml_git_configuration_file_example.git --track
+mkdir my-project
+cd my-project
+ml-git clone https://github.com/user/ml_git_configuration_file_example.git --track
 ```
 
 </details>
@@ -109,7 +109,7 @@ $ ml-git clone https://github.com/user/ml_git_configuration_file_example.git --t
 This command will help you to start a new project, it creates your project artifact metadata:
 
 ```
-$ ml-git datasets create --categories="computer-vision, images" --bucket-name=your_bucket --import=../import-path --mutability=strict dataset-ex 
+ml-git datasets create --categories="computer-vision, images" --bucket-name=your_bucket --import=../import-path --mutability=strict dataset-ex 
 ```
 
 Demonstration video:
@@ -124,7 +124,7 @@ Demonstration video:
 Show changes in project workspace:
 
 ```
-$ ml-git datasets status dataset-ex
+ml-git datasets status dataset-ex
 ```
 
 Demonstration video:
@@ -139,19 +139,19 @@ Demonstration video:
 Add new files to index:
 
 ```
-$ ml-git datasets add dataset-ex
+ml-git datasets add dataset-ex
 ```
 
 To increment version:
 
 ```
-$ ml-git datasets add dataset-ex --bumpversion
+ml-git datasets add dataset-ex --bumpversion
 ```
 
 Add an specific file:
 
 ```
-$ ml-git datasets add dataset-ex data/file_name.ex
+ml-git datasets add dataset-ex data/file_name.ex
 ```
 
 Demonstration video:
@@ -165,7 +165,7 @@ Demonstration video:
 Consolidate added files in the index to repository:
 
 ```
-$ ml-git datasets commit dataset-ex
+ml-git datasets commit dataset-ex
 ```
 
 Demonstration video:
@@ -179,7 +179,7 @@ Demonstration video:
 Upload metadata to remote repository and send [chunks](docs/mlgit_internals.md) to storage:
 
 ```
-$ ml-git datasets push dataset-ex
+ml-git datasets push dataset-ex
 ```
 
 Demonstration video:
@@ -193,7 +193,7 @@ Demonstration video:
 Change workspace and metadata to versioned ml-entity tag:
 
 ```
-$ ml-git datasets checkout computer-vision__images__dataset-ex__1
+ml-git datasets checkout computer-vision__images__dataset-ex__1
 ```
 
 Demonstration video:

--- a/docs/advanced_scenarios.md
+++ b/docs/advanced_scenarios.md
@@ -27,9 +27,9 @@ ML-Git provides support for users link an entitity to another. In this example, 
 First, you need to configure your remote repository. Then, you can configure your storage. It is a similarly process as you did to configure your repository and storage for your dataset.
 
 ```
-$ ml-git repository remote labels add git@github.com:example/your-mlgit-labels.git
-$ ml-git repository storage add mlgit-labels --endpoint-url=<minio-endpoint-url>
-$ ml-git labels init
+ml-git repository remote labels add git@github.com:example/your-mlgit-labels.git
+ml-git repository storage add mlgit-labels --endpoint-url=<minio-endpoint-url>
+ml-git labels init
 ```
 
 Even, we are using a different bucket to store the labels data. It would be possible to store both datasets and labels into the same bucket.
@@ -68,7 +68,7 @@ config:
 Then, you can create your first set of labels. As an example, we will use your-labels. ML-Git expects any set of labels to be specified under the _labels/_ directory of your project. Also, it expects a specification file with the name of the _labels_.
 
 ```
-$ ml-git labels create your-labels --categories="computer-vision, labels" --mutability=mutable --storage-type=s3h --bucket-name=mlgit-labels --version=1
+ml-git labels create your-labels --categories="computer-vision, labels" --mutability=mutable --storage-type=s3h --bucket-name=mlgit-labels --version=1
 ```
 
 After create the entity, you can create the README.md describing your set of labels. Below, we show an example of caption labels for the your-labels directory and file structure:
@@ -85,9 +85,9 @@ your-labels/
 Now, you are ready to version the new set of labels. For this, do:
 
 ```
-$ ml-git labels add your-labels
-$ ml-git labels commit your-labels --dataset=your-datasets
-$ ml-git labels push your-labels
+ml-git labels add your-labels
+ml-git labels commit your-labels --dataset=your-datasets
+ml-git labels push your-labels
 ```
 
 The commands are very similar to dataset operations. However, you can note one particular change in the commit command.

--- a/docs/aws_s3_configuration.md
+++ b/docs/aws_s3_configuration.md
@@ -30,64 +30,64 @@ You can configure the AWS in three ways (environment variables, through the cons
 
 1 - Environment Variables
 
-   **Linux or macOS**:
+**Linux or macOS**:
+```
+export AWS_ACCESS_KEY_ID=your-access-key
+export AWS_SECRET_ACCESS_KEY=your-secret-access-key
+export AWS_DEFAULT_REGION=us-west-2
+```
 
-    export AWS_ACCESS_KEY_ID=your-access-key
-    export AWS_SECRET_ACCESS_KEY=your-secret-access-key
-    export AWS_DEFAULT_REGION=us-west-2
-
-
-   **Windows**:
-
-    setx AWS_ACCESS_KEY_ID your-access-key
-    setx AWS_SECRET_ACCESS_KEY your-secret-access-key
-    setx AWS_DEFAULT_REGION us-west-2
-
+**Windows**:
+```
+setx AWS_ACCESS_KEY_ID your-access-key
+setx AWS_SECRET_ACCESS_KEY your-secret-access-key
+setx AWS_DEFAULT_REGION us-west-2
+```
 2 -  Console 
    
-   From the home directory (UserProfile) execute:   
-            
-   ```
-   mkdir .aws
-   ```
-   
-   You need to create two files to store the sensitive credential information (~/.aws/credentials) separated from the less sensitive configuration options (~/.aws/config). To create these two files type the following commands:
-        
-   For config file:
-        
-   ```
-   echo "
-   [your-profile-name]
-   region=bucket-region
-   output=json 
-   " > .aws/config
-   ```
+From the home directory (UserProfile) execute:   
+  
+```
+mkdir .aws
+```
 
-   For credentials file:
-   ```
-   echo "
-   [your-profile-name]
-   aws_access_key_id = your-access-key
-   aws_secret_access_key = your-secret-access-key     
-   " > .aws/credentials
-   ```
+You need to create two files to store the sensitive credential information (~/.aws/credentials) separated from the less sensitive configuration options (~/.aws/config). To create these two files type the following commands:
+
+For config file:
+
+```
+echo "
+[your-profile-name]
+region=bucket-region
+output=json 
+" > .aws/config
+```
+
+For credentials file:
+```
+echo "
+[your-profile-name]
+aws_access_key_id = your-access-key
+aws_secret_access_key = your-secret-access-key     
+" > .aws/credentials
+```
 
 3 - AWS CLI
 
-   For general use, the *aws configure* command is the fastest way to set up but requires the AWS CLI installed. To install and configure type the following commands:
+For general use, the *aws configure* command is the fastest way to set up but requires the AWS CLI installed. To install and configure type the following commands:
 
-   ```
-   pip install awscli
-   aws configure
-   ```
-   ```
-   AWS Access Key ID [None]: your-access-key
-   AWS Secret Access Key [None]: your-secret-access-key
-   Default region name [None]: bucket-region
-   Default output format [None]: json
-   ```
+```
+pip install awscli
+aws configure
+```
+```
+AWS Access Key ID [None]: your-access-key
+AWS Secret Access Key [None]: your-secret-access-key
+Default region name [None]: bucket-region
+Default output format [None]: json
+```
 
-   These commands will create the files ~/.aws/credentials and ~/.aws/config.
+These commands will create the files ~/.aws/credentials and ~/.aws/config.
 
 - Demonstrating AWS Configure
   

--- a/docs/aws_s3_configuration.md
+++ b/docs/aws_s3_configuration.md
@@ -33,9 +33,9 @@ You can configure the AWS in three ways (environment variables, through the cons
    **Linux or macOS**:
 
     ```
-    $ export AWS_ACCESS_KEY_ID=your-access-key
-    $ export AWS_SECRET_ACCESS_KEY=your-secret-access-key
-    $ export AWS_DEFAULT_REGION=us-west-2
+    export AWS_ACCESS_KEY_ID=your-access-key
+    export AWS_SECRET_ACCESS_KEY=your-secret-access-key
+    export AWS_DEFAULT_REGION=us-west-2
     ```
 
    **Windows**:
@@ -51,7 +51,7 @@ You can configure the AWS in three ways (environment variables, through the cons
    From the home directory (UserProfile) execute:   
             
    ```
-   $ mkdir .aws
+   mkdir .aws
    ```
    
    You need to create two files to store the sensitive credential information (~/.aws/credentials) separated from the less sensitive configuration options (~/.aws/config). To create these two files type the following commands:
@@ -59,7 +59,7 @@ You can configure the AWS in three ways (environment variables, through the cons
    For config file:
         
    ```
-   $ echo "
+   echo "
    [your-profile-name]
    region=bucket-region
    output=json 
@@ -68,7 +68,7 @@ You can configure the AWS in three ways (environment variables, through the cons
 
    For credentials file:
    ```
-   $ echo "
+   echo "
    [your-profile-name]
    aws_access_key_id = your-access-key
    aws_secret_access_key = your-secret-access-key     
@@ -80,8 +80,8 @@ You can configure the AWS in three ways (environment variables, through the cons
    For general use, the *aws configure* command is the fastest way to set up but requires the AWS CLI installed. To install and configure type the following commands:
 
    ```
-   $ pip install awscli
-   $ aws configure
+   pip install awscli
+   aws configure
    AWS Access Key ID [None]: your-access-key
    AWS Secret Access Key [None]: your-secret-access-key
    Default region name [None]: bucket-region

--- a/docs/aws_s3_configuration.md
+++ b/docs/aws_s3_configuration.md
@@ -82,6 +82,8 @@ You can configure the AWS in three ways (environment variables, through the cons
    ```
    pip install awscli
    aws configure
+   ```
+   ```
    AWS Access Key ID [None]: your-access-key
    AWS Secret Access Key [None]: your-secret-access-key
    Default region name [None]: bucket-region

--- a/docs/aws_s3_configuration.md
+++ b/docs/aws_s3_configuration.md
@@ -51,7 +51,7 @@ From the home directory (UserProfile) execute:
 mkdir .aws
 ```
 
-You need to create two files to store the sensitive credential information (~/.aws/credentials) separated from the less sensitive configuration options (~/.aws/config). To create these two files type the following commands:
+You need to create two files to store the sensitive credential information (\~/.aws/credentials) separated from the less sensitive configuration options (\~/.aws/config). To create these two files type the following commands:
 
 For config file:
 

--- a/docs/aws_s3_configuration.md
+++ b/docs/aws_s3_configuration.md
@@ -32,19 +32,16 @@ You can configure the AWS in three ways (environment variables, through the cons
 
    **Linux or macOS**:
 
-    ```
     export AWS_ACCESS_KEY_ID=your-access-key
     export AWS_SECRET_ACCESS_KEY=your-secret-access-key
     export AWS_DEFAULT_REGION=us-west-2
-    ```
+
 
    **Windows**:
-    
-    ```
-    C:\> setx AWS_ACCESS_KEY_ID your-access-key
-    C:\> setx AWS_SECRET_ACCESS_KEY your-secret-access-key
-    C:\> setx AWS_DEFAULT_REGION us-west-2
-    ```
+
+    setx AWS_ACCESS_KEY_ID your-access-key
+    setx AWS_SECRET_ACCESS_KEY your-secret-access-key
+    setx AWS_DEFAULT_REGION us-west-2
 
 2 -  Console 
    

--- a/docs/azure_configurations.md
+++ b/docs/azure_configurations.md
@@ -37,7 +37,7 @@ The Azure command-line interface (Azure CLI) is a set of commands used to create
 Azure CLI uses a file to store the configurations that are used by its services. To add settings to the file, simply run the following command:
 
 ```
-$ az configure
+az configure
 ```
 
 If tou prefer, you can create a configuration file through the console. The configuration file itself is located at ```$AZURE_CONFIG_DIR/config```. The default value of ```AZURE_CONFIG_DIR``` is ```$HOME/.azure``` on Linux and macOS, and ```%USERPROFILE%\.azure``` on Windows.
@@ -45,13 +45,13 @@ If tou prefer, you can create a configuration file through the console. The conf
    From the home directory (UserProfile) execute:   
             
    ```
-   $ mkdir .azure
+   mkdir .azure
    ```
    
    You need to create the config file with the connection string value:
      
    ```
-   $ echo "
+   echo "
     [storage]
     connection_string = "<yourconnectionstring>"
    " > .azure/config

--- a/docs/first_project.md
+++ b/docs/first_project.md
@@ -106,6 +106,9 @@ You can find more information about metadata [here](mlgit_internals.md).
 All configurations are stored in _.ml-git/config.yaml_ and you can look at configuration state at any time with the following command:
 ```
 ml-git repository config show
+```
+Output:
+```
 config:
 {'batch_size': 20,
  'cache_path': '',
@@ -215,6 +218,9 @@ You can look at the working tree status with the following command:
 
 ```
 ml-git datasets status imagenet8
+```
+Output:
+```
 INFO - Repository: dataset: status of ml-git index for [imagenet8]
 Changes to be committed
 
@@ -246,6 +252,9 @@ The command "*ml-git dataset add*" adds the files into a specific dataset, such 
 
 ```
 ml-git datasets status imagenet8
+```
+Output:
+```
 INFO - Repository: dataset: status of ml-git index for [imagenet8]
 Changes to be committed
     new file:   data\train\train_data_batch_1
@@ -324,6 +333,9 @@ Even these commands show a different bucket to store the labels data. It would b
 If you look at your config file, you would see the following information:
 ```
 ml-git repository config show
+```
+Output:
+```
 config:
 {'batch_size': 20,
  'cache_path': '',
@@ -380,6 +392,9 @@ Once done, anyone will be able to retrieve the exact same version of the dataset
 One can look at the specific dataset associated with that set of labels by executing the following command:
 ```
 ml-git labels show mscoco-captions
+```
+Output:
+```
 -- labels : mscoco-captions --
 categories:
 - computer-vision
@@ -513,6 +528,9 @@ To discover which datasets are under ML-Git management, you can execute the foll
 
 ```
 ml-git datasets list
+```
+Output:
+```
 ML dataset
 |-- folderA
 |   |-- folderB
@@ -528,6 +546,9 @@ To show all these tag representing the versions of a dataset, simply type the fo
 
 ```
 ml-git datasets tag list imagenet8
+```
+Output:
+```
 computer-vision__images__imagenet8__1
 computer-vision__images__imagenet8__2
 ```
@@ -536,6 +557,9 @@ It means there are actually 2 versions under ML-Git management. You can check wh
 
 ```
 ml-git datasets branch imagenet8
+```
+Output:
+```
 ('vision-computing__images__imagenet8__2', '48ba1e994a1e39e1b508bff4a3302a5c1bb9063e')
 ```
 

--- a/docs/first_project.md
+++ b/docs/first_project.md
@@ -42,8 +42,8 @@ If you haven't created it yet, you can use the [resources initialization script]
 After that, create a ML-Git project. To do this, use the following commands (note that 'mlgit-project' is the project name used as example):
 
 ```
-$ mkdir mlgit-project && cd mlgit-project (or clone an existing repo from Github or Github Enterprise)
-$ ml-git repository init
+mkdir mlgit-project && cd mlgit-project (or clone an existing repo from Github or Github Enterprise)
+ml-git repository init
 ```
 
 [![asciicast](https://asciinema.org/a/435876.svg)](https://asciinema.org/a/435876)
@@ -63,14 +63,14 @@ In addition to creating the MinIO server, it is necessary to configure the setti
 For a basic ML-Git repository, you need to add a remote repository for metadata and the MinIO bucket configuration.
 
 ```
-$ ml-git repository remote datasets add git@github.com:example/your-mlgit-datasets.git
-$ ml-git repository storage add mlgit-datasets --credentials=mlgit --endpoint-url=<minio-endpoint-url>
+ml-git repository remote datasets add git@github.com:example/your-mlgit-datasets.git
+ml-git repository storage add mlgit-datasets --credentials=mlgit --endpoint-url=<minio-endpoint-url>
 ```
 
 Last but not least, initialize the metadata repository.
 
 ```
-$ ml-git datasets init
+ml-git datasets init
 ```
 
 **Setting up an ML-Git project with MinIO:**
@@ -84,14 +84,14 @@ Similar to the MinIO setup, in addition to creating the bucket in S3, it is nece
 For a basic ML-Git repository, you need to add a remote repository for metadata and a S3 bucket configuration.
 
 ```
-$ ml-git repository remote datasets add git@github.com:example/your-mlgit-datasets.git
-$ ml-git repository storage add mlgit-datasets --credentials=mlgit
+ml-git repository remote datasets add git@github.com:example/your-mlgit-datasets.git
+ml-git repository storage add mlgit-datasets --credentials=mlgit
 ```
 
 After that initialize the metadata repository.
 
 ```
-$ ml-git datasets init
+ml-git datasets init
 ```
 
 #### <a name="git_use">Why ML-Git uses git?</a> ####
@@ -105,7 +105,7 @@ You can find more information about metadata [here](mlgit_internals.md).
 
 All configurations are stored in _.ml-git/config.yaml_ and you can look at configuration state at any time with the following command:
 ```
-$ ml-git repository config show
+ml-git repository config show
 config:
 {'batch_size': 20,
  'cache_path': '',
@@ -134,7 +134,7 @@ ML-Git expects any dataset to be specified under _datasets/_ directory of your p
 To create this specification file for a new entity you must run the following command:
 
 ```
-$ ml-git datasets create imagenet8 --categories="computer-vision, images" --mutability=strict --storage-type=s3h --bucket-name=mlgit-datasets
+ml-git datasets create imagenet8 --categories="computer-vision, images" --mutability=strict --storage-type=s3h --bucket-name=mlgit-datasets
 ```
 
 This command will create the dataset directory at the root of the project entity.
@@ -142,7 +142,7 @@ If you want to create a version of your dataset in a different directory, you ca
 to inform the relative directory where the entity is to be created. Example:
 
 ```
-$ ml-git datasets create imagenet8 --categories="computer-vision, images" --mutability=strict --storage-type=s3h --bucket-name=mlgit-datasets --entity-dir=folderA/folderB
+ml-git datasets create imagenet8 --categories="computer-vision, images" --mutability=strict --storage-type=s3h --bucket-name=mlgit-datasets --entity-dir=folderA/folderB
 ```
 
 After that a file must have been created in datasets/folderA/folderB/imagenet8/imagenet8.spec and should look like this:
@@ -214,7 +214,7 @@ imagenet8/
 You can look at the working tree status with the following command:
 
 ```
-$ ml-git datasets status imagenet8
+ml-git datasets status imagenet8
 INFO - Repository: dataset: status of ml-git index for [imagenet8]
 Changes to be committed
 
@@ -239,13 +239,13 @@ corrupted files
 That command allows printing the tracked files and the ones in the index/staging area. Now, you are ready to put that new dataset under ML-Git management. For this, do:
 
 ```
-$ ml-git datasets add imagenet8
+ml-git datasets add imagenet8
 ```
 
 The command "*ml-git dataset add*" adds the files into a specific dataset, such as imagenet8 in the index/staging area. If you check the working tree status, you can see that now the files appear as tracked but not committed yet:
 
 ```
-$ ml-git datasets status imagenet8
+ml-git datasets status imagenet8
 INFO - Repository: dataset: status of ml-git index for [imagenet8]
 Changes to be committed
     new file:   data\train\train_data_batch_1
@@ -268,13 +268,13 @@ corrupted files
 Then, you can commit the metadata to the local repository. For this purpose, type the following command:
 
 ```
-$ ml-git datasets commit imagenet8
+ml-git datasets commit imagenet8
 ```
 
 After that, you can use "*ml-git dataset push*" to update the remote metadata repository just after storing all actual data under management in the specified remote data storage.
 
 ```
-$ ml-git datasets push imagenet8
+ml-git datasets push imagenet8
 ```
 
 As you can observe, ML-Git follows very similar workflows as git.
@@ -314,16 +314,16 @@ Also, you will need to have a dataset already versioned by ML-Git in your reposi
 The first step is to configure your metadata and data repository/storage.
 
 ```
-$ ml-git repository remote labels add git@github.com:example/your-mlgit-labels.git
-$ ml-git repository storage add mlgit-labels --endpoint-url=<minio-endpoint-url>
-$ ml-git labels init
+ml-git repository remote labels add git@github.com:example/your-mlgit-labels.git
+ml-git repository storage add mlgit-labels --endpoint-url=<minio-endpoint-url>
+ml-git labels init
 ```
 
 Even these commands show a different bucket to store the labels data. It would be possible to store both datasets and labels into the same bucket.
 
 If you look at your config file, you would see the following information:
 ```
-$ ml-git repository config show
+ml-git repository config show
 config:
 {'batch_size': 20,
  'cache_path': '',
@@ -350,7 +350,7 @@ config:
 Then, you can create your first set of labels. As an example, we will use mscoco. ML-Git expects any set of labels to be specified under the _labels/_ directory of your project. Also, it expects a specification file with the name of the _labels_.
 
 ```
-$ ml-git labels create mscoco-captions --categories="computer-vision, captions" --mutability=mutable --storage-type=s3h --bucket-name=mlgit-labels --version=1
+ml-git labels create mscoco-captions --categories="computer-vision, captions" --mutability=mutable --storage-type=s3h --bucket-name=mlgit-labels --version=1
 ```
 
 After create the entity, you can create the README.md describing your set of labels. Below is the tree of caption labels for the mscoco directory and file structure:
@@ -367,9 +367,9 @@ mscoco-captions/
 Now, you are ready to put the new set of labels under ML-Git management.  We assume there is an existing mscoco dataset. For this, do:
 
 ```
-$ ml-git labels add mscoco-captions
-$ ml-git labels commit mscoco-captions --dataset=mscoco
-$ ml-git labels push mscoco-captions
+ml-git labels add mscoco-captions
+ml-git labels commit mscoco-captions --dataset=mscoco
+ml-git labels push mscoco-captions
 ```
 
 The commands are very similar to dataset operations. However, you can note one particular change in the commit command.
@@ -379,7 +379,7 @@ Once done, anyone will be able to retrieve the exact same version of the dataset
 
 One can look at the specific dataset associated with that set of labels by executing the following command:
 ```
-$ ml-git labels show mscoco-captions
+ml-git labels show mscoco-captions
 -- labels : mscoco-captions --
 categories:
 - computer-vision
@@ -406,15 +406,15 @@ To create and upload your model, you must be in an already initialized project, 
 The first step is to configure your metadata & data repository/storage.
 
 ```
-$ ml-git repository remote models add git@github.com:example/your-mlgit-models.git
-$ ml-git repository storage add mlgit-models --endpoint-url=<minio-endpoint-url>
-$ ml-git models init
+ml-git repository remote models add git@github.com:example/your-mlgit-models.git
+ml-git repository storage add mlgit-models --endpoint-url=<minio-endpoint-url>
+ml-git models init
 ```
 
 To create a model entity, you can run the following command:
 
 ```
-$ ml-git models create imagenet-model --categories="computer-vision, images" --storage-type=s3h --mutability=mutable --bucket-name=mlgit-models
+ml-git models create imagenet-model --categories="computer-vision, images" --storage-type=s3h --mutability=mutable --bucket-name=mlgit-models
 ```
 
 After creating the model, we add the model file to the data folder. Here below is the directory tree structure:
@@ -430,9 +430,9 @@ imagenet-model/
 Now, you're ready to put that new model set under ML-Git management. We assume there is an existing imagenet8 dataset and mscoco-captions labels. For this, do:
 
 ```
-$ ml-git models add imagenet-model
-$ ml-git models commit imagenet-model --dataset=imagenet8 --labels=mscoco-captions
-$ ml-git models push imagenet-model
+ml-git models add imagenet-model
+ml-git models commit imagenet-model --dataset=imagenet8 --labels=mscoco-captions
+ml-git models push imagenet-model
 ```
 
 There is not much change compared to dataset and labels operation.
@@ -450,13 +450,13 @@ We can insert metrics to the model in the add command, metrics can be added with
 An example of adding a model passing a metrics file, would be the following command:
 
 ```
-$ ml-git models add imagenet-model --metrics-file='/path/to/your/file.csv'
+ml-git models add imagenet-model --metrics-file='/path/to/your/file.csv'
 ```
 
 An example of adding a model passing metrics through the command line, would be the following command:
 
 ```
-$ ml-git models add imagenet-model --metric accuracy 10 --metric precision 20 --metric recall 30
+ml-git models add imagenet-model --metric accuracy 10 --metric precision 20 --metric recall 30
 ```
 
 Obs: The parameters used above were chosen for example purposes, you can name your metrics however you want to, you can also pass as many metrics as you want, as long as you use the command correctly.
@@ -481,7 +481,7 @@ model:
 You can view metrics for all tags for that entity by running the following command:
 
 ```
-$ ml-git models metrics imagenet-model
+ml-git models metrics imagenet-model
 ```
 
 [![asciicast](https://asciinema.org/a/435899.svg)](https://asciinema.org/a/435899)
@@ -494,25 +494,25 @@ If you don't have a dataset versioned by the ML-Git, see [section 2](#upload-dat
 To download a dataset, you need to be in an initialized and configured ML-Git project. If you have a repository with your saved settings, you can run the following command to set up your environment:
 
 ```
-$ ml-git clone git@github.com:example/your-mlgit-repository.git
+ml-git clone git@github.com:example/your-mlgit-repository.git
 ```
 
 If you are in a configured ML-Git project directory, the following command will update the metadata repository, allowing visibility of what has been shared since the last update (new ML entity, new versions).
 
 ```
-$ ml-git datasets update
+ml-git datasets update
 ```
 
 Or update all metadata repository:
 
 ```
-$ ml-git repository update
+ml-git repository update
 ```
 
 To discover which datasets are under ML-Git management, you can execute the following command:
 
 ```
-$ ml-git datasets list
+ml-git datasets list
 ML dataset
 |-- folderA
 |   |-- folderB
@@ -527,7 +527,7 @@ In order for ML-Git to manage the different versions of the same dataset. It int
 To show all these tag representing the versions of a dataset, simply type the following:
 
 ```
-$ ml-git datasets tag list imagenet8
+ml-git datasets tag list imagenet8
 computer-vision__images__imagenet8__1
 computer-vision__images__imagenet8__2
 ```
@@ -535,7 +535,7 @@ computer-vision__images__imagenet8__2
 It means there are actually 2 versions under ML-Git management. You can check what version is checked out in the ML-Git workspace with the following command:
 
 ```
-$ ml-git datasets branch imagenet8
+ml-git datasets branch imagenet8
 ('vision-computing__images__imagenet8__2', '48ba1e994a1e39e1b508bff4a3302a5c1bb9063e')
 ```
 
@@ -548,17 +548,17 @@ The output is a tuple:
 It is simple to retrieve a specific version locally to start any experiment by executing one of the following commands:
 
 ```
-$ ml-git datasets checkout computer-vision__images__imagenet8__1
+ml-git datasets checkout computer-vision__images__imagenet8__1
 ```
 or 
 ```
-$ ml-git datasets checkout imagenet8 --version=1
+ml-git datasets checkout imagenet8 --version=1
 ```
 
 If you want to get the latest available version of an entity you can just pass its name in the checkout command, as shown below:
 
 ```
-$ ml-git datasets checkout imagenet8
+ml-git datasets checkout imagenet8
 ```
 
 Getting the data will auto-create a directory structure under _dataset_ directory as shown below. That structure _folderA/folderB_ is actually the structure in which the dataset was versioned.
@@ -594,7 +594,7 @@ folderA
 If at some point you want to check the integrity of the metadata repository (e.g. computer shuts down during a process), simply type the following command:
 
 ```
-$ ml-git datasets fsck
+ml-git datasets fsck
 INFO - HashFS: starting integrity check on [.\.ml-git\dataset\objects\hashfs]
 ERROR - HashFS: corruption detected for chunk [zdj7WVccN8cRj1RcvweX3FNUEQyBe1oKEsWsutJNJoxt12mn1] - got [zdj7WdCbyFbcqHVMarj3KCLJ7yjTM3S9X26RyXWTfXGB2czeB]
 INFO - HashFS: starting integrity check on [.\.ml-git\dataset\index\hashfs]

--- a/docs/first_steps.md
+++ b/docs/first_steps.md
@@ -90,17 +90,16 @@ Corrupted files:
 
 Above, the output shows some untracked files. To commit these files, similarly to git, we can run the following sequence of commands:
 
-It will add all untracked files
+The following command will add all untracked files:
 ```
 ml-git datasets add imagenet8
 ```
- It will commit the metadata to the local repository
+The following command will commit the metadata to the local repository:
 ```
 ml-git datasets commit imagenet8
 ```
-
+The following command  will update the remote metadata repository:
 ```
-# It will update the remote metadata repository
 ml-git datasets push imagenet8
 ```
 

--- a/docs/first_steps.md
+++ b/docs/first_steps.md
@@ -89,13 +89,13 @@ Corrupted files:
 ```
 
 Above, the output shows some untracked files. To commit these files, similarly to git, we can run the following sequence of commands:
+
+It will add all untracked files
 ```
-# It will add all untracked files
 ml-git datasets add imagenet8
 ```
-
+ It will commit the metadata to the local repository
 ```
-# It will commit the metadata to the local repository
 ml-git datasets commit imagenet8
 ```
 

--- a/docs/gdrive_configurations.md
+++ b/docs/gdrive_configurations.md
@@ -73,13 +73,13 @@ Create directory with name  of your preference and copy your credentials  file w
 Add storage configurations example:
 
 ```
-$ ml-git repository storage add path-in-your-drive --type=gdriveh --credentials=/home/profile/.gdrive
+ml-git repository storage add path-in-your-drive --type=gdriveh --credentials=/home/profile/.gdrive
 ```
 
 After that initialize the metadata repository:
 
 ```
-$ ml-git datasets init
+ml-git datasets init
 ```
 
 

--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -9,13 +9,12 @@ Also, git is required as ML-Git uses git to manage ML entities metadata.
 You can check if you already have these installed from the command line:
 
 ```
-python --version
-Python 3.8.2
-
-pip --version
+python --version && pip --version && git --version
+```
+Output:
+```
+Pyhon 3.8.2
 pip 20.0.2 from /usr/lib/python3/dist-packages/pip (python 3.8)
-
-git --version
 git version 2.25.1
 ```
 

--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -9,13 +9,13 @@ Also, git is required as ML-Git uses git to manage ML entities metadata.
 You can check if you already have these installed from the command line:
 
 ```
-$ python --version
+python --version
 Python 3.8.2
 
-$ pip --version
+pip --version
 pip 20.0.2 from /usr/lib/python3/dist-packages/pip (python 3.8)
 
-$ git --version
+git --version
 git version 2.25.1
 ```
 
@@ -57,7 +57,7 @@ pip install git+git://github.com/HPInc/ml-git.git
 You should now have the ML-Git installed on your system. Run ```ml-git --version``` to check that everything worked okay.
 
 ```
-$ ml-git --version
+ml-git --version
 ```
 ml-git 2.0.1
 

--- a/docs/minio_s3_configuration.md
+++ b/docs/minio_s3_configuration.md
@@ -64,7 +64,7 @@ From the home directory (UserProfile) execute:
 mkdir .aws
 ```
 
-You need to create two files to store the sensitive credential information (~/.aws/credentials) separated from the less sensitive configuration options (~/.aws/config). To create these two files type the following commands:
+You need to create two files to store the sensitive credential information (\~/.aws/credentials) separated from the less sensitive configuration options (\~/.aws/config). To create these two files type the following commands:
 
 For config file:
 

--- a/docs/minio_s3_configuration.md
+++ b/docs/minio_s3_configuration.md
@@ -42,64 +42,64 @@ You can configure the credentials in three ways (environment variables, through 
 
 1 - Environment Variables
 
-   **Linux or macOS**:
+**Linux or macOS**:
 
-    ```
-    export AWS_ACCESS_KEY_ID=your-access-key
-    export AWS_SECRET_ACCESS_KEY=your-secret-access-key
-    ```
+```
+export AWS_ACCESS_KEY_ID=your-access-key
+export AWS_SECRET_ACCESS_KEY=your-secret-access-key
+```
 
-   **Windows**:
-    
-    ```
-    C:\> setx AWS_ACCESS_KEY_ID your-access-key
-    C:\> setx AWS_SECRET_ACCESS_KEY your-secret-access-key
-    ```
+**Windows**:
+
+```
+C:\> setx AWS_ACCESS_KEY_ID your-access-key
+C:\> setx AWS_SECRET_ACCESS_KEY your-secret-access-key
+```
 
 2 -  Console 
-   
-   From the home directory (UserProfile) execute:   
-            
-   ```
-   mkdir .aws
-   ```
-   
-   You need to create two files to store the sensitive credential information (~/.aws/credentials) separated from the less sensitive configuration options (~/.aws/config). To create these two files type the following commands:
-        
-   For config file:
-        
-   ```
-   echo "
-   [your-profile-name]
-   output=json 
-   " > .aws/config
-   ```
 
-   For credentials file:
-   ```
-   echo "
-   [your-profile-name]
-   aws_access_key_id = your-access-key
-   aws_secret_access_key = your-secret-access-key     
-   " > .aws/credentials
-   ```
+From the home directory (UserProfile) execute:   
+  
+```
+mkdir .aws
+```
+
+You need to create two files to store the sensitive credential information (~/.aws/credentials) separated from the less sensitive configuration options (~/.aws/config). To create these two files type the following commands:
+
+For config file:
+
+```
+echo "
+[your-profile-name]
+output=json 
+" > .aws/config
+```
+
+For credentials file:
+```
+echo "
+[your-profile-name]
+aws_access_key_id = your-access-key
+aws_secret_access_key = your-secret-access-key     
+" > .aws/credentials
+```
 
 3 - AWS CLI
 
-   For general use, the *aws configure* command is the fastest way to set up but requires the AWS CLI installed. To install and configure type the following commands:
+For general use, the *aws configure* command is the fastest way to set up but requires the AWS CLI installed. To install and configure type the following commands:
 
-   ```
-   pip install awscli
-   aws configure
-   ```
-   ```
-   AWS Access Key ID [None]: your-access-key
-   AWS Secret Access Key [None]: your-secret-access-key
-   Default region name [None]: 
-   Default output format [None]: json
-   ```
+```
+pip install awscli
+aws configure
+```
+```
+AWS Access Key ID [None]: your-access-key
+AWS Secret Access Key [None]: your-secret-access-key
+Default region name [None]: 
+Default output format [None]: json
+```
 
-   These commands will create the files ~/.aws/credentials and ~/.aws/config.
+These commands will create the files ~/.aws/credentials and ~/.aws/config.
 
 - Demonstrating AWS Configure
   

--- a/docs/minio_s3_configuration.md
+++ b/docs/minio_s3_configuration.md
@@ -91,6 +91,8 @@ You can configure the credentials in three ways (environment variables, through 
    ```
    pip install awscli
    aws configure
+   ```
+   ```
    AWS Access Key ID [None]: your-access-key
    AWS Secret Access Key [None]: your-secret-access-key
    Default region name [None]: 

--- a/docs/minio_s3_configuration.md
+++ b/docs/minio_s3_configuration.md
@@ -6,7 +6,7 @@
 
 In case you want to run MinIO locally for testing purposes, it's possible to run a docker container using the following command:
 ```
-$ docker run -v /path/to/your/dir:/data --name=minio --network=host minio/minio server --console-address ":9001" /data
+docker run -v /path/to/your/dir:/data --name=minio --network=host minio/minio server --console-address ":9001" /data
 ```
 The command will start the MinIO API and Console servers in ports 9000 and 9001, respectively.
 
@@ -45,8 +45,8 @@ You can configure the credentials in three ways (environment variables, through 
    **Linux or macOS**:
 
     ```
-    $ export AWS_ACCESS_KEY_ID=your-access-key
-    $ export AWS_SECRET_ACCESS_KEY=your-secret-access-key
+    export AWS_ACCESS_KEY_ID=your-access-key
+    export AWS_SECRET_ACCESS_KEY=your-secret-access-key
     ```
 
    **Windows**:
@@ -61,7 +61,7 @@ You can configure the credentials in three ways (environment variables, through 
    From the home directory (UserProfile) execute:   
             
    ```
-   $ mkdir .aws
+   mkdir .aws
    ```
    
    You need to create two files to store the sensitive credential information (~/.aws/credentials) separated from the less sensitive configuration options (~/.aws/config). To create these two files type the following commands:
@@ -69,7 +69,7 @@ You can configure the credentials in three ways (environment variables, through 
    For config file:
         
    ```
-   $ echo "
+   echo "
    [your-profile-name]
    output=json 
    " > .aws/config
@@ -77,7 +77,7 @@ You can configure the credentials in three ways (environment variables, through 
 
    For credentials file:
    ```
-   $ echo "
+   echo "
    [your-profile-name]
    aws_access_key_id = your-access-key
    aws_secret_access_key = your-secret-access-key     
@@ -89,8 +89,8 @@ You can configure the credentials in three ways (environment variables, through 
    For general use, the *aws configure* command is the fastest way to set up but requires the AWS CLI installed. To install and configure type the following commands:
 
    ```
-   $ pip install awscli
-   $ aws configure
+   pip install awscli
+   aws configure
    AWS Access Key ID [None]: your-access-key
    AWS Secret Access Key [None]: your-secret-access-key
    Default region name [None]: 

--- a/docs/mlgit_commands.md
+++ b/docs/mlgit_commands.md
@@ -20,7 +20,7 @@ Commands:
 
 Example:
 ```
-$ ml-git --help
+ml-git --help
 ```
 
 </details>
@@ -51,7 +51,7 @@ Options:
 
 Dataset example:
 ```
-$ ml-git datasets add dataset-ex --bumpversion
+ml-git datasets add dataset-ex --bumpversion
 ```
 
 ml-git expects datasets to be managed under _dataset_ directory.
@@ -63,7 +63,7 @@ Internally, the _ml-git add_ will add all the files under the \<ml-entity\> dire
 
 Model example:
 ```
-$ ml-git models add model-ex --metrics-file='/path/to/your/file.csv'
+ml-git models add model-ex --metrics-file='/path/to/your/file.csv'
 ```
 
 ml-git allows you to enter a metrics file or the metrics themselves on the command line when adding a model.
@@ -86,7 +86,7 @@ Options:
 
 Example:
 ```
-$ ml-git datasets branch imagenet8
+ml-git datasets branch imagenet8
 ('vision-computing__images__imagenet8__1', '48ba1e994a1e39e1b508bff4a3302a5c1bb9063e')
 ```
 
@@ -129,11 +129,11 @@ Options:
 
 Examples:
 ```
-$ ml-git datasets checkout computer-vision__images__faces__fddb__1
+ml-git datasets checkout computer-vision__images__faces__fddb__1
 ```
 or you can use the name of the entity directly and download the latest available tag
 ```
-$ ml-git datasets checkout fddb
+ml-git datasets checkout fddb
 ```
 
 
@@ -174,7 +174,7 @@ Options:
 
 Example:
 ```
-$ ml-git models commit model-ex --dataset=dataset-ex
+ml-git models commit model-ex --dataset=dataset-ex
 ```
 
 This command commits the index / staging area to the local repository. It is a 2-step operation in which 1) the actual data (blobs) is copied to the local repository, 2) committing the metadata to the git repository managing the metadata.
@@ -259,7 +259,7 @@ Options:
 
 Example:
 ```
-$ ml-git datasets export computer-vision__images__faces__fddb__1 minio
+ml-git datasets export computer-vision__images__faces__fddb__1 minio
 ```
 
 </details>
@@ -316,7 +316,7 @@ Options:
 
 Example:
 ```
-$ ml-git datasets fsck
+ml-git datasets fsck
 ```
 
 This command will walk through the internal ml-git directories (index & local repository) and will check the integrity of all blobs under its management.
@@ -355,11 +355,11 @@ Options:
 
 Example:
 ```
-$ ml-git datasets import bucket-name dataset/computer-vision/imagenet8/data
+ml-git datasets import bucket-name dataset/computer-vision/imagenet8/data
 ```
 For google drive storage:
 ```
-$ ml-git datasets import gdrive-folder --storage-type=gdrive --object=file_to_download --credentials=credentials-path dataset/
+ml-git datasets import gdrive-folder --storage-type=gdrive --object=file_to_download --credentials=credentials-path dataset/
 ```
 
 </details>
@@ -379,7 +379,7 @@ Options:
 
 Example:
 ```
-$ ml-git datasets init
+ml-git datasets init
 ```
 
 This command is mandatory to be executed just after the addition of a remote metadata repository (_ml-git \<ml-entity\> remote add_).
@@ -406,7 +406,7 @@ Options:
 
 Example:
 ```
-$ ml-git models metrics model-ex
+ml-git models metrics model-ex
 ```
 
 Note:
@@ -431,7 +431,7 @@ Options:
 
 Example:
 ```
-$ ml-git datasets list
+ml-git datasets list
 ML dataset
 |-- computer-vision
 |   |-- images
@@ -602,7 +602,7 @@ Options:
 
 Example:
 ```
-$ ml-git datasets show dataset-ex
+ml-git datasets show dataset-ex
 -- dataset : imagenet8 --
 categories:
 - vision-computing
@@ -633,7 +633,7 @@ Options:
 
 Example:
 ```
-$ ml-git datasets status dataset-ex
+ml-git datasets status dataset-ex
 ```
 
 </details>
@@ -653,7 +653,7 @@ Options:
 
 Example:
 ```
-$ ml-git datasets tag add dataset-ex my_tag
+ml-git datasets tag add dataset-ex my_tag
 ```
 
 </details>
@@ -673,7 +673,7 @@ Options:
 
 Example:
 ```
-$ ml-git datasets tag list dataset-ex
+ml-git datasets tag list dataset-ex
 ```
 
 </details>
@@ -693,7 +693,7 @@ Options:
 
 Example:
 ```
-$ ml-git datasets update
+ml-git datasets update
 ```
 
 This command enables one to have the visibility of what has been shared since the last update (new ML entity, new versions).
@@ -715,7 +715,7 @@ Options:
 
 Example:
 ```
-$ ml-git datasets unlock dataset-ex data/file1.txt
+ml-git datasets unlock dataset-ex data/file1.txt
 ```
 
 Note:
@@ -744,7 +744,7 @@ Options:
 
 Example:
 ```
-$ ml-git clone https://git@github.com/mlgit-repository
+ml-git clone https://git@github.com/mlgit-repository
 ```
 
 </details>
@@ -794,7 +794,7 @@ Options:
 
 Example:
 ```
-$ ml-git repository config push -m "My commit message"
+ml-git repository config push -m "My commit message"
 ```
 
 </details>
@@ -816,7 +816,7 @@ Options:
 
 Example:
 ```
-$ ml-git repository config show
+ml-git repository config show
 config:
 {'datasets': {'git': 'git@github.com:example/your-mlgit-datasets'},
  'storages': {'s3': {'mlgit-datasets': {'aws-credentials': {'profile': 'mlgit'},
@@ -866,7 +866,7 @@ Options:
 
 Example:
 ```
-$ ml-git repository graph
+ml-git repository graph
 
 digraph "Entities Graph" {
 "models-ex (1)" [color="#d63638"];
@@ -903,7 +903,7 @@ Options:
 
 Example:
 ```
-$ ml-git repository init
+ml-git repository init
 ```
 
 This is the first command you need to run to initialize a ml-git project. It will bascially create a default .ml-git/config.yaml
@@ -925,7 +925,7 @@ Options:
 
 Example:
 ```
-$ ml-git repository remote datasets add https://git@github.com/mlgit-datasets
+ml-git repository remote datasets add https://git@github.com/mlgit-datasets
 ```
 
 </details>
@@ -945,7 +945,7 @@ Options:
 
 Example:
 ```
-$ ml-git repository remote datasets del
+ml-git repository remote datasets del
 ```
 
 </details>
@@ -965,7 +965,7 @@ Options:
 
 Example:
 ```
-$ ml-git repository remote config add https://git@github.com/mlgit-config
+ml-git repository remote config add https://git@github.com/mlgit-config
 ```
 
 </details>
@@ -996,7 +996,7 @@ Options:
 
 Example:
 ```
-$ ml-git repository storage add minio --endpoint-url=<minio-endpoint-url>
+ml-git repository storage add minio --endpoint-url=<minio-endpoint-url>
 ```
 
 Use this command to add a data storage to a ml-git project.
@@ -1020,7 +1020,7 @@ Options:
 
 Example:
 ```
-$ ml-git repository storage del minio
+ml-git repository storage del minio
 ```
 
 </details>
@@ -1037,7 +1037,7 @@ Usage: ml-git repository update
 
 Example:
 ```
-$ ml-git repository update
+ml-git repository update
 ```
 
 </details>

--- a/docs/mlgit_commands.md
+++ b/docs/mlgit_commands.md
@@ -87,6 +87,9 @@ Options:
 Example:
 ```
 ml-git datasets branch imagenet8
+```
+Output:
+```
 ('vision-computing__images__imagenet8__1', '48ba1e994a1e39e1b508bff4a3302a5c1bb9063e')
 ```
 
@@ -432,6 +435,9 @@ Options:
 Example:
 ```
 ml-git datasets list
+```
+Output:
+```
 ML dataset
 |-- computer-vision
 |   |-- images
@@ -603,6 +609,9 @@ Options:
 Example:
 ```
 ml-git datasets show dataset-ex
+```
+Output:
+```
 -- dataset : imagenet8 --
 categories:
 - vision-computing
@@ -817,6 +826,9 @@ Options:
 Example:
 ```
 ml-git repository config show
+```
+Output:
+```
 config:
 {'datasets': {'git': 'git@github.com:example/your-mlgit-datasets'},
  'storages': {'s3': {'mlgit-datasets': {'aws-credentials': {'profile': 'mlgit'},
@@ -867,7 +879,9 @@ Options:
 Example:
 ```
 ml-git repository graph
-
+```
+Output:
+```
 digraph "Entities Graph" {
 "models-ex (1)" [color="#d63638"];
 "dataset-ex (1)" [color="#2271b1"];

--- a/docs/qs_checkout.md
+++ b/docs/qs_checkout.md
@@ -3,25 +3,25 @@
 To download a dataset, you need to be in an initialized and configured ML-Git project. If you have a repository with your saved settings, you can run the following command to set up your environment:
 
 ```
-$ ml-git clone git@github.com:example/your-mlgit-repository.git
+ml-git clone git@github.com:example/your-mlgit-repository.git
 ```
 
 Then, you can retrieve a specific version of a dataset to run an experiment. To achieve that, you can use the version tag to download this version to your local environment using one of the following commands:
 
 ```
-$ ml-git datasets checkout computer-vision__images__faces__fddb__1
+ml-git datasets checkout computer-vision__images__faces__fddb__1
 ```
 
 or 
 
 ```
-$ ml-git datasets checkout fddb --version=1
+ml-git datasets checkout fddb --version=1
 ```
 
 If you want to get the latest available version of a dataset, you can pass its name in the checkout command, as shown below:
 
 ```
-$ ml-git datasets checkout fddb
+ml-git datasets checkout fddb
 ```
 
 Then, your directory should look like this:

--- a/docs/qs_configure_repository.md
+++ b/docs/qs_configure_repository.md
@@ -6,17 +6,17 @@ To create the .ml-git folder that will be versioned, the following commands are 
 
 1. Initialize the ML-Git project.
     ```
-    $ ml-git repository init
+    ml-git repository init
     ```
    
 2. Configure remotes for the entities that will be used.
     ```
-    $ ml-git datasets remote add git@github.com:example/your-mlgit-datasets.git
+    ml-git datasets remote add git@github.com:example/your-mlgit-datasets.git
     ```
 
 3. Configure the storages which will be used.
     ```
-    $ ml-git repository storage add mlgit-datasets --credentials=mlgit --endpoint-url=<minio-endpoint-url>
+    ml-git repository storage add mlgit-datasets --credentials=mlgit --endpoint-url=<minio-endpoint-url>
     ```
 
 After that, you should version, in a git repository, the .ml-git folder created during this process.

--- a/docs/sftp_configurations.md
+++ b/docs/sftp_configurations.md
@@ -7,13 +7,13 @@ This section explains how to configure the settings that the ml-git uses to inte
 Add store configurations example:
 
 ```
-$ ml-git repository storage add path-in-your-sftp-server --type=sftph --username=your-user-name --endpoint-url=your-host --private-key=/home/profile/your_private_key
+ml-git repository storage add path-in-your-sftp-server --type=sftph --username=your-user-name --endpoint-url=your-host --private-key=/home/profile/your_private_key
 ```
 
 After that initialize the metadata repository:
 
 ```
-$ ml-git datasets init
+ml-git datasets init
 ```
 
 


### PR DESCRIPTION
Special character in documentation is inducing the error of copying and pasting.

![1](https://user-images.githubusercontent.com/24386872/135085203-498a161b-e242-4700-a0ac-0c646b0c8106.png)
![2](https://user-images.githubusercontent.com/24386872/135085240-cf52ce4b-9010-4f67-a846-a15d189512bf.png)

