### PR TITLE
Checking if the user is in a valid directory when running the add command

### DIFF
--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -99,14 +99,14 @@ class Repository(object):
         is_shared_objects = 'objects_path' in self.__config[repo_type]
         is_shared_cache = 'cache_path' in self.__config[repo_type]
 
-        if not validate_config_spec_hash(self.__config):
-            log.error(output_messages['ERROR_INVALID_YAML_CONFIG']
-                      % get_yaml_str(get_sample_config_spec('somebucket', 'someprofile', 'someregion')),
-                      class_name=REPOSITORY_CLASS_NAME)
-            return None
-
         path, file = None, None
         try:
+            get_root_path()
+            if not validate_config_spec_hash(self.__config):
+                log.error(output_messages['ERROR_INVALID_YAML_CONFIG']
+                          % get_yaml_str(get_sample_config_spec('somebucket', 'someprofile', 'someregion')),
+                          class_name=REPOSITORY_CLASS_NAME)
+                return None
 
             refs_path = get_refs_path(self.__config, repo_type)
             index_path = get_index_path(self.__config, repo_type)

--- a/tests/integration/test_05_add_files.py
+++ b/tests/integration/test_05_add_files.py
@@ -318,3 +318,14 @@ class AddFilesAcceptanceTests(unittest.TestCase):
             f.write('')
         metrics_options = '--metrics-file="{}"'.format(csv_file)
         self.assertIn(output_messages['ERROR_INVALID_METRICS_FILE'], check_output(MLGIT_ADD % (repo_type, entity_name, metrics_options)))
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir', 'create_csv_file')
+    def test_18_add_command_in_not_initialized_repository(self):
+        repo_type = MODELS
+        entity_name = '{}-ex'.format(repo_type)
+        self.assertIn(output_messages['ERROR_NOT_IN_RESPOSITORY'], check_output(MLGIT_ADD % (repo_type, entity_name, '')))
+        metadata = os.path.join(self.tmp_dir, ML_GIT_DIR, repo_type, 'index', 'metadata', entity_name)
+        metadata_file = os.path.join(metadata, 'MANIFEST.yaml')
+        index_file = os.path.join(metadata, 'INDEX.yaml')
+        self.assertFalse(os.path.exists(metadata_file))
+        self.assertFalse(os.path.exists(index_file))


### PR DESCRIPTION
It was observed that when executing the `add` command in a directory that has not yet started an ml-git project, the tool's output does not match the real error and did not follow the pattern of the other commands.

**Observed behavior:**
```
$ ml-git datasets add dataset-ex
ERROR - Repository: .ml-git/config.yaml invalid. It should look something like this:
storages:
  s3h:
    somebucket:
      aws-credentials:
        profile: someprofile
      region: someregion

A complete log of this run can be found in: ml-git_execution.log
```

**Fixed behavior:**
```
$ ml-git datasets add dataset-ex
ERROR - Repository: You are not in an initialized ml-git repository.
A complete log of this run can be found in: ml-git_execution.log
```