### PR TITLE
Creating MLGitAPI to allow multiple projects in the same script

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,27 +1,30 @@
 # ML-Git API #
 
+The ML-Git API offers the developer the possibility to work with ML-Git programmatically by using the MLGitAPI class.
 
-# <a name="methods"> Methods available in the API </a> #
+# <a name="methods"> Methods available in the MLGitAPI class </a> #
 
 <details markdown="1">
 <summary><code> add </code></summary>
 <br>
 
 ```python
-def add(entity_type, entity_name, bumpversion=False, fsck=False, file_path=[], metric=[], metrics_file=''):
+def add(self, entity_type, entity_name, bumpversion=False, fsck=False, file_path=None, metric=None, metrics_file=''):
     """This command will add all the files under the directory into the ml-git index/staging area.
 
     Example:
-        add('datasets', 'dataset-ex', bumpversion=True)
+        api = MLGitApi()
+        api.add('datasets', 'dataset-ex', bumpversion=True)
 
     Args:
-        type (str): The type of an ML entity. (datasets, labels or models)
+        entity_type (str): The type of an ML entity (datasets, labels or models).
         entity_name (str): The name of the ML entity you want to add the files.
         bumpversion (bool, optional): Increment the entity version number when adding more files [default: False].
         fsck (bool, optional): Run fsck after command execution [default: False].
         file_path (list, optional): List of files that must be added by the command [default: all files].
         metric (dictionary, optional): The metric dictionary, example: { 'metric': value } [default: empty].
-        metrics_file (str, optional): The metrics file path. It is expected a CSV file containing the metric names in the header and the values in the next line [default: empty].
+        metrics_file (str, optional): The metrics file path. It is expected a CSV file containing the metric names in the header and
+         the values in the next line [default: empty].
     """
 ```
 </details>
@@ -31,14 +34,16 @@ def add(entity_type, entity_name, bumpversion=False, fsck=False, file_path=[], m
 <br>
 
 ```python
-def checkout(entity, tag, sampling=None, retries=2, force=False, dataset=False, labels=False, fail_limit=None):
+def checkout(self, entity, tag, sampling=None, retries=2, force=False, dataset=False, labels=False, version=-1,
+             fail_limit=None):
     """This command allows retrieving the data of a specific version of an ML entity.
 
     Example:
-        checkout('datasets', 'computer-vision__images3__imagenet__1')
+        api = MLGitApi()
+        api.checkout('datasets', 'computer-vision__images3__imagenet__1')
 
     Args:
-        entity (str): The type of an ML entity. (datasets, labels or models)
+        entity (str): The type of an ML entity (datasets, labels or models).
         tag (str): An ml-git tag to identify a specific version of an ML entity.
         sampling (dict): group: <amount>:<group> The group sample option consists of amount and group used to
                                  download a sample.\n
@@ -52,11 +57,11 @@ def checkout(entity, tag, sampling=None, retries=2, force=False, dataset=False, 
         force (bool, optional): Force checkout command to delete untracked/uncommitted files from the local repository [default: False].
         dataset (bool, optional): If exist a dataset related with the model or labels, this one must be downloaded [default: False].
         labels (bool, optional): If exist labels related with the model, they must be downloaded [default: False].
+        version (int, optional): The entity version [default: -1].
         fail_limit (int, optional): Number of failures before aborting the command [default: no limit].
 
     Returns:
         str: Return the path where the data was checked out.
-
     """
 ```
 </details>
@@ -67,16 +72,16 @@ def checkout(entity, tag, sampling=None, retries=2, force=False, dataset=False, 
 <br>
 
 ```python
-def clone(repository_url, folder=None, untracked=False):
+def clone(self, repository_url, untracked=False):
     """This command will clone minimal configuration files from repository-url with valid .ml-git/config.yaml,
     then initialize the metadata according to configurations.
 
     Example:
-        clone('https://git@github.com/mlgit-repository')
+        api = MLGitApi()
+        api.clone('https://git@github.com/mlgit-repository')
 
     Args:
         repository_url (str): The git repository that will be cloned.
-        folder (str, optional): Directory that can be created to execute the clone command [default: current path].
         untracked (bool, optional): Set whether cloned repository trace should not be kept [default: False].
     """
 ```
@@ -88,14 +93,15 @@ def clone(repository_url, folder=None, untracked=False):
 <br>
 
 ```python
-def commit(entity, ml_entity_name, commit_message=None, related_dataset=None, related_labels=None):
-    """This command commits the index / staging area to the local repository.
+def commit(self, entity, ml_entity_name, commit_message=None, related_dataset=None, related_labels=None):
+    """That command commits the index / staging area to the local repository.
 
     Example:
-        commit('datasets', 'dataset-ex')
-        
+        api = MLGitApi()
+        api.commit('datasets', 'dataset-ex')
+
     Args:
-        entity (str): The type of an ML entity. (datasets, labels or models)
+        entity (str): The type of an ML entity (datasets, labels or models).
         ml_entity_name (str): Artefact name to commit.
         commit_message (str, optional): Message of commit.
         related_dataset (str, optional): Artefact name of dataset related to commit.
@@ -109,25 +115,26 @@ def commit(entity, ml_entity_name, commit_message=None, related_dataset=None, re
 <br>
 
 ```python
-def create(entity, entity_name, categories, mutability, **kwargs):
+def create(self, entity, entity_name, categories, mutability, **kwargs):
     """This command will create the workspace structure with data and spec file for an entity and set the storage configurations.
 
-        Example:
-            create('datasets', 'dataset-ex', categories=['computer-vision', 'images'], mutability='strict')
+    Example:
+        api = MLGitApi()\n
+        api.create('datasets', 'dataset-ex', categories=['computer-vision', 'images'], mutability='strict')
 
-        Args:
-            entity (str): The type of an ML entity. (datasets, labels or models).
-            entity_name (str): An ml-git entity name to identify a ML entity.
-            categories (list): Artifact's category name.
-            mutability (str): Mutability type. The mutability options are strict, flexible and mutable.
-            storage_type (str, optional): Data storage type [default: s3h].
-            version (int, optional): Number of artifact version [default: 1].
-            import_path (str, optional): Path to be imported to the project.
-            bucket_name (str, optional): Bucket name.
-            import_url (str, optional): Import data from a google drive url.
-            credentials_path (str, optional): Directory of credentials.json.
-            unzip (bool, optional): Unzip imported zipped files [default: False].
-            entity_dir (str, optional): The relative path where the entity will be created inside the ml entity directory [default: empty].
+    Args:
+        entity (str): The type of an ML entity (datasets, labels or models).
+        entity_name (str): An ml-git entity name to identify a ML entity.
+        categories (list): Artifact's categories name.
+        mutability (str): Mutability type. The mutability options are strict, flexible and mutable.
+        storage_type (str, optional): Data storage type [default: s3h].
+        version (int, optional): Number of artifact version [default: 1].
+        import_path (str, optional): Path to be imported to the project.
+        bucket_name (str, optional): Bucket name.
+        import_url (str, optional): Import data from a google drive url.
+        credentials_path (str, optional): Directory of credentials.json.
+        unzip (bool, optional): Unzip imported zipped files [default: False].
+        entity_dir (str, optional): The relative path where the entity will be created inside the ml entity directory [default: empty].
     """
 ```
 </details>
@@ -139,15 +146,16 @@ def create(entity, entity_name, categories, mutability, **kwargs):
 <br>
 
 ```python
-def init(entity):
+def init(self, entity):
     """This command will start the ml-git entity.
 
-        Examples:
-            init('repository')
-            init('datasets')
+    Examples:
+        api = MLGitApi()\n
+        api.init('repository')\n
+        api.init('datasets')
 
-        Args:
-            entity (str): The type of entity that will be initialized. (repository, datasets, labels or models).
+    Args:
+        entity (str): The type of an ML entity (datasets, labels or models).
     """
 ```
 </details>
@@ -157,16 +165,17 @@ def init(entity):
 <br>
 
 ```python
-def get_models_metrics(entity_name, export_path=None, export_type=FileType.JSON.value):
+def get_models_metrics(self, entity_name, export_path=None, export_type=FileType.JSON.value):
     """Get metrics information for each tag of the entity.
 
-        Examples:
-            get_models_metrics('model-ex', export_type='csv')
+    Examples:
+        api = MLGitApi()\n
+        api.get_models_metrics('model-ex', export_type='csv')
 
-        Args:
-            entity_name (str): An ml-git entity name to identify a ML entity.
-            export_path(str, optional): Set the path to export metrics to a file.
-            export_type (str, optional): Choose the format of the file that will be generated with the metrics [default: json].
+    Args:
+        entity_name (str): An ml-git entity name to identify a ML entity.
+        export_path(str, optional): Set the path to export metrics to a file.
+        export_type (str, optional): Choose the format of the file that will be generated with the metrics [default: json].
     """
 ```
 </details>
@@ -176,18 +185,19 @@ def get_models_metrics(entity_name, export_path=None, export_type=FileType.JSON.
 <br>
 
 ```python
-def push(entity, entity_name,  retries=2, clear_on_fail=False, fail_limit=None):
+def push(self, entity, entity_name,  retries=2, clear_on_fail=False, fail_limit=None):
     """This command allows pushing the data of a specific version of an ML entity.
 
-        Example:
-            push('datasets', 'dataset-ex')
+    Example:
+        api = MLGitApi()\n
+        api.push('datasets', 'dataset-ex')
 
-        Args:
-            entity (str): The type of an ML entity. (datasets, labels or models)
-            entity_name (str): An ml-git entity name to identify a ML entity.
-            retries (int, optional): Number of retries to upload the files to the storage [default: 2].
-            clear_on_fail (bool, optional): Remove the files from the storage in case of failure during the push operation [default: False].
-            fail_limit (int, optional): Number of failures before aborting the command [default: no limit].
+    Args:
+        entity (str): The type of an ML entity. (datasets, labels or models)
+        entity_name (str): An ml-git entity name to identify a ML entity.
+        retries (int, optional): Number of retries to upload the files to the storage [default: 2].
+        clear_on_fail (bool, optional): Remove the files from the storage in case of failure during the push operation [default: False].
+        fail_limit (int, optional): Number of failures before aborting the command [default: no limit].
     """
 ```
 </details>
@@ -197,16 +207,17 @@ def push(entity, entity_name,  retries=2, clear_on_fail=False, fail_limit=None):
 <br>
 
 ```python
-def remote_add(entity, remote_url, global_configuration=False):
+def remote_add(self, entity, remote_url, global_configuration=False):
     """This command will add a remote to store the metadata from this ml-git project.
 
-        Examples:
-            remote_add('datasets', 'https://git@github.com/mlgit-datasets')
+    Examples:
+        api = MLGitApi()\n
+        api.remote_add('datasets', 'https://git@github.com/mlgit-datasets')
 
-        Args:
-            entity (str): The type of an ML entity. (repository, datasets, labels or models).
-            remote_url(str): URL of an existing remote git repository.
-            global_configuration (bool, optional): Use this option to set configuration at global level [default: False].
+    Args:
+        entity (str): The type of an ML entity (datasets, labels or models).
+        remote_url(str): URL of an existing remote git repository.
+        global_configuration (bool, optional): Use this option to set configuration at global level [default: False].
     """
 ```
 </details>
@@ -216,21 +227,24 @@ def remote_add(entity, remote_url, global_configuration=False):
 <br>
 
 ```python
-def storage_add(bucket_name, bucket_type=StorageType.S3H.value, credentials=None, global_configuration=False, endpoint_url=None, username=None, private_key=None, port=22, region=None):
+def storage_add(self, bucket_name, bucket_type=StorageType.S3H.value, credentials=None, global_configuration=False,
+                endpoint_url=None, username=None, private_key=None, port=22, region=None):
     """This command will add a storage to the ml-git project.
 
-        Examples:
-            storage_add('my-bucket', type='s3h')
+    Examples:
+        api = MLGitApi()\n
+        api.storage_add('my-bucket', bucket_type='s3h')
 
-        Args:
-            bucket_name (str): The name of the bucket in the storage.
-            bucket_type (str, optional): Storage type (s3h, azureblobh or gdriveh) [default: s3h].
-            credentials (str, optional): Name of the profile that stores the credentials or the path to the credentials.
-            global_configuration (bool, optional): Use this option to set configuration at global level [default: False].
-            endpoint_url (str, optional): Storage endpoint url.
-            username (str, optional): The username for the sftp login.
-            private_key (str, optional): Full path for the private key file.
-            region (str, optional): AWS region for S3 bucket.
+    Args:
+        bucket_name (str): The name of the bucket in the storage.
+        bucket_type (str, optional): Storage type (s3h, azureblobh or gdriveh) [default: s3h].
+        credentials (str, optional): Name of the profile that stores the credentials or the path to the credentials.
+        global_configuration (bool, optional): Use this option to set configuration at global level [default: False].
+        endpoint_url (str, optional): Storage endpoint url.
+        username (str, optional): The username for the sftp login.
+        private_key (str, optional): Full path for the private key file.
+        port (int, optional): The port to be used when connecting to the storage.
+        region (str, optional): AWS region for S3 bucket.
     """
 ```
 </details>
@@ -274,9 +288,9 @@ def init_local_entity_manager():
 ```
 </details>
 
-## Classes used in the API.
+## Classes used by the API.
 
-Some methods uses the classes described below:
+Some methods available in the API use the classes described below:
 <details markdown="1">
 <summary><code> EntityManager </code></summary>
 <br>
@@ -522,5 +536,6 @@ class LinkedEntity:
 
 # <a name="methods"> API notebooks </a> #
 
-In the api_scripts directory you can find notebooks running the ML-Git api for some scenarios. 
-To run them, you just need to boot the jupyter notebook in an environment with ML-Git installed and navigate to the notebook.
+In the api_scripts directory, you can find notebooks running the ML-Git API for some scenarios. 
+To run them, you need to boot the jupyter notebook server in an environment with ML-Git installed and navigate to the
+notebook of your choice.

--- a/docs/api/api_scripts/basic_flow.ipynb
+++ b/docs/api/api_scripts/basic_flow.ipynb
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -250,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -284,7 +284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -314,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -361,7 +361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -402,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -447,7 +447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {

--- a/docs/api/api_scripts/basic_flow.ipynb
+++ b/docs/api/api_scripts/basic_flow.ipynb
@@ -56,6 +56,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Then we must create a new instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api = MLGitAPI()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "To use ml-git, it is necessary to configure storages and remotes that will be used in a project. This configuration can be done through a sequence of commands, or if you already have a git repository with the stored settings, you can run the clone command to import those settings. The following subsections demonstrate how to configure these two forms. "
    ]
   },
@@ -87,7 +103,6 @@
    "outputs": [],
    "source": [
     "repository_url = '/local_ml_git_config_server.git'\n",
-    "api = MLGitAPI()\n",
     "\n",
     "api.clone(repository_url)"
    ]

--- a/docs/api/api_scripts/basic_flow.ipynb
+++ b/docs/api/api_scripts/basic_flow.ipynb
@@ -56,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we must create a new instance"
+    "Then we must create a new instance of the API class"
    ]
   },
   {

--- a/docs/api/api_scripts/basic_flow.ipynb
+++ b/docs/api/api_scripts/basic_flow.ipynb
@@ -49,7 +49,7 @@
     }
    ],
    "source": [
-    "from ml_git import api"
+    "from ml_git.api import MLGitAPI"
    ]
   },
   {
@@ -87,6 +87,7 @@
    "outputs": [],
    "source": [
     "repository_url = '/local_ml_git_config_server.git'\n",
+    "api = MLGitAPI()\n",
     "\n",
     "api.clone(repository_url)"
    ]

--- a/docs/api/api_scripts/basic_flow.ipynb
+++ b/docs/api/api_scripts/basic_flow.ipynb
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6
    "metadata": {},
    "outputs": [
     {
@@ -250,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -284,7 +284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -314,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -361,7 +361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -402,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -447,7 +447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {

--- a/docs/api/api_scripts/clone_repository.ipynb
+++ b/docs/api/api_scripts/clone_repository.ipynb
@@ -28,7 +28,7 @@
     }
    ],
    "source": [
-    "from ml_git import api"
+    "from ml_git.api import MLGitAPI"
    ]
   },
   {
@@ -63,6 +63,7 @@
    ],
    "source": [
     "repository_url = '/local_ml_git_config_server.git'\n",
+    "api = MLGitAPI()\n",
     "\n",
     "api.clone(repository_url)"
    ]

--- a/docs/api/api_scripts/mnist_notebook/mnist_random_forest_api.ipynb
+++ b/docs/api/api_scripts/mnist_notebook/mnist_random_forest_api.ipynb
@@ -78,7 +78,8 @@
     }
    ],
    "source": [
-    "from ml_git import api\n",
+    "from ml_git.api import MLGitAPI\n",
+    "api = MLGitAPI()\n",
     "\n",
     "# def checkout(entity, tag, sampling=None, retries=2, force=False, dataset=False, labels=False, version=-1)\n",
     "api.checkout('labels', 'labelsmnist', dataset=True)\n",

--- a/docs/api/api_scripts/multiple_datasets_notebook/checkout_with_sample.ipynb
+++ b/docs/api/api_scripts/multiple_datasets_notebook/checkout_with_sample.ipynb
@@ -55,7 +55,7 @@
     }
    ],
    "source": [
-    "from ml_git import api"
+    "from ml_git.api import MLGitAPI"
    ]
   },
   {
@@ -484,6 +484,7 @@
    "source": [
     "sampling = {'group': '1:5', 'seed': '10'}\n",
     "\n",
+    "api = MLGitAPI()\n",
     "data_path = api.checkout(entity, tag, sampling)\n",
     "\n",
     "print_files()\n",

--- a/docs/api/api_scripts/multiple_datasets_notebook/multiple_datasets.ipynb
+++ b/docs/api/api_scripts/multiple_datasets_notebook/multiple_datasets.ipynb
@@ -39,7 +39,7 @@
     }
    ],
    "source": [
-    "from ml_git import api"
+    "from ml_git.api import MLGitAPI"
    ]
   },
   {
@@ -107,6 +107,7 @@
    ],
    "source": [
     "repository_url = '/local_ml_git_config_server.git'\n",
+    "api = MLGitAPI()\n",
     "\n",
     "api.clone(repository_url)"
    ]

--- a/docs/api/api_scripts/relationship_notebook/relationship_api_commands.ipynb
+++ b/docs/api/api_scripts/relationship_notebook/relationship_api_commands.ipynb
@@ -53,7 +53,7 @@
     }
    ],
    "source": [
-    "from ml_git import api\n",
+    "from ml_git.api import MLGitAPI",
     "\n",
     "github_token = [removed]\n",
     "api_url = 'https://api.github.com'"
@@ -82,6 +82,7 @@
     }
    ],
    "source": [
+    "api = MLGitAPI()\n",
     "manager = api.init_entity_manager(github_token, api_url)"
    ]
   },

--- a/docs/api/quick_start.md
+++ b/docs/api/quick_start.md
@@ -2,14 +2,59 @@
 
 # <a name="api"> Quick start </a> #
 
-To use the ML-Git API, it is necessary to have ML-Git in the environment that will be executed and be inside a directory with an initialized ML-Git project (you can also perform this initialization using the api clone command if you already have a repository configured).
+To use the ML-Git API, it's necessary to have ML-Git installed in the environment that will be executed. When
+instantiating the MLGitAPI class, it's required to either inform an existing directory in the root_path parameter or not
+pass any value at all. 
 
+## Instantiating the API
 
-## Clone 
+You can inform the root directory of your ML-Git Project by passing an absolute path or a relative path to the root_path
+parameter.
 
 ```python
-from ml_git import api
+from ml_git.api import MLGitAPI
 
+api = MLGitAPI(root_path='/absolute/path/to/your/project')
+# or
+api = MLGitAPI(root_path='./relative/path/to/your/project')
+```
+`Note:` The root_path parameter can receive any string accepted by the
+[pathlib.Path](https://docs.python.org/3/library/pathlib.html) class.
+
+You can also work with your current working directory (CWD) by not passing any value.
+
+```python
+from ml_git.api import MLGitAPI
+
+api = MLGitAPI()
+```
+
+### Multiple ML-Git Projects
+
+It's also possible to work with multiple projects in the same python script by instantiating the MLGitAPI class for each
+project.
+
+```python
+from ml_git.api import MLGitAPI
+
+api_project_1 = MLGitAPI(root_path='/path/to/project_1')
+api_project_2 = MLGitAPI(root_path='/path/to/project_2')
+```
+
+Each instance will run its commands in the context of its project. It's important to note that these instances are not
+aware of each other nor follow the singleton pattern, so it's possible to have multiple instances pointing to the same
+directory, so if you end up in this situation, be careful not to run commands that can be conflicting,
+like trying to create the same entity in more than one instance.
+
+## ML-Git Repository
+
+To use most of the commands available in the API, you need to be working with a directory containing a valid ML-Git
+Project. For that, you can clone a repository by using the clone command, or you can start a new repository with the
+init command.
+
+### Clone 
+
+```python
 repository_url = 'https://git@github.com/mlgit-repository'
 
 api.clone(repository_url)
@@ -21,15 +66,23 @@ output:
     INFO - Metadata: Successfully loaded configuration files!
 
 
-## Checkout
+### Init
 
-We assume there is an initialized ML-Git project in the directory.
+```python
+api.init('repository')
+```
+
+output:
+
+    INFO - Admin: Initialized empty ml-git repository in /home/user/Documentos/project/.ml-git
+    
+`Note:` To use these commands, the instance must be pointing to an empty (or not previously initialized) directory.
+
+## Checkout
 
 #### Checkout dataset
 
 ```python
-from ml_git import api
-
 entity = 'datasets'
 tag = 'computer-vision__images__imagenet__1'
 
@@ -47,8 +100,6 @@ output:
 #### Checkout labels with dataset
 
 ```python
-from ml_git import api
-
 entity = 'labels'
 tag = 'computer-vision__images__mscoco__2'
 
@@ -73,8 +124,6 @@ output:
 #### Group-Sample
 
 ```python
-from ml_git import api
-
 entity = 'datasets'
 tag = 'computer-vision__images__imagenet__1'
 
@@ -94,8 +143,6 @@ output:
 #### Range-Sample
 
 ```python
-from ml_git import api
-
 entity = 'datasets'
 tag = 'computer-vision__images__imagenet__1'
 
@@ -116,8 +163,6 @@ output:
 #### Random-Sample
 
 ```python
-from ml_git import api
-
 entity = 'datasets'
 tag = 'computer-vision__images__imagenet__1'
 
@@ -138,8 +183,6 @@ output:
 ## Add 
 
 ```python
-from ml_git import api
-
 api.add('datasets', 'dataset-ex')
 ```
 
@@ -153,8 +196,6 @@ output:
 ## Commit
 
 ```python
-from ml_git import api
-
 entity = 'datasets'
 entity_name = 'dataset-ex'
 message = 'Commit example'
@@ -170,8 +211,6 @@ output:
 ## Push
 
 ```python
-from ml_git import api
-
 entity = 'datasets'
 spec = 'dataset-ex'
 
@@ -186,8 +225,6 @@ output:
 ## Create
 
 ```python
-from ml_git import api
-
 entity = 'datasets'
 spec = 'dataset-ex'
 categories = ['computer-vision', 'images']
@@ -202,12 +239,11 @@ output:
     
 ## Init
 
+The init command is used to start either an entity or, as shown before, a repository.
 
 #### Repository
 
 ```python
-from ml_git import api
-
 api.init('repository')
 ```
 
@@ -219,8 +255,6 @@ output:
 #### Entity
 
 ```python
-from ml_git import api
-
 entity_type = 'datasets'
 
 api.init(entity_type)
@@ -233,8 +267,6 @@ output:
 ## Remote add
 
 ```python
-from ml_git import api
-
 entity_type = 'datasets'
 datasets_repository = 'https://git@github.com/mlgit-datasets'
 
@@ -249,8 +281,6 @@ output:
 ## Storage add
 
 ```python
-from ml_git import api
-
 bucket_name = 'minio'
 bucket_type='s3h'
 endpoint_url = 'http://127.0.0.1:9000/'
@@ -266,7 +296,6 @@ output:
 
 #### List entities from a config file
 ```python
-from ml_git import api
 github_token = ''
 api_url = 'https://api.github.com'
 manager = api.init_entity_manager(github_token, api_url)
@@ -277,7 +306,6 @@ entities = manager.get_entities(config_path='path/to/config.yaml')
 
 #### List entities from a repository
 ```python
-from ml_git import api
 github_token = ''
 api_url = 'https://api.github.com'
 manager = api.init_entity_manager(github_token, api_url)
@@ -288,7 +316,6 @@ entities = manager.get_entities(config_repo_name='user/config_repository')
 
 #### List versions from a entity
 ```python
-from ml_git import api
 github_token = ''
 api_url = 'https://api.github.com'
 manager = api.init_entity_manager(github_token, api_url)
@@ -299,7 +326,6 @@ versions = manager.get_entity_versions('entity_name', metadata_repo_name='user/m
 
 #### List linked entities from a entity version
 ```python
-from ml_git import api
 github_token = ''
 api_url = 'https://api.github.com'
 manager = api.init_entity_manager(github_token, api_url)
@@ -310,7 +336,6 @@ linked_entities = manager.get_linked_entities('entity_name', 'entity_version', m
 
 #### List relationships from a entity
 ```python
-from ml_git import api
 github_token = ''
 api_url = 'https://api.github.com'
 manager = api.init_entity_manager(github_token, api_url)
@@ -321,7 +346,6 @@ relationships = manager.get_entity_relationships('entity_name', metadata_repo_na
 
 #### List relationships from all project entities
 ```python
-from ml_git import api
 github_token = ''
 api_url = 'https://api.github.com'
 manager = api.init_entity_manager(github_token, api_url)

--- a/ml_git/api.py
+++ b/ml_git/api.py
@@ -47,7 +47,9 @@ def validate_sample(sampling):
 
 
 def checkout(entity, tag, sampling=None, retries=2, force=False, dataset=False, labels=False, version=-1, fail_limit=None):
-    """This command allows retrieving the data of a specific version of an ML entity.
+    """**DEPRECATED**: This method will be removed in future versions, MLGitAPI.checkout should be used instead.
+
+    This command allows retrieving the data of a specific version of an ML entity.
 
     Example:
         checkout('datasets', 'computer-vision__images3__imagenet__1')
@@ -71,7 +73,6 @@ def checkout(entity, tag, sampling=None, retries=2, force=False, dataset=False, 
 
     Returns:
         str: Return the path where the data was checked out.
-
     """
 
     repo = get_repository_instance(entity)
@@ -99,7 +100,9 @@ def checkout(entity, tag, sampling=None, retries=2, force=False, dataset=False, 
 
 
 def clone(repository_url, folder=None, untracked=False):
-    """This command will clone minimal configuration files from repository-url with valid .ml-git/config.yaml,
+    """**DEPRECATED**: This method will be removed in future versions, MLGitAPI.clone should be used instead.
+
+    This command will clone minimal configuration files from repository-url with valid .ml-git/config.yaml,
     then initialize the metadata according to configurations.
 
     Example:
@@ -125,7 +128,9 @@ def clone(repository_url, folder=None, untracked=False):
 
 
 def add(entity_type, entity_name, bumpversion=False, fsck=False, file_path=[], metric=[], metrics_file=''):
-    """This command will add all the files under the directory into the ml-git index/staging area.
+    """**DEPRECATED**: This method will be removed in future versions, MLGitAPI.add should be used instead.
+
+    This command will add all the files under the directory into the ml-git index/staging area.
 
     Example:
         add('datasets', 'dataset-ex', bumpversion=True)
@@ -152,7 +157,9 @@ def add(entity_type, entity_name, bumpversion=False, fsck=False, file_path=[], m
 
 
 def commit(entity, ml_entity_name, commit_message=None, related_dataset=None, related_labels=None):
-    """That command commits the index / staging area to the local repository.
+    """**DEPRECATED**: This method will be removed in future versions, MLGitAPI.commit should be used instead.
+
+    That command commits the index / staging area to the local repository.
 
     Example:
         commit('datasets', 'dataset-ex')
@@ -179,7 +186,9 @@ def commit(entity, ml_entity_name, commit_message=None, related_dataset=None, re
 
 
 def push(entity, entity_name,  retries=2, clear_on_fail=False, fail_limit=None):
-    """This command allows pushing the data of a specific version of an ML entity.
+    """**DEPRECATED**: This method will be removed in future versions, MLGitAPI.push should be used instead.
+
+    This command allows pushing the data of a specific version of an ML entity.
 
         Example:
             push('datasets', 'dataset-ex')
@@ -197,7 +206,9 @@ def push(entity, entity_name,  retries=2, clear_on_fail=False, fail_limit=None):
 
 
 def create(entity, entity_name, categories, mutability, **kwargs):
-    """This command will create the workspace structure with data and spec file for an entity and set the storage configurations.
+    """**DEPRECATED**: This method will be removed in future versions, MLGitAPI.create should be used instead.
+
+    This command will create the workspace structure with data and spec file for an entity and set the storage configurations.
 
         Example:
             create('datasets', 'dataset-ex', categories=['computer-vision', 'images'], mutability='strict')
@@ -229,7 +240,9 @@ def create(entity, entity_name, categories, mutability, **kwargs):
 
 
 def init(entity):
-    """This command will start the ml-git entity.
+    """**DEPRECATED**: This method will be removed in future versions, MLGitAPI.init should be used instead.
+
+    This command will start the ml-git entity.
 
         Examples:
             init('repository')
@@ -250,7 +263,9 @@ def init(entity):
 
 def storage_add(bucket_name, bucket_type=StorageType.S3H.value, credentials=None, global_configuration=False,
                 endpoint_url=None, username=None, private_key=None, port=22, region=None):
-    """This command will add a storage to the ml-git project.
+    """**DEPRECATED**: This method will be removed in future versions, MLGitAPI.storage_add should be used instead.
+
+    This command will add a storage to the ml-git project.
 
         Examples:
             storage_add('my-bucket', type='s3h')
@@ -278,7 +293,9 @@ def storage_add(bucket_name, bucket_type=StorageType.S3H.value, credentials=None
 
 
 def remote_add(entity, remote_url, global_configuration=False):
-    """This command will add a remote to store the metadata from this ml-git project.
+    """**DEPRECATED**: This method will be removed in future versions, MLGitAPI.remote_add should be used instead.
+
+    This command will add a remote to store the metadata from this ml-git project.
 
         Examples:
             remote_add('datasets', 'https://git@github.com/mlgit-datasets')
@@ -294,7 +311,9 @@ def remote_add(entity, remote_url, global_configuration=False):
 
 
 def get_models_metrics(entity_name, export_path=None, export_type=FileType.JSON.value):
-    """Get metrics information for each tag of the entity.
+    """**DEPRECATED**: This method will be removed in future versions, MLGitAPI.get_models_metrics should be used instead.
+
+    Get metrics information for each tag of the entity.
 
         Examples:
             get_models_metrics('model-ex', export_type='csv')
@@ -369,21 +388,88 @@ class ContextWrappedMeta(type):
 
 
 class MLGitAPI(metaclass=ContextWrappedMeta):
-    def __init__(self, root_path):
+    def __init__(self, root_path=''):
+        """ML-Git API instance with the context of a ML-Git Project.
+
+            Examples:
+                api = MLGitAPI('/absolute/path/to/your/project')\n
+                api = MLGitAPI('./relative/path/to/your/project')\n
+                api = MLGitAPI()
+
+            Args:
+                root_path (str, optional): The path for the project root directory. It can be the relative path or the
+                 absolute path, if untouched the CWD will be used [default: ''].
+        """
+
         root_path = Path(root_path)
         if not root_path.is_dir():
             raise NotADirectoryError(output_messages['ERROR_INVALID_STATUS_DIRECTORY'])
         self.root_path = root_path
 
     def clone(self, repository_url, untracked=False):
+        """This command will clone minimal configuration files from repository-url with valid .ml-git/config.yaml,
+        then initialize the metadata according to configurations.
+
+        Example:
+            clone('https://git@github.com/mlgit-repository')
+
+        Args:
+            repository_url (str): The git repository that will be cloned.
+            untracked (bool, optional): Set whether cloned repository trace should not be kept [default: False].
+        """
+
         clone(repository_url=repository_url, untracked=untracked)
 
     def checkout(self, entity, tag, sampling=None, retries=2, force=False, dataset=False, labels=False, version=-1,
                  fail_limit=None):
+        """This command allows retrieving the data of a specific version of an ML entity.
+
+        Example:
+            checkout('datasets', 'computer-vision__images3__imagenet__1')
+
+        Args:
+            entity (str): The type of an ML entity (datasets, labels or models).
+            tag (str): An ml-git tag to identify a specific version of an ML entity.
+            sampling (dict): group: <amount>:<group> The group sample option consists of amount and group used to
+                                     download a sample.\n
+                             range: <start:stop:step> The range sample option consists of start, stop and step used
+                                    to download a sample. The start parameter can be equal or greater than zero. The
+                                    stop parameter can be 'all', -1 or any integer above zero.\n
+                             random: <amount:frequency> The random sample option consists of amount and frequency
+                                    used to download a sample.
+                             seed: The seed is used to initialize the pseudorandom numbers.
+            retries (int, optional): Number of retries to download the files from the storage [default: 2].
+            force (bool, optional): Force checkout command to delete untracked/uncommitted files from the local repository [default: False].
+            dataset (bool, optional): If exist a dataset related with the model or labels, this one must be downloaded [default: False].
+            labels (bool, optional): If exist labels related with the model, they must be downloaded [default: False].
+            version (int, optional): The entity version [default: -1].
+            fail_limit (int, optional): Number of failures before aborting the command [default: no limit].
+
+        Returns:
+            str: Return the path where the data was checked out.
+        """
+
         checkout(entity=entity, tag=tag, sampling=sampling, retries=retries, force=force, dataset=dataset,
                  labels=labels, version=version, fail_limit=fail_limit)
 
-    def add(self, entity_type, entity_name, bumpversion=False, fsck=False, file_path=[], metric=[], metrics_file=''):
+    def add(self, entity_type, entity_name, bumpversion=False, fsck=False, file_path=None, metric=None,
+            metrics_file=''):
+        """This command will add all the files under the directory into the ml-git index/staging area.
+
+        Example:
+            add('datasets', 'dataset-ex', bumpversion=True)
+
+        Args:
+            entity_type (str): The type of an ML entity (datasets, labels or models).
+            entity_name (str): The name of the ML entity you want to add the files.
+            bumpversion (bool, optional): Increment the entity version number when adding more files [default: False].
+            fsck (bool, optional): Run fsck after command execution [default: False].
+            file_path (list, optional): List of files that must be added by the command [default: all files].
+            metric (dictionary, optional): The metric dictionary, example: { 'metric': value } [default: empty].
+            metrics_file (str, optional): The metrics file path. It is expected a CSV file containing the metric names in the header and
+             the values in the next line [default: empty].
+        """
+
         if metric is None:
             metric = []
         if file_path is None:
@@ -392,27 +478,122 @@ class MLGitAPI(metaclass=ContextWrappedMeta):
             metric=metric, metrics_file=metrics_file)
 
     def commit(self, entity, ml_entity_name, commit_message=None, related_dataset=None, related_labels=None):
+        """That command commits the index / staging area to the local repository.
+
+        Example:
+            commit('datasets', 'dataset-ex')
+
+        Args:
+            entity (str): The type of an ML entity (datasets, labels or models).
+            ml_entity_name (str): Artefact name to commit.
+            commit_message (str, optional): Message of commit.
+            related_dataset (str, optional): Artefact name of dataset related to commit.
+            related_labels (str, optional): Artefact name of labels related to commit.
+        """
+
         commit(entity=entity, ml_entity_name=ml_entity_name, commit_message=commit_message,
                related_dataset=related_dataset, related_labels=related_labels)
 
     def push(self, entity, entity_name,  retries=2, clear_on_fail=False, fail_limit=None):
+        """This command allows pushing the data of a specific version of an ML entity.
+
+            Example:
+                push('datasets', 'dataset-ex')
+
+            Args:
+                entity (str): The type of an ML entity. (datasets, labels or models)
+                entity_name (str): An ml-git entity name to identify a ML entity.
+                retries (int, optional): Number of retries to upload the files to the storage [default: 2].
+                clear_on_fail (bool, optional): Remove the files from the storage in case of failure during the push operation [default: False].
+                fail_limit (int, optional): Number of failures before aborting the command [default: no limit].
+        """
+
         push(entity=entity, entity_name=entity_name, retries=retries, clear_on_fail=clear_on_fail,
              fail_limit=fail_limit)
 
     def create(self, entity, entity_name, categories, mutability, **kwargs):
+        """This command will create the workspace structure with data and spec file for an entity and set the storage configurations.
+
+            Example:
+                create('datasets', 'dataset-ex', categories=['computer-vision', 'images'], mutability='strict')
+
+            Args:
+                entity (str): The type of an ML entity (datasets, labels or models).
+                entity_name (str): An ml-git entity name to identify a ML entity.
+                categories (list): Artifact's categories name.
+                mutability (str): Mutability type. The mutability options are strict, flexible and mutable.
+                storage_type (str, optional): Data storage type [default: s3h].
+                version (int, optional): Number of artifact version [default: 1].
+                import_path (str, optional): Path to be imported to the project.
+                bucket_name (str, optional): Bucket name.
+                import_url (str, optional): Import data from a google drive url.
+                credentials_path (str, optional): Directory of credentials.json.
+                unzip (bool, optional): Unzip imported zipped files [default: False].
+                entity_dir (str, optional): The relative path where the entity will be created inside the ml entity directory [default: empty].
+        """
+
         create(entity=entity, entity_name=entity_name, categories=categories, mutability=mutability, **kwargs)
 
     def init(self, entity):
+        """This command will start the ml-git entity.
+
+            Examples:
+                init('repository')
+                init('datasets')
+
+            Args:
+                entity (str): The type of an ML entity (datasets, labels or models).
+        """
+
         init(entity=entity)
 
     def storage_add(self, bucket_name, bucket_type=StorageType.S3H.value, credentials=None, global_configuration=False,
                     endpoint_url=None, username=None, private_key=None, port=22, region=None):
+        """This command will add a storage to the ml-git project.
+
+            Examples:
+                storage_add('my-bucket', type='s3h')
+
+            Args:
+                bucket_name (str): The name of the bucket in the storage.
+                bucket_type (str, optional): Storage type (s3h, azureblobh or gdriveh) [default: s3h].
+                credentials (str, optional): Name of the profile that stores the credentials or the path to the credentials.
+                global_configuration (bool, optional): Use this option to set configuration at global level [default: False].
+                endpoint_url (str, optional): Storage endpoint url.
+                username (str, optional): The username for the sftp login.
+                private_key (str, optional): Full path for the private key file.
+                port (int, optional): The port to be used when connecting to the storage.
+                region (str, optional): AWS region for S3 bucket.
+        """
+
         storage_add(bucket_name=bucket_name, bucket_type=bucket_type, credentials=credentials,
                     global_configuration=global_configuration, endpoint_url=endpoint_url, username=username,
                     private_key=private_key, port=port, region=region)
 
     def remote_add(self, entity, remote_url, global_configuration=False):
+        """This command will add a remote to store the metadata from this ml-git project.
+
+            Examples:
+                remote_add('datasets', 'https://git@github.com/mlgit-datasets')
+
+            Args:
+                entity (str): The type of an ML entity (datasets, labels or models).
+                remote_url(str): URL of an existing remote git repository.
+                global_configuration (bool, optional): Use this option to set configuration at global level [default: False].
+        """
+
         remote_add(entity=entity, remote_url=remote_url, global_configuration=global_configuration)
 
     def get_models_metrics(self, entity_name, export_path=None, export_type=FileType.JSON.value):
+        """Get metrics information for each tag of the entity.
+
+            Examples:
+                get_models_metrics('model-ex', export_type='csv')
+
+            Args:
+                entity_name (str): An ml-git entity name to identify a ML entity.
+                export_path(str, optional): Set the path to export metrics to a file.
+                export_type (str, optional): Choose the format of the file that will be generated with the metrics [default: json].
+        """
+
         get_models_metrics(entity_name=entity_name, export_path=export_path, export_type=export_type)

--- a/ml_git/api.py
+++ b/ml_git/api.py
@@ -268,7 +268,7 @@ def storage_add(bucket_name, bucket_type=StorageType.S3H.value, credentials=None
     This command will add a storage to the ml-git project.
 
         Examples:
-            storage_add('my-bucket', type='s3h')
+            storage_add('my-bucket', bucket_type='s3h')
 
         Args:
             bucket_name (str): The name of the bucket in the storage.
@@ -391,14 +391,14 @@ class MLGitAPI(metaclass=ContextWrappedMeta):
     def __init__(self, root_path=''):
         """ML-Git API instance with the context of a ML-Git Project.
 
-            Examples:
-                api = MLGitAPI('/absolute/path/to/your/project')\n
-                api = MLGitAPI('./relative/path/to/your/project')\n
-                api = MLGitAPI()
+        Examples:
+            api = MLGitAPI('/absolute/path/to/your/project')\n
+            api = MLGitAPI('./relative/path/to/your/project')\n
+            api = MLGitAPI()
 
-            Args:
-                root_path (str, optional): The path for the project root directory. It can be the relative path or the
-                 absolute path, if untouched the CWD will be used [default: ''].
+        Args:
+            root_path (str, optional): The path for the project root directory. It can be the relative path or the
+             absolute path, if untouched the CWD will be used [default: ''].
         """
 
         root_path = Path(root_path)
@@ -411,7 +411,8 @@ class MLGitAPI(metaclass=ContextWrappedMeta):
         then initialize the metadata according to configurations.
 
         Example:
-            clone('https://git@github.com/mlgit-repository')
+            api = MLGitApi()\n
+            api.clone('https://git@github.com/mlgit-repository')
 
         Args:
             repository_url (str): The git repository that will be cloned.
@@ -425,7 +426,8 @@ class MLGitAPI(metaclass=ContextWrappedMeta):
         """This command allows retrieving the data of a specific version of an ML entity.
 
         Example:
-            checkout('datasets', 'computer-vision__images3__imagenet__1')
+            api = MLGitApi()\n
+            api.checkout('datasets', 'computer-vision__images3__imagenet__1')
 
         Args:
             entity (str): The type of an ML entity (datasets, labels or models).
@@ -457,7 +459,8 @@ class MLGitAPI(metaclass=ContextWrappedMeta):
         """This command will add all the files under the directory into the ml-git index/staging area.
 
         Example:
-            add('datasets', 'dataset-ex', bumpversion=True)
+            api = MLGitApi()\n
+            api.add('datasets', 'dataset-ex', bumpversion=True)
 
         Args:
             entity_type (str): The type of an ML entity (datasets, labels or models).
@@ -481,7 +484,8 @@ class MLGitAPI(metaclass=ContextWrappedMeta):
         """That command commits the index / staging area to the local repository.
 
         Example:
-            commit('datasets', 'dataset-ex')
+            api = MLGitApi()\n
+            api.commit('datasets', 'dataset-ex')
 
         Args:
             entity (str): The type of an ML entity (datasets, labels or models).
@@ -497,15 +501,16 @@ class MLGitAPI(metaclass=ContextWrappedMeta):
     def push(self, entity, entity_name,  retries=2, clear_on_fail=False, fail_limit=None):
         """This command allows pushing the data of a specific version of an ML entity.
 
-            Example:
-                push('datasets', 'dataset-ex')
+        Example:
+            api = MLGitApi()\n
+            api.push('datasets', 'dataset-ex')
 
-            Args:
-                entity (str): The type of an ML entity. (datasets, labels or models)
-                entity_name (str): An ml-git entity name to identify a ML entity.
-                retries (int, optional): Number of retries to upload the files to the storage [default: 2].
-                clear_on_fail (bool, optional): Remove the files from the storage in case of failure during the push operation [default: False].
-                fail_limit (int, optional): Number of failures before aborting the command [default: no limit].
+        Args:
+            entity (str): The type of an ML entity. (datasets, labels or models)
+            entity_name (str): An ml-git entity name to identify a ML entity.
+            retries (int, optional): Number of retries to upload the files to the storage [default: 2].
+            clear_on_fail (bool, optional): Remove the files from the storage in case of failure during the push operation [default: False].
+            fail_limit (int, optional): Number of failures before aborting the command [default: no limit].
         """
 
         push(entity=entity, entity_name=entity_name, retries=retries, clear_on_fail=clear_on_fail,
@@ -514,22 +519,23 @@ class MLGitAPI(metaclass=ContextWrappedMeta):
     def create(self, entity, entity_name, categories, mutability, **kwargs):
         """This command will create the workspace structure with data and spec file for an entity and set the storage configurations.
 
-            Example:
-                create('datasets', 'dataset-ex', categories=['computer-vision', 'images'], mutability='strict')
+        Example:
+            api = MLGitApi()\n
+            api.create('datasets', 'dataset-ex', categories=['computer-vision', 'images'], mutability='strict')
 
-            Args:
-                entity (str): The type of an ML entity (datasets, labels or models).
-                entity_name (str): An ml-git entity name to identify a ML entity.
-                categories (list): Artifact's categories name.
-                mutability (str): Mutability type. The mutability options are strict, flexible and mutable.
-                storage_type (str, optional): Data storage type [default: s3h].
-                version (int, optional): Number of artifact version [default: 1].
-                import_path (str, optional): Path to be imported to the project.
-                bucket_name (str, optional): Bucket name.
-                import_url (str, optional): Import data from a google drive url.
-                credentials_path (str, optional): Directory of credentials.json.
-                unzip (bool, optional): Unzip imported zipped files [default: False].
-                entity_dir (str, optional): The relative path where the entity will be created inside the ml entity directory [default: empty].
+        Args:
+            entity (str): The type of an ML entity (datasets, labels or models).
+            entity_name (str): An ml-git entity name to identify a ML entity.
+            categories (list): Artifact's categories name.
+            mutability (str): Mutability type. The mutability options are strict, flexible and mutable.
+            storage_type (str, optional): Data storage type [default: s3h].
+            version (int, optional): Number of artifact version [default: 1].
+            import_path (str, optional): Path to be imported to the project.
+            bucket_name (str, optional): Bucket name.
+            import_url (str, optional): Import data from a google drive url.
+            credentials_path (str, optional): Directory of credentials.json.
+            unzip (bool, optional): Unzip imported zipped files [default: False].
+            entity_dir (str, optional): The relative path where the entity will be created inside the ml entity directory [default: empty].
         """
 
         create(entity=entity, entity_name=entity_name, categories=categories, mutability=mutability, **kwargs)
@@ -537,12 +543,13 @@ class MLGitAPI(metaclass=ContextWrappedMeta):
     def init(self, entity):
         """This command will start the ml-git entity.
 
-            Examples:
-                init('repository')
-                init('datasets')
+        Examples:
+            api = MLGitApi()\n
+            api.init('repository')\n
+            api.init('datasets')
 
-            Args:
-                entity (str): The type of an ML entity (datasets, labels or models).
+        Args:
+            entity (str): The type of an ML entity (datasets, labels or models).
         """
 
         init(entity=entity)
@@ -551,19 +558,20 @@ class MLGitAPI(metaclass=ContextWrappedMeta):
                     endpoint_url=None, username=None, private_key=None, port=22, region=None):
         """This command will add a storage to the ml-git project.
 
-            Examples:
-                storage_add('my-bucket', type='s3h')
+        Examples:
+            api = MLGitApi()\n
+            api.storage_add('my-bucket', bucket_type='s3h')
 
-            Args:
-                bucket_name (str): The name of the bucket in the storage.
-                bucket_type (str, optional): Storage type (s3h, azureblobh or gdriveh) [default: s3h].
-                credentials (str, optional): Name of the profile that stores the credentials or the path to the credentials.
-                global_configuration (bool, optional): Use this option to set configuration at global level [default: False].
-                endpoint_url (str, optional): Storage endpoint url.
-                username (str, optional): The username for the sftp login.
-                private_key (str, optional): Full path for the private key file.
-                port (int, optional): The port to be used when connecting to the storage.
-                region (str, optional): AWS region for S3 bucket.
+        Args:
+            bucket_name (str): The name of the bucket in the storage.
+            bucket_type (str, optional): Storage type (s3h, azureblobh or gdriveh) [default: s3h].
+            credentials (str, optional): Name of the profile that stores the credentials or the path to the credentials.
+            global_configuration (bool, optional): Use this option to set configuration at global level [default: False].
+            endpoint_url (str, optional): Storage endpoint url.
+            username (str, optional): The username for the sftp login.
+            private_key (str, optional): Full path for the private key file.
+            port (int, optional): The port to be used when connecting to the storage.
+            region (str, optional): AWS region for S3 bucket.
         """
 
         storage_add(bucket_name=bucket_name, bucket_type=bucket_type, credentials=credentials,
@@ -573,13 +581,14 @@ class MLGitAPI(metaclass=ContextWrappedMeta):
     def remote_add(self, entity, remote_url, global_configuration=False):
         """This command will add a remote to store the metadata from this ml-git project.
 
-            Examples:
-                remote_add('datasets', 'https://git@github.com/mlgit-datasets')
+        Examples:
+            api = MLGitApi()\n
+            api.remote_add('datasets', 'https://git@github.com/mlgit-datasets')
 
-            Args:
-                entity (str): The type of an ML entity (datasets, labels or models).
-                remote_url(str): URL of an existing remote git repository.
-                global_configuration (bool, optional): Use this option to set configuration at global level [default: False].
+        Args:
+            entity (str): The type of an ML entity (datasets, labels or models).
+            remote_url(str): URL of an existing remote git repository.
+            global_configuration (bool, optional): Use this option to set configuration at global level [default: False].
         """
 
         remote_add(entity=entity, remote_url=remote_url, global_configuration=global_configuration)
@@ -587,13 +596,14 @@ class MLGitAPI(metaclass=ContextWrappedMeta):
     def get_models_metrics(self, entity_name, export_path=None, export_type=FileType.JSON.value):
         """Get metrics information for each tag of the entity.
 
-            Examples:
-                get_models_metrics('model-ex', export_type='csv')
+        Examples:
+            api = MLGitApi()\n
+            api.get_models_metrics('model-ex', export_type='csv')
 
-            Args:
-                entity_name (str): An ml-git entity name to identify a ML entity.
-                export_path(str, optional): Set the path to export metrics to a file.
-                export_type (str, optional): Choose the format of the file that will be generated with the metrics [default: json].
+        Args:
+            entity_name (str): An ml-git entity name to identify a ML entity.
+            export_path(str, optional): Set the path to export metrics to a file.
+            export_type (str, optional): Choose the format of the file that will be generated with the metrics [default: json].
         """
 
         get_models_metrics(entity_name=entity_name, export_path=export_path, export_type=export_type)

--- a/tests/integration/test_24_api.py
+++ b/tests/integration/test_24_api.py
@@ -749,3 +749,23 @@ class APIAcceptanceTests(unittest.TestCase):
             content = graph_file.read()
             self.assertIn('\\"{} (1)\\" -> \\"{} (2)\\"'.format(DATASET_NAME, DATASET_NAME), content)
             self.assertIn('\\"{} (2)\\" -> \\"{} (10)\\"'.format(DATASET_NAME, DATASET_NAME), content)
+
+    @pytest.mark.usefixtures('switch_to_tmp_dir')
+    def test_43_working_with_two_projects(self):
+        project_1_dir_name = 'project-test-1'
+        project_2_dir_name = 'project-test-2'
+        os.mkdir(project_1_dir_name)
+        os.mkdir(project_2_dir_name)
+
+        config_project_1 = os.path.join(self.tmp_dir, project_1_dir_name, ML_GIT_DIR, 'config.yaml')
+        config_project_2 = os.path.join(self.tmp_dir, project_2_dir_name,  ML_GIT_DIR, 'config.yaml')
+        self.assertFalse(os.path.exists(config_project_1))
+        self.assertFalse(os.path.exists(config_project_2))
+
+        api_1 = api.MLGitAPI(root_path='./{}'.format(project_1_dir_name))
+        api_1.init('repository')
+        self.assertTrue(os.path.exists(config_project_1))
+
+        api_2 = api.MLGitAPI(root_path='./{}'.format(project_2_dir_name))
+        api_2.init('repository')
+        self.assertTrue(os.path.exists(config_project_2))

--- a/tests/integration/test_24_api.py
+++ b/tests/integration/test_24_api.py
@@ -751,7 +751,16 @@ class APIAcceptanceTests(unittest.TestCase):
             self.assertIn('\\"{} (2)\\" -> \\"{} (10)\\"'.format(DATASET_NAME, DATASET_NAME), content)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
-    def test_43_working_with_two_projects(self):
+    def test_43_using_api_class_without_path(self):
+        config = os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml')
+        self.assertFalse(os.path.exists(config))
+
+        api_instance = api.MLGitAPI()
+        api_instance.init('repository')
+        self.assertTrue(os.path.exists(config))
+
+    @pytest.mark.usefixtures('switch_to_tmp_dir')
+    def test_44_working_with_two_projects(self):
         project_1_dir_name = 'project-test-1'
         project_2_dir_name = 'project-test-2'
         os.mkdir(project_1_dir_name)
@@ -762,10 +771,10 @@ class APIAcceptanceTests(unittest.TestCase):
         self.assertFalse(os.path.exists(config_project_1))
         self.assertFalse(os.path.exists(config_project_2))
 
-        api_1 = api.MLGitAPI(root_path='./{}'.format(project_1_dir_name))
-        api_1.init('repository')
+        api_project_1 = api.MLGitAPI(root_path='./{}'.format(project_1_dir_name))
+        api_project_1.init('repository')
         self.assertTrue(os.path.exists(config_project_1))
 
-        api_2 = api.MLGitAPI(root_path='./{}'.format(project_2_dir_name))
-        api_2.init('repository')
+        api_project_2 = api.MLGitAPI(root_path='./{}'.format(project_2_dir_name))
+        api_project_2.init('repository')
         self.assertTrue(os.path.exists(config_project_2))


### PR DESCRIPTION
This PR creates a class in the ML-Git API to hold the root path of a project so that every command of the API can run in the context of said project.

This happens because of the decorator that is automatically added to all methods within the class by its Metaclass, the decorator is responsible for: changing the current dir to the project root, executing the command, changing the current dir back to the origin.

The decorator was implemented using the `pathlib.Path` class, which means that we can tell the API the project root by using: a relative path, an absolute path, or the current working directory (CWD) by not passing any path.

An important thing to keep in mind is that the decorator can only work in the class methods that have the parameter self because the decorator needs to access the instance to gather the root_path attribute.