### PR TITLE
Updating the error message when identifying an invalid category

### DIFF
--- a/ml_git/commands/custom_types.py
+++ b/ml_git/commands/custom_types.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2021 HP Development Company, L.P.
+© Copyright 2021-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
@@ -60,7 +60,7 @@ class GitTagName(NotEmptyString):
     def convert(self, value, param, ctx):
         tag_name = super().convert(value, param, ctx)
         if not re.match(RGX_TAG_NAME, tag_name):
-            self.fail(value, param, ctx)
+            self.fail(output_messages['ERROR_INVALID_VALUE'].format(value), param, ctx)
         return tag_name
 
 

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -327,6 +327,7 @@ output_messages = {
     'ERROR_PUSH_CONFIG': 'Could not push configuration file. ERROR: %s',
     'ERROR_FIND_FILE_PATH_LOCATION': 'A complete log of this run can be found in: %s',
     'ERROR_EMPTY_VALUE': 'Value cannot be empty.',
+    'ERROR_INVALID_VALUE': 'The value \'{}\' is invalid. A category cannot contain blank space, special characters, and punctuation characters.',
     'ERROR_REQUIRED_OPTION_MISSING': 'The option `{}` is required if `{}` is used. Please, inform the value for the `{}`',
     'ERROR_TAGS_NOT_MATCH_WITH_ENTITY': 'The tags do not match the entity name',
     'ERROR_INVALID_METRICS_FILE': 'It was not possible to obtain the metrics from the informed file, please check if the file is correctly formatted.',

--- a/tests/integration/test_19_create.py
+++ b/tests/integration/test_19_create.py
@@ -311,8 +311,9 @@ class CreateAcceptanceTests(unittest.TestCase):
                                     'category&']
 
         for invalid_category_name in invalid_categories_names:
-            self.assertIn(invalid_category_name, check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
-                          + ' --categories="{}" --version=1 --mutability=strict'.format(invalid_category_name)))
+            self.assertIn(output_messages['ERROR_INVALID_VALUE'].format(invalid_category_name),
+                          check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
+                                       + ' --categories="{}" --version=1 --mutability=strict'.format(invalid_category_name)))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_25_create_with_invalid_version_number(self):


### PR DESCRIPTION
**Observed behaviour:**
```
$ ml-git datasets create dataset=ex
At least one category must be defined. The categories' names must be comma-separated. Please inform the value for the categories option: wrong name
Error: wrong name
```

**After adjustments:**
```
$ ml-git datasets create dataset=ex
At least one category must be defined. The categories' names must be comma-separated. Please inform the value for the categories option: wrong name
Error: The value 'wrong name' is invalid. A category cannot contain blank space, special characters, and punctuation characters.
```