### PR TITLE
Adding handling for invalid csv file in add command

### DIFF
--- a/ml_git/file_system/local.py
+++ b/ml_git/file_system/local.py
@@ -1121,7 +1121,9 @@ class LocalRepository(MultihashFS):
             second_line = 1
 
             metrics_data = list(csv_reader)
-            return zip(metrics_data[first_line], metrics_data[second_line])
+            if len(metrics_data) > 1:
+                return zip(metrics_data[first_line], metrics_data[second_line])
+            return
 
     def add_metrics(self, spec_path, metrics, metrics_file_path):
 
@@ -1139,10 +1141,15 @@ class LocalRepository(MultihashFS):
 
         spec_file = yaml_load(spec_path)
         metrics = self.__add_metrics_from_file(metrics_file_path, metrics)
+        if not metrics:
+            raise Exception(output_messages['ERROR_INVALID_METRICS_FILE'])
         metrics_to_save = dict()
 
         for metric, value in metrics:
-            metrics_to_save[metric] = float(value)
+            try:
+                metrics_to_save[metric] = float(value)
+            except Exception:
+                raise Exception(output_messages['ERROR_INVALID_METRICS_FILE'])
 
         spec_file[get_spec_key(self.__repo_type)][PERFORMANCE_KEY] = metrics_to_save
         yaml_save(spec_file, spec_path)

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -327,7 +327,7 @@ output_messages = {
     'ERROR_EMPTY_VALUE': 'Value cannot be empty.',
     'ERROR_REQUIRED_OPTION_MISSING': 'The option `{}` is required if `{}` is used.',
     'ERROR_TAGS_NOT_MATCH_WITH_ENTITY': 'The tags do not match the entity name',
-    'ERROR_INVALID_METRICS_FILE': 'It was not possible to obtain the metrics from the informed file, please check if the file is correctly.',
+    'ERROR_INVALID_METRICS_FILE': 'It was not possible to obtain the metrics from the informed file, please check if the file is correctly formatted.',
 
     'WARN_CORRUPTED_CANNOT_BE_ADD': 'The following files cannot be added because they are corrupted:',
     'WARN_HAS_CONFIGURED_REMOTE': 'YOU ALREADY HAS A CONFIGURED REMOTE. All data stored in this repository will be sent to the new one on the first push.',

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -327,6 +327,7 @@ output_messages = {
     'ERROR_EMPTY_VALUE': 'Value cannot be empty.',
     'ERROR_REQUIRED_OPTION_MISSING': 'The option `{}` is required if `{}` is used.',
     'ERROR_TAGS_NOT_MATCH_WITH_ENTITY': 'The tags do not match the entity name',
+    'ERROR_INVALID_METRICS_FILE': 'It was not possible to obtain the metrics from the informed file, please check if the file is correctly.',
 
     'WARN_CORRUPTED_CANNOT_BE_ADD': 'The following files cannot be added because they are corrupted:',
     'WARN_HAS_CONFIGURED_REMOTE': 'YOU ALREADY HAS A CONFIGURED REMOTE. All data stored in this repository will be sent to the new one on the first push.',

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -141,7 +141,7 @@ class Repository(object):
             return None
         try:
             repo.add_metrics(spec_path, metrics, metrics_file_path)
-        except FileNotFoundError as e:
+        except Exception as e:
             log.error(e, class_name=REPOSITORY_CLASS_NAME)
             return
 

--- a/tests/integration/test_05_add_files.py
+++ b/tests/integration/test_05_add_files.py
@@ -291,3 +291,18 @@ class AddFilesAcceptanceTests(unittest.TestCase):
 
         index = os.path.join(ML_GIT_DIR, DATASETS, 'index', 'metadata', DATASET_NAME, 'INDEX.yaml')
         self._check_index(index, ['file1', 'file1 - Copy'], [])
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir', 'create_csv_file')
+    def test_16_add_command_with_empty_metric_file(self):
+        repo_type = MODELS
+        entity_name = '{}-ex'.format(repo_type)
+        self.set_up_add(repo_type)
+        create_spec(self, repo_type, self.tmp_dir)
+        workspace = os.path.join(self.tmp_dir, repo_type, entity_name)
+        os.makedirs(os.path.join(workspace, 'data'))
+        create_file(workspace, 'file1', '0')
+        csv_file = os.path.join(self.tmp_dir, 'metrics.csv')
+        with open(csv_file, 'wt') as f:
+            f.write('')
+        metrics_options = '--metrics-file="{}"'.format(csv_file)
+        self.assertIn(output_messages['ERROR_INVALID_METRICS_FILE'], check_output(MLGIT_ADD % (repo_type, entity_name, metrics_options)))


### PR DESCRIPTION
It was observed that when passing the --metrics-file option with an empty csv file, the command return an unhandled error. This PR adds a handling message for this scenario and other possible errors.

**Observed behavior:**
```
$ ml-git models add model-ex --metrics-file=D:\empty.csv
list index out of range
```


**Fixed behavior:**
```
$ ml-git models add model-ex --metrics-file=D:\empty.csv
ERROR - Repository: It was not possible to obtain the metrics of the informed file, please check if the file is correctly.
A complete log of this run can be found in: ml-git_execution.log
```