### PR TITLE
Feature/update log command

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -2,12 +2,11 @@ name: MLGit-CI
 
 on:
   push:
-    branches: [ development, feature/output_commands ]
+    branches: [ development ]
   pull_request:
     branches: 
       - development
       - bugfix/**
-      - feature/output_commands
 
 jobs:
   flake8:

--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020-2021 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 import io
@@ -520,13 +520,16 @@ class MetadataRepo(object):
                 paths = {}
                 for file_path in files_path_list:
                     index = file_path.rfind('/')
-                    key = file_path[:index+1]
+                    if index == -1:
+                        key = './'
+                    else:
+                        key = file_path[:index+1]
                     if key in paths:
                         paths[key] += 1
                     else:
                         paths[key] = 1
 
-                return '\n\t'.join('\t{}\t-> \t{} FILES'.format(k, paths[k]) for k in paths.keys())
+                return '\n\t'.join('{}\t-> \t{} FILES'.format(k, paths[k]) for k in paths.keys())
 
         commit = tag.commit
         info_format = '\n{}: {}'

--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -360,7 +360,7 @@ class MetadataRepo(object):
     def get_log_info(self, spec, fullstat=False, stat=False, specialized_data_info=None):
         formatted = ''
         tags = self._get_ordered_entity_tags(spec)
-        
+
         for tag in tags:
             formatted += '\n' + self.get_formatted_log_info(spec, tag, fullstat, stat)
             formatted += self._get_metrics(spec, tag.commit)

--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -510,27 +510,26 @@ class MetadataRepo(object):
 
         return added_files, deleted_files, size_files, amount_files
 
+    def _get_files_log_output(self, files_path_list, fullstat):
+        if fullstat:
+            return '\n\t'.join(files_path_list)
+
+        else:
+            paths = {}
+            for file_path in files_path_list:
+                index = file_path.rfind('/')
+                if index == -1:
+                    key = './'
+                else:
+                    key = file_path[:index+1]
+                if key in paths:
+                    paths[key] += 1
+                else:
+                    paths[key] = 1
+
+            return '\n\t'.join('{}\t-> \t{} FILES'.format(k, paths[k]) for k in paths.keys())
+
     def get_formatted_log_info(self, entity_name, tag, fullstat, stat):
-
-        def get_files_log_output(files_path_list, fullstat):
-            if fullstat:
-                return '\n\t'.join(files_path_list)
-
-            else:
-                paths = {}
-                for file_path in files_path_list:
-                    index = file_path.rfind('/')
-                    if index == -1:
-                        key = './'
-                    else:
-                        key = file_path[:index+1]
-                    if key in paths:
-                        paths[key] += 1
-                    else:
-                        paths[key] = 1
-
-                return '\n\t'.join('{}\t-> \t{} FILES'.format(k, paths[k]) for k in paths.keys())
-
         commit = tag.commit
         info_format = '\n{}: {}'
         info = ''
@@ -544,10 +543,10 @@ class MetadataRepo(object):
             added, deleted, size, amount = self.get_tag_diff_from_parent(entity_name, tag)
             if len(added) > 0:
                 added_list = list(added)
-                info += '\n\n{} [{}]:\n\t{}'.format(ADDED, len(added_list), get_files_log_output(added_list, fullstat))
+                info += '\n\n{} [{}]:\n\t{}'.format(ADDED, len(added_list), self._get_files_log_output(added_list, fullstat))
             if len(deleted) > 0:
                 deleted_list = list(deleted)
-                info += '\n\n{} [{}]:\n\t{}'.format(DELETED, len(deleted_list), get_files_log_output(deleted_list, fullstat))
+                info += '\n\n{} [{}]:\n\t{}'.format(DELETED, len(deleted_list), self._get_files_log_output(deleted_list, fullstat))
             if len(size) > 0:
                 info += '\n\n{}: {}'.format(SIZE, '\n\t'.join(size))
             if len(amount) > 0:

--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -357,12 +357,12 @@ class MetadataRepo(object):
         tags.sort(key=self.__sort_tag_by_date)
         return tags
 
-    def get_log_info(self, spec, fullstat=False, specialized_data_info=None):
+    def get_log_info(self, spec, fullstat=False, stat=False, specialized_data_info=None):
         formatted = ''
         tags = self._get_ordered_entity_tags(spec)
-
+        
         for tag in tags:
-            formatted += '\n' + self.get_formatted_log_info(spec, tag, fullstat)
+            formatted += '\n' + self.get_formatted_log_info(spec, tag, fullstat, stat)
             formatted += self._get_metrics(spec, tag.commit)
             if specialized_data_info:
                 value = next(specialized_data_info, '')
@@ -510,7 +510,24 @@ class MetadataRepo(object):
 
         return added_files, deleted_files, size_files, amount_files
 
-    def get_formatted_log_info(self, entity_name, tag, fullstat):
+  def get_formatted_log_info(self, entity_name, tag, fullstat, stat):
+
+        def get_files_log_output(files_path_list, fullstat):
+            if fullstat:
+                return '\n\t'.join(files_path_list)
+
+            else:
+                paths = {}
+                for file_path in files_path_list:
+                    index = file_path.rfind('/')
+                    key = file_path[:index+1]
+                    if key in paths:
+                        paths[key] += 1
+                    else:
+                        paths[key] = 1
+
+                return '\n\t'.join('\t{}\t-> \t{} FILES'.format(k, paths[k]) for k in paths.keys())
+
         commit = tag.commit
         info_format = '\n{}: {}'
         info = ''
@@ -520,14 +537,14 @@ class MetadataRepo(object):
         info += info_format.format(DATE, time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(commit.authored_date)))
         info += info_format.format(MESSAGE, commit.message)
 
-        if fullstat:
+        if fullstat or stat:
             added, deleted, size, amount = self.get_tag_diff_from_parent(entity_name, tag)
             if len(added) > 0:
                 added_list = list(added)
-                info += '\n\n{} [{}]:\n\t{}'.format(ADDED, len(added_list), '\n\t'.join(added_list))
+                info += '\n\n{} [{}]:\n\t{}'.format(ADDED, len(added_list), get_files_log_output(added_list, fullstat))
             if len(deleted) > 0:
                 deleted_list = list(deleted)
-                info += '\n\n{} [{}]:\n\t{}'.format(DELETED, len(deleted_list), '\n\t'.join(deleted_list))
+                info += '\n\n{} [{}]:\n\t{}'.format(DELETED, len(deleted_list), get_files_log_output(deleted_list, fullstat))
             if len(size) > 0:
                 info += '\n\n{}: {}'.format(SIZE, '\n\t'.join(size))
             if len(amount) > 0:

--- a/ml_git/_metadata.py
+++ b/ml_git/_metadata.py
@@ -510,7 +510,7 @@ class MetadataRepo(object):
 
         return added_files, deleted_files, size_files, amount_files
 
-  def get_formatted_log_info(self, entity_name, tag, fullstat, stat):
+    def get_formatted_log_info(self, entity_name, tag, fullstat, stat):
 
         def get_files_log_output(files_path_list, fullstat):
             if fullstat:

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020-2021 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 import errno

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -1150,7 +1150,7 @@ class Repository(object):
             metadata = Metadata(spec, metadata_path, self.__config, repo_type)
             index_path = get_index_path(self.__config, repo_type)
             specialized_data_compared = self._log_compare_spec_from_versions(spec, metadata)
-            log_info = metadata.get_log_info(spec, fullstat, specialized_data_compared)
+            log_info = metadata.get_log_info(spec, fullstat, stat, specialized_data_compared)
         except Exception as e:
             log.error(e, class_name=REPOSITORY_CLASS_NAME)
             return

--- a/tests/integration/test_29_log.py
+++ b/tests/integration/test_29_log.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020-2021 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
@@ -58,13 +58,22 @@ class LogTests(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_02_log_with_stat(self):
         self.set_up_test()
+        add_file(self, DATASETS, '--bumpversion')
+        check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, ''))
+        added = 5
+        amount_files = 5
+        workspace_size = 14
+
         output = check_output(MLGIT_LOG % (DATASETS, DATASET_NAME, '--stat'))
+
+        self.assertIn('%s FILES' % added, output)
+
         self.assertIn(output_messages['INFO_FILES_TOTAL'] % 0, output)
         self.assertIn(output_messages['INFO_WORKSPACE_SIZE'] % 0, output)
-        self.assertNotIn(output_messages['INFO_ADDED_FILES'] % 0, output)
+        self.assertIn(output_messages['INFO_ADDED_FILES'] % added, output)
         self.assertNotIn(output_messages['INFO_DELETED_FILES'] % 0, output)
-        self.assertNotIn(output_messages['INFO_FILES_SIZE'] % 0, output)
-        self.assertNotIn(output_messages['INFO_AMOUNT_SIZE'] % 0, output)
+        self.assertIn(output_messages['INFO_AMOUNT_SIZE'] % amount_files, output)
+        self.assertIn(output_messages['INFO_FILES_SIZE'] % workspace_size, output)
         self.assertNotIn(self.create_metrics_table(), output)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')

--- a/tests/integration/test_29_log.py
+++ b/tests/integration/test_29_log.py
@@ -68,8 +68,8 @@ class LogTests(unittest.TestCase):
 
         self.assertIn('%s FILES' % added, output)
 
-        self.assertIn(output_messages['INFO_FILES_TOTAL'] % 0, output)
-        self.assertIn(output_messages['INFO_WORKSPACE_SIZE'] % 0, output)
+        self.assertIn(output_messages['INFO_FILES_TOTAL'] % amount_files, output)
+        self.assertIn(output_messages['INFO_WORKSPACE_SIZE'] % workspace_size, output)
         self.assertIn(output_messages['INFO_ADDED_FILES'] % added, output)
         self.assertNotIn(output_messages['INFO_DELETED_FILES'] % 0, output)
         self.assertIn(output_messages['INFO_AMOUNT_SIZE'] % amount_files, output)


### PR DESCRIPTION
This PR update how a list o files displayed by command log should react when --stat option is active, when active rather than display only commit data like bellow:

```
$ ml-git datasets log dataset-2 --stat
INFO - Repository: 
Tag: computer-vision__images__dataset-2__1
Author: MatheusClaudi
Email: matheus.claudino@ccc.ufcg.edu.br
Date: 2022-02-25 11:16:50
Message: computer-vision/images/dataset-2
```

It should display to user a short report of all files in commit (Both Added and Deleted) and information about quantity and storage space been used, like bellow:

```
INFO - Repository: 

Tag: computer-vision__images__dataset-2__1
Author: MatheusClaudi
Email: matheus.claudino@ccc.ufcg.edu.br
Date: 2022-02-25 11:16:50
Message: computer-vision/images/dataset-2

Added files [5]:
	data/	-> 	5 FILES

Files size: 13.3 MB

Amount of files: 5
------------------------------------------------- 
Total of files: 5	Workspace size: 13.3 MB
```
