### PR TITLE
Updating checkout command output when it has unsaved files

### DIFF
--- a/ml_git/api.py
+++ b/ml_git/api.py
@@ -424,7 +424,7 @@ class MLGitAPI(metaclass=ContextWrappedMeta):
         clone(repository_url=repository_url, untracked=untracked)
 
     def checkout(self, entity, tag, sampling=None, retries=2, force=False, dataset=False, labels=False, version=-1,
-                 fail_limit=None):
+                 fail_limit=None, full=False):
         """This command allows retrieving the data of a specific version of an ML entity.
 
         Example:
@@ -448,13 +448,14 @@ class MLGitAPI(metaclass=ContextWrappedMeta):
             labels (bool, optional): If exist labels related with the model, they must be downloaded [default: False].
             version (int, optional): The entity version [default: -1].
             fail_limit (int, optional): Number of failures before aborting the command [default: no limit].
+            full (bool, optional): Show all contents for each directory. [default: False].
 
         Returns:
             str: Return the path where the data was checked out.
         """
 
         checkout(entity=entity, tag=tag, sampling=sampling, retries=retries, force=force, dataset=dataset,
-                 labels=labels, version=version, fail_limit=fail_limit)
+                 labels=labels, version=version, fail_limit=fail_limit, full=full)
 
     def add(self, entity_type, entity_name, bumpversion=False, fsck=False, file_path=None, metric=None,
             metrics_file=''):

--- a/ml_git/api.py
+++ b/ml_git/api.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020-2021 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
@@ -46,7 +46,7 @@ def validate_sample(sampling):
     return True
 
 
-def checkout(entity, tag, sampling=None, retries=2, force=False, dataset=False, labels=False, version=-1, fail_limit=None):
+def checkout(entity, tag, sampling=None, retries=2, force=False, dataset=False, labels=False, version=-1, fail_limit=None, full=False):
     """**DEPRECATED**: This method will be removed in future versions, MLGitAPI.checkout should be used instead.
 
     This command allows retrieving the data of a specific version of an ML entity.
@@ -70,6 +70,7 @@ def checkout(entity, tag, sampling=None, retries=2, force=False, dataset=False, 
         dataset (bool, optional): If exist a dataset related with the model or labels, this one must be downloaded [default: False].
         labels (bool, optional): If exist labels related with the model, they must be downloaded [default: False].
         fail_limit (int, optional): Number of failures before aborting the command [default: no limit].
+        full (bool, optional): Show all contents for each directory. [default: False].
 
     Returns:
         str: Return the path where the data was checked out.
@@ -87,6 +88,7 @@ def checkout(entity, tag, sampling=None, retries=2, force=False, dataset=False, 
     options['bare'] = False
     options['version'] = version
     options['fail_limit'] = fail_limit
+    options['full'] = full
     repo.checkout(tag, sampling, options)
 
     spec_name = tag

--- a/ml_git/commands/descriptor.py
+++ b/ml_git/commands/descriptor.py
@@ -85,7 +85,7 @@ commands = [
             '--bare': {'default': False, 'is_flag': True, 'help': help_msg.BARE_OPTION},
             '--version': {'default': -1, 'help': help_msg.ARTIFACT_VERSION},
             '--fail-limit': {'type': int, 'help': help_msg.FAIL_LIMIT},
-            '--full': {'is_flag': True, 'default': False, 'help': help_msg.STATUS_FULL_OPTION},
+            '--full': {'is_flag': True, 'default': False, 'help': help_msg.STATUS_FULL_OPTION}
         },
 
         'arguments': {
@@ -114,7 +114,8 @@ commands = [
             '--force': {'is_flag': True, 'default': False, 'help': help_msg.FORCE_CHECKOUT},
             '--bare': {'default': False, 'is_flag': True, 'help': help_msg.BARE_OPTION},
             '--version': {'default': -1, 'help': help_msg.ARTIFACT_VERSION},
-            '--fail-limit': {'type': int, 'help': help_msg.FAIL_LIMIT}
+            '--fail-limit': {'type': int, 'help': help_msg.FAIL_LIMIT},
+            '--full': {'is_flag': True, 'default': False, 'help': help_msg.STATUS_FULL_OPTION}
         },
 
         'help': 'Checkout the ML_ENTITY_TAG|ML_ENTITY of a label set into user workspace.'
@@ -133,7 +134,8 @@ commands = [
             '--force': {'default': False, 'is_flag': True, 'help': help_msg.FORCE_CHECKOUT},
             '--bare': {'default': False, 'is_flag': True, 'help': help_msg.BARE_OPTION},
             '--version': {'default': -1, 'help': help_msg.ARTIFACT_VERSION},
-            '--fail-limit': {'type': int, 'help': help_msg.FAIL_LIMIT}
+            '--fail-limit': {'type': int, 'help': help_msg.FAIL_LIMIT},
+            '--full': {'is_flag': True, 'default': False, 'help': help_msg.STATUS_FULL_OPTION}
         },
 
         'arguments': {

--- a/ml_git/commands/descriptor.py
+++ b/ml_git/commands/descriptor.py
@@ -84,7 +84,8 @@ commands = [
             '--force': {'default': False, 'is_flag': True, 'help': help_msg.FORCE_CHECKOUT},
             '--bare': {'default': False, 'is_flag': True, 'help': help_msg.BARE_OPTION},
             '--version': {'default': -1, 'help': help_msg.ARTIFACT_VERSION},
-            '--fail-limit': {'type': int, 'help': help_msg.FAIL_LIMIT}
+            '--fail-limit': {'type': int, 'help': help_msg.FAIL_LIMIT},
+            '--full': {'is_flag': True, 'default': False, 'help': help_msg.STATUS_FULL_OPTION},
         },
 
         'arguments': {

--- a/ml_git/commands/entity.py
+++ b/ml_git/commands/entity.py
@@ -95,6 +95,7 @@ def checkout(context, **kwargs):
     options['bare'] = kwargs['bare']
     options['version'] = kwargs['version']
     options['fail_limit'] = kwargs['fail_limit']
+    options['full'] = kwargs['full']
     repo.checkout(kwargs['ml_entity_tag'], sample, options)
 
 

--- a/ml_git/file_system/local.py
+++ b/ml_git/file_system/local.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
@@ -667,7 +667,7 @@ class LocalRepository(MultihashFS):
 
         return True
 
-    def exist_local_changes(self, spec_name):
+    def exist_local_changes(self, spec_name, print_method, full_option=False):
         new_files, deleted_files, untracked_files, _, _ = self.status(spec_name, status_directory='', log_errors=False)
         if new_files is not None and deleted_files is not None and untracked_files is not None:
             unsaved_files = new_files + deleted_files + untracked_files
@@ -676,9 +676,8 @@ class LocalRepository(MultihashFS):
             if 'README.md' in unsaved_files:
                 unsaved_files.remove('README.md')
             if len(unsaved_files) > 0:
-                log.error(output_messages['ERROR_DISCARDED_LOCAL_CHANGES'])
-                for file in unsaved_files:
-                    print('\t%s' % file)
+                log.warn(output_messages['ERROR_DISCARDED_LOCAL_CHANGES'])
+                print_method(unsaved_files, full_option)
                 log.info(
                     'Please, commit your changes before the get. You can also use the --force option '
                     'to discard these changes. See \'ml-git --help\'.',

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -833,6 +833,7 @@ class Repository(object):
         force_get = options['force']
         bare = options['bare']
         version = options['version']
+        full_option = options['full']
         repo_type = self.__repo_type
         try:
             cache_path = get_cache_path(self.__config, repo_type)
@@ -863,7 +864,7 @@ class Repository(object):
 
         local_rep = LocalRepository(self.__config, objects_path, repo_type)
         # check if no data left untracked/uncommitted. otherwise, stop.
-        if not force_get and local_rep.exist_local_changes(spec_name) is True:
+        if not force_get and local_rep.exist_local_changes(spec_name, self._print_files, full_option) is True:
             return None, None
 
         try:


### PR DESCRIPTION
This PR adds handling to the file listing when the user has unsaved files in their workspace and tries to checkout an entity.
Also, the --full option was added in case he wants to have the complete listing of the files.


```
$ ml-git datasets checkout dataset-ex
INFO - Metadata: Performing checkout in tag images__dataset-ex__2
WARNING - MLGit: Your local changes to the following files would be discarded:
        data/     ->      8 FILES
        data2/    ->      8 FILES
INFO - Local Repository: Please, commit your changes before the get. You can also use the --force option to discard these changes. See 'ml-git --help'.
```

With the --full option the user gets a output similar to the current output
```
$ ml-git datasets checkout dataset-ex --full
INFO - Metadata: Performing checkout in tag images__dataset-ex__2
WARNING - MLGit: Your local changes to the following files would be discarded:
        data\0019
        data\0020
        data\0021
        data\0022
        data\0023
        data\0024
        data\0025
        data\0026
        data2\0026
        data2\0027
        data2\0028
        data2\0029
        data2\0030
        data2\0031
        data2\0032
        data2\0033
INFO - Local Repository: Please, commit your changes before the get. You can also use the --force option to discard these changes. See 'ml-git --help'.
```


