### PR TITLE
Adding message when executing remote-fsck for empty entity

### DIFF
--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -340,5 +340,6 @@ output_messages = {
     'WARN_NOT_FOUND': '[%s] Not found!',
     'WARN_FILE_EXISTS_IN_REPOSITORY': 'The file %s already exists in the repository. If you commit, the file will be overwritten.',
     'WARN_REPOSITORY_NOT_FOUND_FOR_ENTITY': 'No repositories found for %s, verify your configurations!',
-    'WARN_USELESS_OPTION': 'Ignoring option `--{}` because it is only needed when using `--{}` option.'
+    'WARN_USELESS_OPTION': 'Ignoring option `--{}` because it is only needed when using `--{}` option.',
+    'WARN_EMPTY_ENTITY': 'The entity %s has no data to be checked. You have to commit some data before executing this command.',
 }

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -804,7 +804,7 @@ class Repository(object):
 
         r = LocalRepository(self.__config, objects_path, repo_type)
 
-        r.remote_fsck(metadata_path, tag, full_spec_path, retries, thorough, paranoid, full_log)
+        r.remote_fsck(metadata_path, spec, full_spec_path, retries, thorough, paranoid, full_log)
 
         # ensure first we're on master !
         self._checkout_ref()

--- a/tests/integration/test_13_remote_fsck.py
+++ b/tests/integration/test_13_remote_fsck.py
@@ -92,3 +92,9 @@ class RemoteFsckAcceptanceTests(unittest.TestCase):
         self.assertIn(output_messages['INFO_REMOTE_FSCK_FIXED'] % (0, 1), output)
         self.assertTrue(os.path.exists(os.path.join(MINIO_BUCKET_PATH, 'zdj7Wi996ViPiddvDGvzjBBACZzw6YfPujBCaPHunVoyiTUCj')))
         self.assertIn(output_messages['INFO_REMOTE_FSCK_FIXED_LIST'] % ('Blobs', ['zdj7Wi996ViPiddvDGvzjBBACZzw6YfPujBCaPHunVoyiTUCj']), output)
+
+    @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
+    def test_05_remote_fsck_empty_entity(self):
+        init_repository(DATASETS, self)
+        output = check_output(MLGIT_REMOTE_FSCK % (DATASETS, DATASET_NAME))
+        self.assertIn(output_messages['WARN_EMPTY_ENTITY'] % DATASET_NAME, output)

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -374,7 +374,7 @@ class LocalRepositoryTestCases(unittest.TestCase):
 
         yaml_save({'zdj7WjdojNAZN53Wf29rPssZamfbC6MVerzcGwd9tNciMpsQh': {'imghires.jpg'}}, manifestpath)
         fullspecpath = os.path.join(specpath, os.path.join(specpath, 'dataset-ex.spec'))
-        spec = 'vision-computing__images__dataset-ex__5'
+        spec = 'dataset-ex'
         c = yaml_load('hdata/config.yaml')
         r = LocalRepository(c, hfspath)
         ret = r.remote_fsck(mdpath, spec, fullspecpath, 2, True, True)


### PR DESCRIPTION
An error was observed when the user try to execute the remote-fsck for an empty entity:

```
$ ml-git datasets remote-fsck dataset-ex
'NoneType' object has no attribute 'split'
```

As a fix, a treatment was added to this case:

```
$ ml-git datasets remote-fsck dataset-ex
WARNING - Local Repository: The entity dataset-ex has no data to be checked. You have to commit some data before executing this command.
```