### PR TITLE
Updating add command output when it has corrupt files

### DIFF
--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -175,7 +175,6 @@ output_messages = {
     'INFO_FILE_AUTOMATICALLY_ADDED': 'File {} has been automatically added to staged files.',
     'INFO_FSCK_CORRUPTED_FILES': '\n[%d] corrupted file(s) in Local Repository %s\n[%d] corrupted file(s) in Index %s\nTotal of corrupted files: %d',
     'INFO_FSCK_VERBOSE_MODE': 'For more information about the corrupted files you can run the command with the --full option.',
-    'INFO_SEE_CORRUPTED_FILES': 'There are corrupted files in your workspace. These files were not added. Files:',
     'INFO_SEE_ALL_CORRUPTED_FILES': 'You can view the complete list of corrupted files at logs/ml-git_execution.log',
 
     'ERROR_PATH_NOT_EMPTY': 'The path [%s] is not an empty directory. Consider using --folder to create an empty folder.',

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -325,7 +325,7 @@ output_messages = {
     'ERROR_REQUIRED_OPTION_MISSING': 'The option `{}` is required if `{}` is used.',
     'ERROR_TAGS_NOT_MATCH_WITH_ENTITY': 'The tags do not match the entity name',
 
-    'WARN_CORRUPTED_CANNOT_BE_ADD': 'There are corrupt files in your workspace. These files were not added. Files:',
+    'WARN_CORRUPTED_CANNOT_BE_ADD': 'There are corrupted files in your workspace. These files were not added. Files:',
     'WARN_CORRUPTED_FILES_THAT_CANNOT_BE_ADD': 'The following files cannot be added because they are corrupted:',
     'WARN_HAS_CONFIGURED_REMOTE': 'YOU ALREADY HAS A CONFIGURED REMOTE. All data stored in this repository will be sent to the new one on the first push.',
     'WARN_STORAGE_NOT_IN_CONFIG': 'Storage [%s://%s] not found in configuration file.',

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -175,7 +175,7 @@ output_messages = {
     'INFO_FILE_AUTOMATICALLY_ADDED': 'File {} has been automatically added to staged files.',
     'INFO_FSCK_CORRUPTED_FILES': '\n[%d] corrupted file(s) in Local Repository %s\n[%d] corrupted file(s) in Index %s\nTotal of corrupted files: %d',
     'INFO_FSCK_VERBOSE_MODE': 'For more information about the corrupted files you can run the command with the --full option.',
-    'INFO_SEE_CORRUPTED_FILES': 'There are corrupt files in your workspace. These files were not added. Files:',
+    'INFO_SEE_CORRUPTED_FILES': 'There are corrupted files in your workspace. These files were not added. Files:',
     'INFO_SEE_ALL_CORRUPTED_FILES': 'You can view the complete list of corrupted files at logs/ml-git_execution.log',
 
     'ERROR_PATH_NOT_EMPTY': 'The path [%s] is not an empty directory. Consider using --folder to create an empty folder.',

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -175,6 +175,8 @@ output_messages = {
     'INFO_FILE_AUTOMATICALLY_ADDED': 'File {} has been automatically added to staged files.',
     'INFO_FSCK_CORRUPTED_FILES': '\n[%d] corrupted file(s) in Local Repository %s\n[%d] corrupted file(s) in Index %s\nTotal of corrupted files: %d',
     'INFO_FSCK_VERBOSE_MODE': 'For more information about the corrupted files you can run the command with the --full option.',
+    'INFO_SEE_CORRUPTED_FILES': 'There are corrupt files in your workspace. These files were not added. Files:',
+    'INFO_SEE_ALL_CORRUPTED_FILES': 'You can view the complete list of corrupted files at logs/ml-git_execution.log',
 
     'ERROR_PATH_NOT_EMPTY': 'The path [%s] is not an empty directory. Consider using --folder to create an empty folder.',
     'ERROR_WITHOUT_TAG_FOR_THIS_ENTITY': 'No entity with that name was found.',
@@ -323,7 +325,8 @@ output_messages = {
     'ERROR_REQUIRED_OPTION_MISSING': 'The option `{}` is required if `{}` is used.',
     'ERROR_TAGS_NOT_MATCH_WITH_ENTITY': 'The tags do not match the entity name',
 
-    'WARN_CORRUPTED_CANNOT_BE_ADD': 'The following files cannot be added because they are corrupted:',
+    'WARN_CORRUPTED_CANNOT_BE_ADD': 'There are corrupt files in your workspace. These files were not added. Files:',
+    'WARN_CORRUPTED_FILES_THAT_CANNOT_BE_ADD': 'The following files cannot be added because they are corrupted:',
     'WARN_HAS_CONFIGURED_REMOTE': 'YOU ALREADY HAS A CONFIGURED REMOTE. All data stored in this repository will be sent to the new one on the first push.',
     'WARN_STORAGE_NOT_IN_CONFIG': 'Storage [%s://%s] not found in configuration file.',
     'WARN_EXCPETION_CREATING_STORAGE': 'Exception creating storage -- Configuration not found for bucket [%s]. '

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -234,15 +234,18 @@ class Repository(object):
                 cache = Cache(cache_path, path, mf)
                 cache.update()
 
-    def _check_corrupted_files(self, spec, repo):
+    def _check_corrupted_files(self, spec, repo, full_path=False):
         try:
             corrupted_files = repo.get_corrupted_files(spec)
             if corrupted_files is not None and len(corrupted_files) > 0:
                 print('\n')
-                log.warn(output_messages['WARN_CORRUPTED_CANNOT_BE_ADD'],
-                         class_name=REPOSITORY_CLASS_NAME)
+                log.warn(output_messages['WARN_CORRUPTED_CANNOT_BE_ADD'], class_name=REPOSITORY_CLASS_NAME)
+                self._print_files(corrupted_files, full_path)
+                log.info(output_messages['INFO_SEE_ALL_CORRUPTED_FILES'], class_name=REPOSITORY_CLASS_NAME)
+
+                log.debug(output_messages['WARN_CORRUPTED_FILES_THAT_CANNOT_BE_ADD'], class_name=REPOSITORY_CLASS_NAME)
                 for file in corrupted_files:
-                    print('\t %s' % file)
+                    log.debug('\t %s' % file, class_name=REPOSITORY_CLASS_NAME)
         except Exception as e:
             log.error(e, class_name=REPOSITORY_CLASS_NAME)
             return

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -244,8 +244,7 @@ class Repository(object):
                 log.info(output_messages['INFO_SEE_ALL_CORRUPTED_FILES'], class_name=REPOSITORY_CLASS_NAME)
 
                 log.debug(output_messages['WARN_CORRUPTED_FILES_THAT_CANNOT_BE_ADD'], class_name=REPOSITORY_CLASS_NAME)
-                for file in corrupted_files:
-                    log.debug('\t %s' % file, class_name=REPOSITORY_CLASS_NAME)
+                log.debug('\t %s' % corrupted_files, class_name=REPOSITORY_CLASS_NAME)
         except Exception as e:
             log.error(e, class_name=REPOSITORY_CLASS_NAME)
             return

--- a/tests/integration/test_05_add_files.py
+++ b/tests/integration/test_05_add_files.py
@@ -291,25 +291,3 @@ class AddFilesAcceptanceTests(unittest.TestCase):
 
         index = os.path.join(ML_GIT_DIR, DATASETS, 'index', 'metadata', DATASET_NAME, 'INDEX.yaml')
         self._check_index(index, ['file1', 'file1 - Copy'], [])
-
-    def corrupt_file(self, file_name):
-        corrupted_file = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, file_name)
-
-        os.chmod(corrupted_file, S_IWUSR | S_IREAD)
-        with open(corrupted_file, 'wb') as z:
-            z.write(b'0' * 0)
-
-    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
-    def test_16_add_command_with_multiple_corrupted_files_added(self):
-        entity_init(DATASETS, self)
-
-        add_file(self, DATASETS, '--bumpversion', 'new', entity_dir='test')
-        self.corrupt_file('newfile0')
-        self.corrupt_file('newfile1')
-        self.corrupt_file('newfile2')
-        self.corrupt_file('newfile4')
-
-        command_output = check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion'))
-        self.assertIn(output_messages['WARN_CORRUPTED_CANNOT_BE_ADD'], command_output)
-        self.assertIn('test', command_output)
-        self.assertIn('4 FILES', command_output)

--- a/tests/integration/test_05_add_files.py
+++ b/tests/integration/test_05_add_files.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020-2021 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
@@ -77,7 +77,9 @@ class AddFilesAcceptanceTests(unittest.TestCase):
         with open(corrupted_file, 'wb') as z:
             z.write(b'0' * 0)
 
-        self.assertIn(output_messages['WARN_CORRUPTED_CANNOT_BE_ADD'], check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion')))
+        command_output = check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion'))
+        self.assertIn(output_messages['WARN_CORRUPTED_CANNOT_BE_ADD'], command_output)
+        self.assertIn('newfile0', command_output)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_07_add_command_with_multiple_files(self):
@@ -289,3 +291,25 @@ class AddFilesAcceptanceTests(unittest.TestCase):
 
         index = os.path.join(ML_GIT_DIR, DATASETS, 'index', 'metadata', DATASET_NAME, 'INDEX.yaml')
         self._check_index(index, ['file1', 'file1 - Copy'], [])
+
+    def corrupt_file(self, file_name):
+        corrupted_file = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, file_name)
+
+        os.chmod(corrupted_file, S_IWUSR | S_IREAD)
+        with open(corrupted_file, 'wb') as z:
+            z.write(b'0' * 0)
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_16_add_command_with_multiple_corrupted_files_added(self):
+        entity_init(DATASETS, self)
+
+        add_file(self, DATASETS, '--bumpversion', 'new', entity_dir='test')
+        self.corrupt_file('newfile0')
+        self.corrupt_file('newfile1')
+        self.corrupt_file('newfile2')
+        self.corrupt_file('newfile4')
+
+        command_output = check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '--bumpversion'))
+        self.assertIn(output_messages['WARN_CORRUPTED_CANNOT_BE_ADD'], command_output)
+        self.assertIn('test', command_output)
+        self.assertIn('4 FILES', command_output)


### PR DESCRIPTION
When the user executes the add command on an entity that has corrupted files, ML-Git informs that these corrupted files were not added. In this PR the list of files was adjusted to be grouped by directories.

**Proposed output:**
```
$ ml-git datasets add dataset-ex10
INFO - Metadata Manager: Pull [D:\Virtus\demo\.ml-git\datasets\metadata]
INFO - Repository: datasets adding path [D:\Virtus\demo\datasets\dataset-ex] to ml-git index
files: 100%|██████████████████| 113/113 [00:00<00:00, 934files/s]
files: 100%|██████████████████| 113/113 [00:00<00:00, 109kfiles/s]

WARNING - Repository: There are corrupted files in your workspace. These files were not added. Files:
        data/   ->      6 FILES
        data2/  ->      6 FILES
INFO - Repository: You can view the complete list of corrupted files at logs/ml-git_execution.log
```

**Current output:**

```
$ ml-git datasets add dataset-ex10 --bumpversion
INFO - Metadata Manager: Pull [D:\Virtus\demo\.ml-git\datasets\metadata]
INFO - Repository: datasets adding path [D:\Virtus\demo\datasets\dataset-ex] to ml-git index
files: 100%|██████████████████| 113/113 [00:00<00:00, 934files/s]
files: 100%|██████████████████| 113/113 [00:00<00:00, ?files/s]

WARNING - Repository: The following files cannot be added because they are corrupted:
         data\0010.png
         data\0011.png
         data\0012.png
         data\0013.png
         data\0014.png
         data\0015.png
         data2\0010.png
         data2\0011.png
         data2\0012.png
         data2\0013.png
         data2\0014.png
         data2\0015.png
```