### PR TITLE
Adding treatments in fsck command for repository and entity uninitialized

### DIFF
--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -689,8 +689,14 @@ class Repository(object):
         try:
             objects_path = get_objects_path(self.__config, repo_type)
             index_path = get_index_path(self.__config, repo_type)
-        except RootPathException:
+            metadata_path = get_metadata_path(self.__config, repo_type)
+            m = Metadata('', metadata_path, self.__config, repo_type)
+            if not m.check_exists():
+                raise RuntimeError(output_messages['INFO_NOT_INITIALIZED'] % self.__repo_type)
+        except Exception as e:
+            log.error(e, class_name=REPOSITORY_CLASS_NAME)
             return
+
         o = Objects('', objects_path)
         corrupted_files_obj = o.fsck()
         corrupted_files_obj_len = len(corrupted_files_obj)

--- a/tests/integration/test_14_fsck.py
+++ b/tests/integration/test_14_fsck.py
@@ -9,8 +9,8 @@ import unittest
 import pytest
 
 from ml_git.ml_git_message import output_messages
-from tests.integration.commands import MLGIT_FSCK
-from tests.integration.helper import check_output, init_repository, add_file, ML_GIT_DIR, DATASETS, LABELS, MODELS
+from tests.integration.commands import MLGIT_FSCK, MLGIT_INIT
+from tests.integration.helper import check_output, init_repository, add_file, ML_GIT_DIR, DATASETS, LABELS, MODELS, ERROR_MESSAGE
 
 
 @pytest.mark.usefixtures('tmp_dir')
@@ -38,7 +38,7 @@ class FsckAcceptanceTests(unittest.TestCase):
         self._fsck(MODELS)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
-    def test_03_fsck_with_full_option(self):
+    def test_04_fsck_with_full_option(self):
         entity = DATASETS
         init_repository(entity, self)
         add_file(self, entity, '', 'new', file_content='2')
@@ -49,3 +49,14 @@ class FsckAcceptanceTests(unittest.TestCase):
         output = check_output((MLGIT_FSCK % entity) + ' --full')
         self.assertIn(output_messages['INFO_CORRUPTED_FILES_TOTAL'] % 2, output)
         self.assertIn('zdj7WdrvGPx9s8wmSB6KJGCmfCRNDQX6i8kVfFenQbWDQ1pmd', output)
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_05_fsck_in_not_initialized_repository(self):
+        entity = DATASETS
+        self.assertIn(output_messages['ERROR_NOT_IN_RESPOSITORY'], check_output(MLGIT_FSCK % entity))
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_06_fsck_with_not_initialized_entity(self):
+        entity = DATASETS
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_INIT))
+        self.assertIn(output_messages['INFO_NOT_INITIALIZED'] % entity, check_output(MLGIT_FSCK % entity))


### PR DESCRIPTION
It was observed that when executing the fsck command in a directory that does not have an initialized ml-git project or that the command entity has not been initialized, the user did not receive adequate feedback. This PR added handling for these scenarios.

**Uninitialized Project:**
```
$ ml-git datasets fsck
ERROR - Repository: You are not in an initialized ml-git repository.
A complete log of this run can be found in: ml-git_execution.log
```

**Uninitialized Entity:**
```
$ ml-git datasets fsck
ERROR - Repository: The datasets doesn't have been initialized.
A complete log of this run can be found in: ml-git_execution.log
```
