### PR TITLE
Fixing issue related with storage type s3h being saving in global configuration instead of local configuration

### DIFF
--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -380,7 +380,7 @@ def _create_new_bucket():
                         'private_key': input(USER_INPUT_MESSAGE.format('credentials path')),
                         'port': int(input(USER_INPUT_MESSAGE.format('port')))}
     from ml_git.admin import storage_add
-    storage_add(storage_type, bucket, credential_profile, endpoint, sftp_configs=sftp_configs)
+    storage_add(storage_type, bucket, credential_profile, endpoint_url=endpoint, sftp_configs=sftp_configs)
     return storage_type, bucket
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -104,6 +104,12 @@ class ConfigTestCases(unittest.TestCase):
     def test_config_load(self):
         mlgit_config_load()
 
+    def check_storage(self, bucket_name, storage_type, tmpdir):
+        config = yaml_load(os.path.join(tmpdir, 'test_dir', '.ml-git', 'config.yaml'))
+        print(config, os.path.join(tmpdir, '.ml-git', 'config.yaml'))
+        self.assertIn(storage_type, config[STORAGE_CONFIG_KEY])
+        self.assertIn(bucket_name, config[STORAGE_CONFIG_KEY][storage_type])
+
     @pytest.mark.usefixtures('switch_to_test_dir')
     def test_paths(self):
         config = config_load()
@@ -219,16 +225,19 @@ class ConfigTestCases(unittest.TestCase):
             storage_type, bucket = start_wizard_questions(DATASETS)
             self.assertEqual(storage_type, S3H)
             self.assertEqual(bucket, bucket_name)
+            self.check_storage(bucket, storage_type, self.tmp_dir)
 
         with mock.patch('builtins.input', new=lambda *args, **kwargs: new_gdrive_storage_options.pop()):
             storage_type, bucket = start_wizard_questions(DATASETS)
             self.assertEqual(storage_type, GDRIVEH)
             self.assertEqual(bucket, bucket_name)
+            self.check_storage(bucket, storage_type, self.tmp_dir)
 
         with mock.patch('builtins.input', new=lambda *args, **kwargs: new_sftph_storage_options.pop()):
             storage_type, bucket = start_wizard_questions(DATASETS)
             self.assertEqual(storage_type, SFTPH)
             self.assertEqual(bucket, 'mlgit')
+            self.check_storage(bucket, storage_type, self.tmp_dir)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_merged_config_load(self):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -106,7 +106,6 @@ class ConfigTestCases(unittest.TestCase):
 
     def check_storage(self, bucket_name, storage_type, tmpdir):
         config = yaml_load(os.path.join(tmpdir, 'test_dir', '.ml-git', 'config.yaml'))
-        print(config, os.path.join(tmpdir, '.ml-git', 'config.yaml'))
         self.assertIn(storage_type, config[STORAGE_CONFIG_KEY])
         self.assertIn(bucket_name, config[STORAGE_CONFIG_KEY][storage_type])
 


### PR DESCRIPTION
Depends on: https://github.com/HPInc/ml-git/pull/173

If the user executes the create command with the option --wizard-config, selects the option 'X' to create a new data storage and selects the storage type s3h, the information is saved in the global configuration file '.mlgitconfig ' instead of local configuration file.

This PR fixes this problem. Now the storage is saved in its correct place (local configuration file).