### PR TITLE
Adding message to show the list of missing IPLD

### DIFF
--- a/docs/mlgit_commands.md
+++ b/docs/mlgit_commands.md
@@ -562,9 +562,9 @@ This command will perform a 2-step operations:
 
 ```
 Usage: ml-git datasets remote-fsck [OPTIONS] ML_ENTITY_NAME
-
-  This command will check and repair the remote by uploading lacking
-  chunks/blobs.
+  This command will check and repair the remote, by default it will 
+  only repair by uploading lacking chunks/blobs. Options bring more 
+  specialized repairs.
 
 Options:
   --thorough       Try to download the IPLD if it is not present in the local

--- a/ml_git/commands/descriptor.py
+++ b/ml_git/commands/descriptor.py
@@ -481,7 +481,8 @@ commands = [
             'ml-entity-name': {}
         },
 
-        'help': 'This command will check and repair the remote by uploading lacking chunks/blobs.'
+        'help': 'This command will check and repair the remote, by default it will only repair by uploading lacking chunks/blobs. '
+                'Options bring more specialized repairs.'
 
     },
 

--- a/ml_git/file_system/local.py
+++ b/ml_git/file_system/local.py
@@ -647,8 +647,7 @@ class LocalRepository(MultihashFS):
 
         if len(submit_iplds_args['ipld_missing']) > 0:
             if thorough:
-                log.info(output_messages['INFO_MISSING_DESCRIPTOR_FILES_DOWNLOAD'] %
-                         str(len(submit_iplds_args['ipld_missing'])), class_name=LOCAL_REPOSITORY_CLASS_NAME)
+                log.info(output_messages['INFO_MISSING_DESCRIPTOR_FILES_DOWNLOAD'] % len(submit_iplds_args['ipld_missing']), class_name=LOCAL_REPOSITORY_CLASS_NAME)
                 self._work_pool_to_submit_file(manifest, retries, submit_iplds_args['ipld_missing'], self._fetch_ipld)
             else:
                 log.info(output_messages['INFO_MISSING_DESCRIPTOR_FILES'] %

--- a/ml_git/file_system/local.py
+++ b/ml_git/file_system/local.py
@@ -651,8 +651,7 @@ class LocalRepository(MultihashFS):
                          len(submit_iplds_args['ipld_missing']), class_name=LOCAL_REPOSITORY_CLASS_NAME)
                 self._work_pool_to_submit_file(manifest, retries, submit_iplds_args['ipld_missing'], self._fetch_ipld)
             else:
-                log.info(output_messages['INFO_MISSING_DESCRIPTOR_FILES'] %
-                         str(len(submit_iplds_args['ipld_missing'])), class_name=LOCAL_REPOSITORY_CLASS_NAME)
+                log.info(output_messages['INFO_MISSING_DESCRIPTOR_FILES'] % len(submit_iplds_args['ipld_missing']), class_name=LOCAL_REPOSITORY_CLASS_NAME)
                 if full_log:
                     log.info(output_messages['INFO_LIST_OF_MISSING_FILES'] % str(submit_iplds_args['ipld_missing']), class_name=LOCAL_REPOSITORY_CLASS_NAME)
                 else:

--- a/ml_git/file_system/local.py
+++ b/ml_git/file_system/local.py
@@ -647,7 +647,8 @@ class LocalRepository(MultihashFS):
 
         if len(submit_iplds_args['ipld_missing']) > 0:
             if thorough:
-                log.info(output_messages['INFO_MISSING_DESCRIPTOR_FILES_DOWNLOAD'] % len(submit_iplds_args['ipld_missing']), class_name=LOCAL_REPOSITORY_CLASS_NAME)
+                log.info(output_messages['INFO_MISSING_DESCRIPTOR_FILES_DOWNLOAD'] %
+                         len(submit_iplds_args['ipld_missing']), class_name=LOCAL_REPOSITORY_CLASS_NAME)
                 self._work_pool_to_submit_file(manifest, retries, submit_iplds_args['ipld_missing'], self._fetch_ipld)
             else:
                 log.info(output_messages['INFO_MISSING_DESCRIPTOR_FILES'] %

--- a/ml_git/file_system/local.py
+++ b/ml_git/file_system/local.py
@@ -644,13 +644,17 @@ class LocalRepository(MultihashFS):
 
         if len(submit_iplds_args['ipld_missing']) > 0:
             if thorough:
-                log.info(str(len(submit_iplds_args['ipld_missing'])) + ' missing descriptor files. Download: ',
-                         class_name=LOCAL_REPOSITORY_CLASS_NAME)
+                log.info(output_messages['INFO_MISSING_DESCRIPTOR_FILES_DOWNLOAD'] %
+                         str(len(submit_iplds_args['ipld_missing'])), class_name=LOCAL_REPOSITORY_CLASS_NAME)
                 self._work_pool_to_submit_file(manifest, retries, submit_iplds_args['ipld_missing'], self._fetch_ipld)
             else:
-                log.info(str(len(submit_iplds_args[
-                                     'ipld_missing'])) + ' missing descriptor files. Consider using the --thorough option.',
-                         class_name=LOCAL_REPOSITORY_CLASS_NAME)
+                log.info(output_messages['INFO_MISSING_DESCRIPTOR_FILES'] %
+                         str(len(submit_iplds_args['ipld_missing'])), class_name=LOCAL_REPOSITORY_CLASS_NAME)
+                if full_log:
+                    log.info(output_messages['INFO_LIST_OF_MISSING_FILES'] % str(submit_iplds_args['ipld_missing']), class_name=LOCAL_REPOSITORY_CLASS_NAME)
+                else:
+                    log.info(output_messages['INFO_SEE_COMPLETE_LIST_OF_MISSING_FILES'], class_name=LOCAL_REPOSITORY_CLASS_NAME)
+
         wp_blob = self._create_pool(self.__config, manifest[STORAGE_SPEC_KEY], retries, len(obj_files))
         submit_blob_args = {'wp': wp_blob, 'blob': 0, 'blob_fixed': 0, 'blob_unfixed': 0,
                             'full_log': full_log, 'blob_fixed_list': [], 'blob_unfixed_list': []}

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -177,9 +177,11 @@ output_messages = {
     'INFO_FILE_AUTOMATICALLY_ADDED': 'File {} has been automatically added to staged files.',
     'INFO_FSCK_CORRUPTED_FILES': '\n[%d] corrupted file(s) in Local Repository %s\n[%d] corrupted file(s) in Index %s\nTotal of corrupted files: %d',
     'INFO_FSCK_VERBOSE_MODE': 'For more information about the corrupted files you can run the command with the --full option.',
-    'INFO_SEE_ALL_CORRUPTED_FILES': 'You can view the complete list of corrupted files at logs/ml-git_execution.log',
+    'INFO_SEE_ALL_CORRUPTED_FILES': 'You can view the complete list of corrupted files using the status command.',
     'INFO_SEE_ALL_FIXED_FILES': 'You can view the complete list of fixed files at logs/ml-git_execution.log',
     'INFO_SEE_ALL_UNFIXED_FILES': 'You can view the complete list of unfixed files at logs/ml-git_execution.log',
+    'INFO_LIST_OF_MISSING_FILES': 'List of missing descriptor files: %s',
+    'INFO_SEE_COMPLETE_LIST_OF_MISSING_FILES': 'You can use the --full option to see the complete list of missing descriptor files.',
 
     'ERROR_PATH_NOT_EMPTY': 'The path [%s] is not an empty directory. Consider using --folder to create an empty folder.',
     'ERROR_WITHOUT_TAG_FOR_THIS_ENTITY': 'No entity with that name was found.',

--- a/tests/integration/test_13_remote_fsck.py
+++ b/tests/integration/test_13_remote_fsck.py
@@ -92,3 +92,17 @@ class RemoteFsckAcceptanceTests(unittest.TestCase):
         self.assertIn(output_messages['INFO_REMOTE_FSCK_FIXED'] % (0, 1), output)
         self.assertTrue(os.path.exists(os.path.join(MINIO_BUCKET_PATH, 'zdj7Wi996ViPiddvDGvzjBBACZzw6YfPujBCaPHunVoyiTUCj')))
         self.assertIn(output_messages['INFO_REMOTE_FSCK_FIXED_LIST'] % ('Blobs', ['zdj7Wi996ViPiddvDGvzjBBACZzw6YfPujBCaPHunVoyiTUCj']), output)
+
+    @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
+    def test_05_remote_fsck_thorough(self):
+        self.setup_remote_fsck()
+        file_path = self._get_file_path()
+        os.remove(file_path)
+
+        output_messages = check_output(MLGIT_REMOTE_FSCK % (DATASETS, DATASET_NAME))
+        self.assertIn(output_messages['INFO_MISSING_DESCRIPTOR_FILES'] % 1, output_messages)
+        self.assertIn(output_messages['INFO_SEE_COMPLETE_LIST_OF_MISSING_FILES'], output_messages)
+
+        output_messages = check_output(MLGIT_REMOTE_FSCK % (DATASETS, DATASET_NAME + ' --full'))
+        self.assertIn(output_messages['INFO_MISSING_DESCRIPTOR_FILES'] % 1, output_messages)
+        self.assertIn(output_messages['INFO_LIST_OF_MISSING_FILES'], output_messages)

--- a/tests/integration/test_13_remote_fsck.py
+++ b/tests/integration/test_13_remote_fsck.py
@@ -111,4 +111,4 @@ class RemoteFsckAcceptanceTests(unittest.TestCase):
 
         message = check_output(MLGIT_REMOTE_FSCK % (DATASETS, DATASET_NAME + ' --full'))
         self.assertIn(output_messages['INFO_MISSING_DESCRIPTOR_FILES'] % 1, message)
-        self.assertIn(output_messages['INFO_LIST_OF_MISSING_FILES'], message)
+        self.assertIn(output_messages['INFO_LIST_OF_MISSING_FILES'] % '[', message)

--- a/tests/integration/test_13_remote_fsck.py
+++ b/tests/integration/test_13_remote_fsck.py
@@ -100,15 +100,15 @@ class RemoteFsckAcceptanceTests(unittest.TestCase):
         self.assertIn(output_messages['WARN_EMPTY_ENTITY'] % DATASET_NAME, output)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
-    def test_06_remote_fsck_thorough(self):
+    def test_06_remote_fsck_missing_descriptor_files(self):
         self.setup_remote_fsck()
         file_path = self._get_file_path()
         os.remove(file_path)
 
-        output_messages = check_output(MLGIT_REMOTE_FSCK % (DATASETS, DATASET_NAME))
-        self.assertIn(output_messages['INFO_MISSING_DESCRIPTOR_FILES'] % 1, output_messages)
-        self.assertIn(output_messages['INFO_SEE_COMPLETE_LIST_OF_MISSING_FILES'], output_messages)
+        message = check_output(MLGIT_REMOTE_FSCK % (DATASETS, DATASET_NAME))
+        self.assertIn(output_messages['INFO_MISSING_DESCRIPTOR_FILES'] % 1, message)
+        self.assertIn(output_messages['INFO_SEE_COMPLETE_LIST_OF_MISSING_FILES'], message)
 
-        output_messages = check_output(MLGIT_REMOTE_FSCK % (DATASETS, DATASET_NAME + ' --full'))
-        self.assertIn(output_messages['INFO_MISSING_DESCRIPTOR_FILES'] % 1, output_messages)
-        self.assertIn(output_messages['INFO_LIST_OF_MISSING_FILES'], output_messages)
+        message = check_output(MLGIT_REMOTE_FSCK % (DATASETS, DATASET_NAME + ' --full'))
+        self.assertIn(output_messages['INFO_MISSING_DESCRIPTOR_FILES'] % 1, message)
+        self.assertIn(output_messages['INFO_LIST_OF_MISSING_FILES'], message)

--- a/tests/integration/test_13_remote_fsck.py
+++ b/tests/integration/test_13_remote_fsck.py
@@ -98,7 +98,7 @@ class RemoteFsckAcceptanceTests(unittest.TestCase):
         init_repository(DATASETS, self)
         output = check_output(MLGIT_REMOTE_FSCK % (DATASETS, DATASET_NAME))
         self.assertIn(output_messages['WARN_EMPTY_ENTITY'] % DATASET_NAME, output)
-        
+
     @pytest.mark.usefixtures('switch_to_tmp_dir', 'start_local_git_server')
     def test_06_remote_fsck_thorough(self):
         self.setup_remote_fsck()


### PR DESCRIPTION
It was observed that when using the `remote-fsck` command and detecting the missing of some IPLD, even with the `--full` option, the user could not see the list of missing files.

This PR has added treatment messages to inform the user that he can use the `--full` option to view the full list, and once he has used it, a message presenting the full list.

**Without --full option:**
```
$ ml-git models remote-fsck model-ex
iplds: 100%|████████████████████████████████| 1.00/1.00 [00:00<00:00, 1.87iplds/s]
INFO - Local Repository: 1 missing descriptor files. Consider using the --thorough option.
INFO - Local Repository: You can use the --full option to see the complete list of missing descriptor files.
blobs: 100%|████████████████████████████████| 2.00/2.00 [00:00<00:00, 667blobs/s]
INFO - MLGit: remote-fsck -- total   : ipld[1] / blob[2]
```

**With --full option:**
```
ml-git models remote-fsck model-ex --full
iplds: 100%|████████████████████████████████| 1.00/1.00 [00:00<00:00, 1.78iplds/s]
INFO - Local Repository: 1 missing descriptor files. Consider using the --thorough option.
INFO - Local Repository: List of missing descriptor files: ['zdj7WeNowmbNnWTnDv7QphAHARKVhJy7XD7pB2ugwkwzwyzNQ']
blobs: 100%|████████████████████████████████| 2.00/2.00 [00:00<00:00, 660blobs/s]
INFO - MLGit: remote-fsck -- total   : ipld[1] / blob[2]
```