### PR TITLE
Prompt user for values for dependent options

### DIFF
--- a/ml_git/commands/custom_options.py
+++ b/ml_git/commands/custom_options.py
@@ -1,11 +1,12 @@
 """
-© Copyright 2020-2021 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
 from click import Option, UsageError, MissingParameter, Command
 
 from ml_git import log
+from ml_git.commands.wizard import wizard_for_field
 from ml_git.ml_git_message import output_messages
 
 
@@ -50,11 +51,13 @@ class OptionRequiredIf(Option):
     def handle_parse_result(self, ctx, opts, args):
         using_required_option = self.name in opts
         using_dependent_options = all(opt.replace('-', '_') in opts for opt in self.required_option)
+        option_name = self.name.replace('_', '-')
         if not using_required_option and using_dependent_options:
-            msg = output_messages['ERROR_REQUIRED_OPTION_MISSING'].format(self.name, ', '.join(self.required_option))
-            raise MissingParameter(ctx=ctx, param=self, message=msg)
+            msg = output_messages['ERROR_REQUIRED_OPTION_MISSING'].format(option_name, ', '.join(self.required_option), option_name)
+            requested_value = wizard_for_field(ctx, None, msg, required=True)
+            opts[self.name] = requested_value
+            return super(OptionRequiredIf, self).handle_parse_result(ctx, opts, args)
         elif using_required_option and not using_dependent_options:
-            option_name = self.name.replace('_', '-')
             log.warn(output_messages['WARN_USELESS_OPTION'].format(option_name, ', '.join(self.required_option)))
         return super(OptionRequiredIf, self).handle_parse_result(ctx, opts, args)
 

--- a/ml_git/commands/custom_options.py
+++ b/ml_git/commands/custom_options.py
@@ -3,7 +3,7 @@
 SPDX-License-Identifier: GPL-2.0-only
 """
 
-from click import Option, UsageError, MissingParameter, Command
+from click import Option, UsageError, Command
 
 from ml_git import log
 from ml_git.commands.wizard import wizard_for_field

--- a/ml_git/commands/wizard.py
+++ b/ml_git/commands/wizard.py
@@ -15,8 +15,11 @@ def check_empty_for_none(value):
     return value if value != EMPTY_FOR_NONE else None
 
 
-def request_new_value(input_message):
-    field_value = click.prompt(input_message, default=EMPTY_FOR_NONE, show_default=False)
+def request_new_value(input_message, required=False):
+    default = EMPTY_FOR_NONE
+    if required:
+        default = None
+    field_value = click.prompt(input_message, default=default, show_default=False)
     return field_value
 
 
@@ -25,13 +28,13 @@ def request_user_confirmation(confimation_message):
     return should_continue
 
 
-def wizard_for_field(context, field, input_message):
+def wizard_for_field(context, field, input_message, required=False):
     config_file = merged_config_load()
     if field or (WIZARD_ENABLE_KEY in config_file and not config_file[WIZARD_ENABLE_KEY]):
         return field
     else:
         try:
-            new_field = check_empty_for_none(request_new_value(input_message))
+            new_field = check_empty_for_none(request_new_value(input_message, required))
             return new_field
         except Exception:
             context.exit()

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -327,7 +327,7 @@ output_messages = {
     'ERROR_PUSH_CONFIG': 'Could not push configuration file. ERROR: %s',
     'ERROR_FIND_FILE_PATH_LOCATION': 'A complete log of this run can be found in: %s',
     'ERROR_EMPTY_VALUE': 'Value cannot be empty.',
-    'ERROR_REQUIRED_OPTION_MISSING': 'The option `{}` is required if `{}` is used.',
+    'ERROR_REQUIRED_OPTION_MISSING': 'The option `{}` is required if `{}` is used. Please, inform the value for the `{}`',
     'ERROR_TAGS_NOT_MATCH_WITH_ENTITY': 'The tags do not match the entity name',
     'ERROR_INVALID_METRICS_FILE': 'It was not possible to obtain the metrics from the informed file, please check if the file is correctly formatted.',
 

--- a/tests/integration/test_38_models_metrics.py
+++ b/tests/integration/test_38_models_metrics.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 import csv
@@ -9,8 +9,10 @@ import unittest
 from datetime import datetime
 
 import pytest
+from click.testing import CliRunner
 from prettytable import PrettyTable
 
+from ml_git.commands import entity
 from ml_git.constants import FileType, DATE, RELATED_DATASET_TABLE_INFO, RELATED_LABELS_TABLE_INFO, TAG
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_ADD, MLGIT_MODELS_METRICS
@@ -120,9 +122,9 @@ class ModelsMetricsAcceptanceTests(unittest.TestCase):
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_04_export_metrics_without_export_path(self):
-        repo_type = MODELS
-        entity_name = '{}-ex'.format(repo_type)
-        self.set_up_test(repo_type)
-        self.assertIn(output_messages['ERROR_REQUIRED_OPTION_MISSING'].format('export_path', 'export-type'),
-                      check_output(MLGIT_MODELS_METRICS %
-                                   (entity_name, ' --export-type={}'.format(FileType.CSV.value))))
+        runner = CliRunner()
+        used_option = 'export-type'
+        required_option = 'export-path'
+        result = runner.invoke(entity.models, ['metrics', 'ENTITY_NAME', '--export-type=csv'], input='CREDENTIALS_PATH\n')
+        self.assertIn(output_messages['ERROR_REQUIRED_OPTION_MISSING']
+                      .format(required_option, used_option, required_option), result.output)


### PR DESCRIPTION
**Observed behaviour:**
```
$ ml-git datasets create dataset-ex --import-url='test' --categories=test --mutability=strict
Usage: ml-git datasets create [OPTIONS] ARTIFACT_NAME

Error: Missing option "--credentials-path". The option `credentials_path` is required if `import-url` is used.
```

**Fixed behaviour:**
```
$ ml-git datasets create dataset-ex --import-url='test' --categories=test --mutability=strict
The option `credentials-path` is required if `import-url` is used. Please, inform the value for the `credentials-path`:
```