### PR TITLE
Adding validation for empty string in metrics-file option

### DIFF
--- a/ml_git/commands/descriptor.py
+++ b/ml_git/commands/descriptor.py
@@ -258,7 +258,7 @@ commands = [
             '--bumpversion': {'is_flag': True, 'help': help_msg.BUMP_VERSION},
             '--fsck': {'is_flag': True, 'help': help_msg.FSCK_OPTION},
             '--metric': {'required': False, 'multiple': True, 'type': (str, float), 'help': help_msg.METRIC_OPTION},
-            '--metrics-file': {'required': False, 'help': help_msg.METRICS_FILE_OPTION},
+            '--metrics-file': {'type': NotEmptyString(), 'required': False, 'help': help_msg.METRICS_FILE_OPTION},
         },
 
         'help': 'Add %s change set ML_ENTITY_NAME to the local ml-git staging area.'

--- a/tests/integration/test_05_add_files.py
+++ b/tests/integration/test_05_add_files.py
@@ -291,3 +291,15 @@ class AddFilesAcceptanceTests(unittest.TestCase):
 
         index = os.path.join(ML_GIT_DIR, DATASETS, 'index', 'metadata', DATASET_NAME, 'INDEX.yaml')
         self._check_index(index, ['file1', 'file1 - Copy'], [])
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir', 'create_csv_file')
+    def test_16_add_command_with_metric_file_empty(self):
+        repo_type = MODELS
+        entity_name = '{}-ex'.format(repo_type)
+        self.set_up_add(repo_type)
+        create_spec(self, repo_type, self.tmp_dir)
+        workspace = os.path.join(self.tmp_dir, repo_type, entity_name)
+        os.makedirs(os.path.join(workspace, 'data'))
+        create_file(workspace, 'file1', '0')
+        metrics_options = '--metrics-file='
+        self.assertIn(output_messages['ERROR_EMPTY_VALUE'], check_output(MLGIT_ADD % (repo_type, entity_name, metrics_options)))


### PR DESCRIPTION
It was observed that when passing the --metrics-file option with an empty value, the command is executed without informing the user of the error.

**Observed behavior:**
```
$ ml-git models add model-ex --metrics-file=
INFO - Metadata Manager: Pull [D:\demo\.ml-git\models\metadata]
INFO - Repository: models adding path [D:\demo\models\model-ex] to ml-git index
files: 100%|██████████████████████████████████| 1.00/1.00 [00:00<00:00, 66.7files/s]
files: 100%|██████████████████████████████████| 1.00/1.00 [00:00<?, ?files/s]
```


**Fixed behavior:**
```
$ ml-git models add model-ex --metrics-file=
Usage: ml-git models add [OPTIONS] ML_ENTITY_NAME [FILE_PATH]...

Error: Invalid value for "--metrics-file": Value cannot be empty.
```