### PR TITLE
 Adding the wizard option to commands that support it

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ git config --global user.name "Your User"
 git config --global user.email "your_email@example.com"
 ```
 
-2 - **(OPTIONAL)** ML-Git has a wizard that will request the necessary information, when not informed, to execute the commands. We strongly recommend that you enable this wizard especially if you are a novice user. To enable, run the following command:
+2 - **(OPTIONAL)** Some ML-Git commands have a wizard to help you during their execution. These commands have the ```--wizard``` option to enable this wizard. However, you can configure the wizard to be enabled by default on all supported commands by running the following command:
 
 ```
 ml-git repository config --set-wizard=enabled

--- a/docs/mlgit_commands.md
+++ b/docs/mlgit_commands.md
@@ -42,11 +42,14 @@ Usage: ml-git datasets add [OPTIONS] ML_ENTITY_NAME [FILE_PATH]...
   Add datasets change set ML_ENTITY_NAME to the local ml-git staging area.
 
 Options:
-  --bumpversion  Increment the version number when adding more files.
-  --fsck         Run fsck after command execution.
-  --metric       Insert the metric key and value.
-  --metrics-file Insert the methic file path. It is expected a CSV file containing the metric names in the header and the values in the next line.
-  --help         Show this message and exit.
+  --bumpversion                   Increment the version number when adding
+                                  more files.
+  --fsck                          Run fsck after command execution.
+  --metric <TEXT FLOAT>...        Metric key and value.
+  --metrics-file                  Metrics file path.
+  --wizard                        Enable the wizard to prompt the user
+                                  requesting information when needed.
+  --verbose                       Debug mode
 ```
 
 Dataset example:
@@ -173,6 +176,8 @@ Options:
   -m, --message TEXT              Use the provided <msg> as the commit
                                   message.
   --fsck                          Run fsck after command execution.
+  --wizard                        Enable the wizard to prompt the user requesting
+                                  information when needed.
   --verbose                       Debug mode
 ```
 
@@ -228,6 +233,8 @@ Options:
                                   if --import-url is used.
   --entity-dir TEXT               The relative path where the entity will be
                                   created inside the ml entity directory.
+  --wizard                        Enable the wizard to prompt the user
+                                  requesting information when needed.
   --verbose                       Debug mode
 ```
 
@@ -1077,16 +1084,18 @@ Usage: ml-git repository storage add [OPTIONS] BUCKET_NAME
 
 Options:
   --credentials TEXT              Profile name for storage credentials
-  --region TEXT                   AWS region name for S3 bucket
   --type [s3h|azureblobh|gdriveh|sftph]
                                   Storage type (s3h, azureblobh, gdriveh,
                                   sftph) [default: s3h]
+  --region TEXT                   AWS region name for S3 bucket
   --endpoint-url TEXT             Storage endpoint url.
   --username TEXT                 The username for the sftp login.
   --private-key TEXT              Full path for the private key file.
   --port INTEGER                  SFTP port [default: 22].
   -g, --global                    Use this option to set configuration at
                                   global level
+  --wizard                        Enable the wizard to prompt the user
+                                  requesting information when needed.
   --verbose                       Debug mode
 ```
 

--- a/ml_git/commands/descriptor.py
+++ b/ml_git/commands/descriptor.py
@@ -7,7 +7,7 @@ import copy
 
 import click
 
-from ml_git.commands import entity, help_msg, storage, prompt_msg
+from ml_git.commands import entity, help_msg, storage
 from ml_git.commands.custom_options import MutuallyExclusiveOption, OptionRequiredIf, DeprecatedOptionsCommand, \
     DeprecatedOption
 from ml_git.commands.custom_types import CategoriesType, NotEmptyString

--- a/ml_git/commands/descriptor.py
+++ b/ml_git/commands/descriptor.py
@@ -3,15 +3,16 @@
 SPDX-License-Identifier: GPL-2.0-only
 """
 
-import click
 import copy
 
+import click
+
 from ml_git.commands import entity, help_msg, storage, prompt_msg
-from ml_git.commands.custom_options import MutuallyExclusiveOption, OptionRequiredIf, DeprecatedOptionsCommand
+from ml_git.commands.custom_options import MutuallyExclusiveOption, OptionRequiredIf, DeprecatedOptionsCommand, \
+    DeprecatedOption
 from ml_git.commands.custom_types import CategoriesType, NotEmptyString
 from ml_git.commands.utils import set_verbose_mode
-from ml_git.commands.wizard import WIZARD_KEY, WizardMode
-from ml_git.config import merged_config_load
+from ml_git.commands.wizard import is_wizard_enabled
 from ml_git.constants import MultihashStorageType, MutabilityType, StorageType, FileType
 
 commands = [
@@ -261,6 +262,7 @@ commands = [
             '--fsck': {'is_flag': True, 'help': help_msg.FSCK_OPTION},
             '--metric': {'required': False, 'multiple': True, 'type': (str, float), 'help': help_msg.METRIC_OPTION},
             '--metrics-file': {'type': NotEmptyString(), 'required': False, 'help': help_msg.METRICS_FILE_OPTION},
+            '--wizard': {'is_flag': True, 'default': False, 'help': help_msg.WIZARD_OPTION}
         },
 
         'help': 'Add %s change set ML_ENTITY_NAME to the local ml-git staging area.'
@@ -297,11 +299,12 @@ commands = [
         },
 
         'options': {
-            '--dataset': {'help': help_msg.LINK_DATASET_TO_LABEL, 'default': prompt_msg.EMPTY_FOR_NONE, 'prompt': prompt_msg.LINKED_DATASET_TO_LABEL_MESSAGE},
+            '--dataset': {'help': help_msg.LINK_DATASET_TO_LABEL, 'type': NotEmptyString()},
             '--tag': {'help': help_msg.TAG_OPTION},
             '--version': {'type': click.IntRange(0, int(8 * '9')), 'help': help_msg.SET_VERSION_NUMBER},
             ('--message', '-m'): {'help': help_msg.COMMIT_MSG},
             '--fsck': {'is_flag': True, 'help': help_msg.FSCK_OPTION},
+            '--wizard': {'is_flag': True, 'default': False, 'help': help_msg.WIZARD_OPTION}
         },
 
         'help': 'Commit labels change set of ML_ENTITY_NAME locally to this ml-git repository.'
@@ -318,14 +321,13 @@ commands = [
         },
 
         'options': {
-            '--dataset': {'help': help_msg.LINK_DATASET, 'default': prompt_msg.EMPTY_FOR_NONE,
-                          'prompt': prompt_msg.LINKED_DATASET_TO_MODEL_MESSAGE, 'type': NotEmptyString()},
-            '--labels': {'help': help_msg.LINK_LABELS, 'default': prompt_msg.EMPTY_FOR_NONE, 'type': NotEmptyString(),
-                         'prompt': prompt_msg.LINKED_LABEL_TO_MODEL_MESSAGE},
+            '--dataset': {'help': help_msg.LINK_DATASET, 'type': NotEmptyString()},
+            '--labels': {'help': help_msg.LINK_LABELS, 'type': NotEmptyString()},
             '--tag': {'help': help_msg.TAG_OPTION},
             '--version': {'type': click.IntRange(0, int(8 * '9')), 'help': help_msg.SET_VERSION_NUMBER},
             ('--message', '-m'): {'help': help_msg.COMMIT_MSG},
             '--fsck': {'is_flag': True, 'help': help_msg.FSCK_OPTION},
+            '--wizard': {'is_flag': True, 'default': False, 'help': help_msg.WIZARD_OPTION}
         },
 
         'help': 'Commit model change set of ML_ENTITY_NAME locally to this ml-git repository.'
@@ -498,9 +500,8 @@ commands = [
         'groups': [entity.datasets, entity.models, entity.labels],
 
         'options': {
-            '--categories': {'required': True, 'type': CategoriesType(), 'help': help_msg.CATEGORIES_OPTION, 'prompt': prompt_msg.CATEGORIES_MESSAGE},
-            '--mutability': {'required': True, 'type': click.Choice(MutabilityType.to_list()),
-                             'help': help_msg.MUTABILITY, 'prompt': prompt_msg.MUTABILITY_MESSAGE},
+            '--categories': {'type': CategoriesType(), 'help': help_msg.CATEGORIES_OPTION},
+            '--mutability': {'type': click.Choice(MutabilityType.to_list()), 'help': help_msg.MUTABILITY},
             '--storage-type': {
                 'type': click.Choice(MultihashStorageType.to_list(),
                                      case_sensitive=True),
@@ -509,7 +510,8 @@ commands = [
             '--version': {'type': click.IntRange(0, int(8 * '9')), 'help': help_msg.SET_VERSION_NUMBER, 'default': 1},
             '--import': {'help': help_msg.IMPORT_OPTION, 'type': NotEmptyString(),
                          'cls': MutuallyExclusiveOption, 'mutually_exclusive': ['import_url', 'credentials_path']},
-            '--wizard-config': {'is_flag': True, 'help': help_msg.WIZARD_CONFIG},
+            '--wizard-config': {'is_flag': True, 'help': help_msg.WIZARD_CONFIG, 'cls': DeprecatedOption,
+                                'deprecated': [' This option should no longer be used.']},
             '--bucket-name': {'type': NotEmptyString(), 'help': help_msg.BUCKET_NAME},
             '--import-url': {'help': help_msg.IMPORT_URL,
                              'type': NotEmptyString(),
@@ -517,7 +519,8 @@ commands = [
             '--credentials-path': {'default': None, 'type': NotEmptyString(), 'help': help_msg.CREDENTIALS_PATH,
                                    'cls': OptionRequiredIf, 'required_option': ['import-url']},
             '--unzip': {'help': help_msg.UNZIP_OPTION, 'is_flag': True},
-            '--entity-dir': {'type': NotEmptyString(), 'help': help_msg.ENTITY_DIR}
+            '--entity-dir': {'type': NotEmptyString(), 'help': help_msg.ENTITY_DIR},
+            '--wizard': {'is_flag': True, 'default': False, 'help': help_msg.WIZARD_OPTION}
         },
 
         'arguments': {
@@ -577,16 +580,15 @@ commands = [
 
         'options': {
             '--credentials': {'help': help_msg.STORAGE_CREDENTIALS},
-            '--type': {'default': StorageType.S3H.value,
-                       'type': click.Choice(MultihashStorageType.to_list(), case_sensitive=True),
-                       'help': help_msg.STORAGE_TYPE_MULTIHASH,
-                       'prompt': prompt_msg.STORAGE_TYPE_MESSAGE},
+            '--type': {'type': click.Choice(MultihashStorageType.to_list(), case_sensitive=True),
+                       'help': help_msg.STORAGE_TYPE_MULTIHASH},
             '--region': {'help': help_msg.STORAGE_REGION},
             '--endpoint-url': {'help': help_msg.ENDPOINT_URL},
             '--username': {'help': help_msg.USERNAME},
             '--private-key': {'help': help_msg.PRIVATE_KEY},
             '--port': {'help': help_msg.PORT, 'default': 22},
             ('--global', '-g'): {'is_flag': True, 'default': False, 'help': help_msg.GLOBAL_OPTION},
+            '--wizard': {'is_flag': True, 'default': False, 'help': help_msg.WIZARD_OPTION}
         },
 
         'help': help_msg.STORAGE_ADD_COMMAND
@@ -650,10 +652,9 @@ def define_command(descriptor):
         for key, value in descriptor['arguments'].items():
             command = click.argument(key, **value)(command)
 
-    config_file = merged_config_load()
     if 'options' in descriptor:
         for key, value in descriptor['options'].items():
-            if WIZARD_KEY in config_file and config_file[WIZARD_KEY] == WizardMode.DISABLED.value:
+            if not is_wizard_enabled():
                 value.pop('prompt', None)
             if type(key) == tuple:
                 click_option = click.option(*key, **value)

--- a/ml_git/commands/entity.py
+++ b/ml_git/commands/entity.py
@@ -4,14 +4,14 @@ SPDX-License-Identifier: GPL-2.0-only
 """
 
 import click
-from click import MissingParameter, UsageError
+from click import UsageError
 from click_didyoumean import DYMGroup
 
 from ml_git.commands import prompt_msg
 from ml_git.commands.custom_types import CategoriesType
 from ml_git.commands.general import mlgit
 from ml_git.commands.utils import repositories, LABELS, DATASETS, MODELS
-from ml_git.commands.wizard import check_empty_for_none, wizard_for_field, choise_wizard_for_field
+from ml_git.commands.wizard import wizard_for_field, choise_wizard_for_field
 from ml_git.constants import EntityType, MutabilityType
 from ml_git.ml_git_message import output_messages
 
@@ -255,7 +255,7 @@ def create(context, **kwargs):
     if not kwargs['categories']:
         raise UsageError(output_messages['ERROR_MISSING_OPTION'].format('categories'))
     kwargs['mutability'] = choise_wizard_for_field(context, kwargs['mutability'], prompt_msg.MUTABILITY_MESSAGE,
-                                             click.Choice(MutabilityType.to_list()), default=None, wizard_flag=wizard_flag)
+                                                   click.Choice(MutabilityType.to_list()), default=None, wizard_flag=wizard_flag)
     if not kwargs['mutability']:
         raise UsageError(output_messages['ERROR_MISSING_OPTION'].format('mutability'))
     repo_type = context.parent.command.name

--- a/ml_git/commands/entity.py
+++ b/ml_git/commands/entity.py
@@ -134,7 +134,9 @@ def add(context, **kwargs):
 
 
 def commit(context, **kwargs):
-    wizard_flag = kwargs['wizard']
+    wizard_flag = False
+    if 'wizard' in kwargs:
+        wizard_flag = kwargs['wizard']
     repo_type = context.parent.command.name
     linked_dataset_key = 'dataset'
     msg = kwargs['message']

--- a/ml_git/commands/entity.py
+++ b/ml_git/commands/entity.py
@@ -4,13 +4,16 @@ SPDX-License-Identifier: GPL-2.0-only
 """
 
 import click
+from click import MissingParameter, UsageError
 from click_didyoumean import DYMGroup
 
 from ml_git.commands import prompt_msg
+from ml_git.commands.custom_types import CategoriesType
 from ml_git.commands.general import mlgit
 from ml_git.commands.utils import repositories, LABELS, DATASETS, MODELS
-from ml_git.commands.wizard import check_empty_for_none, wizard_for_field
-from ml_git.constants import EntityType
+from ml_git.commands.wizard import check_empty_for_none, wizard_for_field, choise_wizard_for_field
+from ml_git.constants import EntityType, MutabilityType
+from ml_git.ml_git_message import output_messages
 
 
 @mlgit.group(DATASETS, help='Management of datasets within this ml-git repository.', cls=DYMGroup)
@@ -125,11 +128,13 @@ def add(context, **kwargs):
     metric = kwargs.get('metric')
     metrics_file_path = kwargs.get('metrics_file')
     if not metric and repo_type == MODELS:
-        metrics_file_path = wizard_for_field(context, kwargs.get('metrics_file'), prompt_msg.METRIC_FILE)
+        metrics_file_path = wizard_for_field(context, kwargs.get('metrics_file'),
+                                             prompt_msg.METRIC_FILE, wizard_flag=kwargs['wizard'])
     repositories[repo_type].add(entity_name, file_path, bump_version, run_fsck, metric, metrics_file_path)
 
 
 def commit(context, **kwargs):
+    wizard_flag = kwargs['wizard']
     repo_type = context.parent.command.name
     linked_dataset_key = 'dataset'
     msg = kwargs['message']
@@ -140,10 +145,13 @@ def commit(context, **kwargs):
     labels_tag = None
 
     if repo_type == MODELS:
-        dataset_tag = check_empty_for_none(kwargs[linked_dataset_key])
-        labels_tag = check_empty_for_none(kwargs[EntityType.LABELS.value])
+        dataset_tag = wizard_for_field(context, kwargs[linked_dataset_key],
+                                       prompt_msg.LINKED_DATASET_TO_MODEL_MESSAGE, wizard_flag=wizard_flag)
+        labels_tag = wizard_for_field(context, kwargs[EntityType.LABELS.value],
+                                      prompt_msg.LINKED_LABEL_TO_MODEL_MESSAGE, wizard_flag=wizard_flag)
     elif repo_type == LABELS:
-        dataset_tag = check_empty_for_none(kwargs[linked_dataset_key])
+        dataset_tag = wizard_for_field(context, kwargs[linked_dataset_key],
+                                       prompt_msg.LINKED_DATASET_TO_LABEL_MESSAGE, wizard_flag=wizard_flag)
     tags = {}
     if dataset_tag is not None:
         tags[EntityType.DATASETS.value] = dataset_tag
@@ -239,6 +247,15 @@ def remote_fsck(context, **kwargs):
 
 
 def create(context, **kwargs):
+    wizard_flag = kwargs['wizard']
+    kwargs['categories'] = wizard_for_field(context, kwargs['categories'], prompt_msg.CATEGORIES_MESSAGE,
+                                            wizard_flag=wizard_flag, required=True, type=CategoriesType())
+    if not kwargs['categories']:
+        raise UsageError(output_messages['ERROR_MISSING_OPTION'].format('categories'))
+    kwargs['mutability'] = choise_wizard_for_field(context, kwargs['mutability'], prompt_msg.MUTABILITY_MESSAGE,
+                                             click.Choice(MutabilityType.to_list()), default=None, wizard_flag=wizard_flag)
+    if not kwargs['mutability']:
+        raise UsageError(output_messages['ERROR_MISSING_OPTION'].format('mutability'))
     repo_type = context.parent.command.name
     repositories[repo_type].create(kwargs)
 

--- a/ml_git/commands/help_msg.py
+++ b/ml_git/commands/help_msg.py
@@ -48,7 +48,7 @@ THOROUGH_OPTION = 'Try to download the IPLD if it is not present in the local re
 PARANOID_OPTION = 'Adds an additional step that will download all ' \
                   'IPLD and its associated IPLD links to verify the content by ' \
                   'computing the multihash of all these.'
-CATEGORIES_OPTION = 'Artifact\'s categories names. The categories names must be separated by comma. E.g: "category1,category2,category3"'
+CATEGORIES_OPTION = 'Artifact\'s categories names. The categories names must be separated by comma. E.g: "category1,category2,category3" [required]'
 VERSION_NUMBER = 'Number of artifact version.'
 IMPORT_OPTION = 'Path to be imported to the project.'
 WIZARD_CONFIG = 'If specified, ask interactive questions at console for git & storage configurations.'
@@ -60,7 +60,7 @@ STAT_OPTION = 'Show amount of files and size of an ml-entity.'
 FULL_STAT_OPTION = 'Show added and deleted files.'
 SET_VERSION_NUMBER = 'Set the version number of the artifact. This number must be in the range 0 to 999999999.'
 ARTIFACT_VERSION = 'Number of artifact version to be downloaded [default: latest].'
-MUTABILITY = 'Mutability type.'
+MUTABILITY = 'Mutability type. [required]'
 STATUS_FULL_OPTION = 'Show all contents for each directory.'
 STORAGE_CREDENTIALS = 'Profile name for storage credentials'
 STORAGE_REGION = 'AWS region name for S3 bucket'
@@ -86,3 +86,4 @@ CREATE_COMMAND = 'This command will create the workspace structure with data and
                  'if it is not informed]'
 STORAGE_ADD_COMMAND = 'Add a storage BUCKET_NAME to ml-git. [This command has a wizard that will request the necessary' \
                       ' information if it is not informed]'
+WIZARD_OPTION = 'Enable the wizard to prompt the user requesting information when needed.'

--- a/ml_git/commands/storage.py
+++ b/ml_git/commands/storage.py
@@ -2,15 +2,16 @@
 © Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
-
+import click
 from click_didyoumean import DYMGroup
 
 from ml_git import admin
+from ml_git.commands import prompt_msg
 from ml_git.commands.prompt_msg import CREDENTIALS_PROFILE_MESSAGE, REGION_MESSAGE, ENDPOINT_MESSAGE, \
     CREDENTIALS_PATH_MESSAGE, USERNAME_SFTPH, PRIVATE_KEY_SFTPH, SFTPH_ENDPOINT_MESSAGE
 from ml_git.commands.repository import repository
-from ml_git.commands.wizard import wizard_for_field
-from ml_git.constants import StorageType
+from ml_git.commands.wizard import wizard_for_field, choise_wizard_for_field
+from ml_git.constants import StorageType, MultihashStorageType
 
 
 @repository.group('storage', help='Storage management for this ml-git repository.', cls=DYMGroup)
@@ -22,19 +23,27 @@ def storage():
 
 
 def storage_add(context, **kwargs):
+    wizard_flag = kwargs['wizard']
+    kwargs['type'] = choise_wizard_for_field(context, kwargs['type'], prompt_msg.STORAGE_TYPE_MESSAGE,
+                                             click.Choice(MultihashStorageType.to_list()), default=StorageType.S3H.value,
+                                             wizard_flag=wizard_flag)
     if kwargs['type'] == StorageType.S3H.value:
-        admin.storage_add(kwargs['type'], kwargs['bucket_name'], wizard_for_field(context, kwargs['credentials'], CREDENTIALS_PROFILE_MESSAGE),
-                          global_conf=kwargs['global'], endpoint_url=wizard_for_field(context, kwargs['endpoint_url'], ENDPOINT_MESSAGE),
-                          region=wizard_for_field(context, kwargs['region'], REGION_MESSAGE))
+        admin.storage_add(kwargs['type'], kwargs['bucket_name'],
+                          wizard_for_field(context, kwargs['credentials'], CREDENTIALS_PROFILE_MESSAGE, wizard_flag=wizard_flag),
+                          global_conf=kwargs['global'],
+                          endpoint_url=wizard_for_field(context, kwargs['endpoint_url'], ENDPOINT_MESSAGE, wizard_flag=wizard_flag),
+                          region=wizard_for_field(context, kwargs['region'], REGION_MESSAGE, wizard_flag=wizard_flag))
     elif kwargs['type'] == StorageType.GDRIVEH.value:
         admin.storage_add(kwargs['type'], kwargs['bucket_name'],
-                          wizard_for_field(context, kwargs['credentials'], CREDENTIALS_PATH_MESSAGE), global_conf=kwargs['global'])
+                          wizard_for_field(context, kwargs['credentials'], CREDENTIALS_PATH_MESSAGE, wizard_flag=wizard_flag),
+                          global_conf=kwargs['global'])
     elif kwargs['type'] == StorageType.SFTPH.value:
-        sftp_configs = {'username':  wizard_for_field(context, kwargs['username'], USERNAME_SFTPH),
-                        'private_key':  wizard_for_field(context, kwargs['private_key'], PRIVATE_KEY_SFTPH),
+        sftp_configs = {'username':  wizard_for_field(context, kwargs['username'], USERNAME_SFTPH, wizard_flag=wizard_flag),
+                        'private_key':  wizard_for_field(context, kwargs['private_key'], PRIVATE_KEY_SFTPH, wizard_flag=wizard_flag),
                         'port': kwargs['port']}
         admin.storage_add(kwargs['type'], kwargs['bucket_name'], kwargs['credentials'],
-                          global_conf=kwargs['global'], endpoint_url=wizard_for_field(context, kwargs['endpoint_url'], SFTPH_ENDPOINT_MESSAGE),
+                          global_conf=kwargs['global'],
+                          endpoint_url=wizard_for_field(context, kwargs['endpoint_url'], SFTPH_ENDPOINT_MESSAGE, wizard_flag=wizard_flag),
                           sftp_configs=sftp_configs)
     else:
         admin.storage_add(kwargs['type'], kwargs['bucket_name'], kwargs['credentials'], global_conf=kwargs['global'])

--- a/ml_git/commands/wizard.py
+++ b/ml_git/commands/wizard.py
@@ -19,11 +19,16 @@ def check_empty_for_none(value):
     return value if value != EMPTY_FOR_NONE else None
 
 
-def request_new_value(input_message, required=False):
+def request_new_value(input_message, required=False, type=None):
     default = EMPTY_FOR_NONE
     if required:
         default = None
-    field_value = click.prompt(input_message, default=default, show_default=False)
+    field_value = click.prompt(input_message, default=default, show_default=True, type=type)
+    return field_value
+
+
+def request_choise_value(input_message, choises=[], default=None):
+    field_value = click.prompt(input_message, default=default, show_default=True, type=choises, show_choices=True)
     return field_value
 
 
@@ -32,13 +37,26 @@ def request_user_confirmation(confimation_message):
     return should_continue
 
 
-def wizard_for_field(context, field, input_message, required=False):
+def wizard_for_field(context, field, input_message, required=False, wizard_flag=False, type=None):
     wizard_enabled = is_wizard_enabled()
-    if field or not wizard_enabled:
+    if field or (not wizard_enabled and not wizard_flag):
         return field
     else:
         try:
-            new_field = check_empty_for_none(request_new_value(input_message, required))
+            new_field = check_empty_for_none(request_new_value(input_message, required, type))
+            return new_field
+        except Exception:
+            context.exit()
+
+
+def choise_wizard_for_field(context, field, input_message, choises, default, wizard_flag=False):
+    if field:
+        return field
+    elif not is_wizard_enabled() and not wizard_flag:
+        return default
+    else:
+        try:
+            new_field = check_empty_for_none(request_choise_value(input_message, choises, default))
             return new_field
         except Exception:
             context.exit()

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -194,7 +194,7 @@ output_messages = {
     'ERROR_REMOTE_UNCONFIGURED': 'Remote URL not found for [%s]. Check your configuration file.',
     'ERROR_ENTITY_NOT_FOUND': 'Entity type [%s] not found in your configuration file.',
     'ERROR_REMOTE_NOT_FOUND': 'Remote URL not found.',
-    'ERROR_MISSING_MUTABILITY': 'Missing option "--mutability".  Choose from:\n\tstrict,\n\tflexible,\n\tmutable.',
+    'ERROR_MISSING_OPTION': 'Missing option "--{}".',
     'ERROR_INVALID_TYPE_OF_FILE': 'This type of file is not supported, use one of the following types: %s',
     'ERROR_SPEC_WITHOUT_MUTABILITY': 'You need to define a mutability type when creating a new entity. '
                                      'Your spec should look something like this:' + doc,

--- a/tests/integration/test_06_commit_files.py
+++ b/tests/integration/test_06_commit_files.py
@@ -138,16 +138,16 @@ class CommitFilesAcceptanceTests(unittest.TestCase):
         entity_init(entity_type, self)
         add_file(self, entity_type, '--bumpversion', 'new')
         runner = CliRunner()
-        result = runner.invoke(entity.labels, ['commit', 'ENTITY_NAME'], input='LABEL_USER_INPUT\n')
+        result = runner.invoke(entity.labels, ['commit', 'ENTITY_NAME', '--wizard'], input='LABEL_USER_INPUT\n')
         self.assertIn(help_msg.LINK_DATASET_TO_LABEL, result.output)
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
-    def test_11_commit_files_to_labels_with_wizard_enabled(self):
+    def test_11_commit_files_to_model_with_wizard_enabled(self):
         entity_type = MODELS
         entity_init(entity_type, self)
         add_file(self, entity_type, '--bumpversion', 'new')
         runner = CliRunner()
-        result = runner.invoke(entity.models, ['commit', 'ENTITY_NAME'], input='DATASET_USER_INPUT\nLABEL_USER_INPUT')
+        result = runner.invoke(entity.models, ['commit', 'ENTITY_NAME', '--wizard'], input='DATASET_USER_INPUT\nLABEL_USER_INPUT')
         self.assertIn(help_msg.LINK_DATASET, result.output)
         self.assertIn(help_msg.LINK_LABELS, result.output)
 

--- a/tests/integration/test_19_create.py
+++ b/tests/integration/test_19_create.py
@@ -218,8 +218,8 @@ class CreateAcceptanceTests(unittest.TestCase):
         entity_type = DATASETS
         self.assertIn(output_messages['INFO_INITIALIZED_PROJECT_IN'] % self.tmp_dir, check_output(MLGIT_INIT))
         disable_wizard_in_config(self.tmp_dir)
-        self.assertIn(output_messages['ERROR_MISSING_MUTABILITY'], check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
-                                                                                + ' --categories=img --version=1'))
+        self.assertIn(output_messages['ERROR_MISSING_OPTION'].format('mutability'), check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex')
+                                                                                                 + ' --categories=img --version=1'))
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_17_create_with_entity_option(self):

--- a/tests/integration/test_40_wizard_config.py
+++ b/tests/integration/test_40_wizard_config.py
@@ -15,9 +15,9 @@ from ml_git.commands.storage import storage
 from ml_git.commands.wizard import WizardMode, WIZARD_KEY
 from ml_git.constants import GLOBAL_ML_GIT_CONFIG
 from ml_git.ml_git_message import output_messages
-from tests.integration.commands import MLGIT_CONFIG_WIZARD, MLGIT_INIT, MLGIT_CREATE, MLGIT_ENTITY_INIT
+from tests.integration.commands import MLGIT_CONFIG_WIZARD, MLGIT_INIT, MLGIT_CREATE
 from tests.integration.helper import GLOBAL_CONFIG_PATH, check_output, yaml_processor, \
-    DATASETS, LABELS, entity_init, add_file, init_repository, ERROR_MESSAGE
+    DATASETS, LABELS, entity_init, add_file
 
 
 @pytest.mark.usefixtures('tmp_dir')

--- a/tests/integration/test_40_wizard_config.py
+++ b/tests/integration/test_40_wizard_config.py
@@ -9,14 +9,15 @@ from unittest import mock
 import pytest
 from click.testing import CliRunner
 
-from ml_git.commands import entity
+from ml_git.commands import entity, help_msg, prompt_msg
 from ml_git.commands.prompt_msg import MUTABILITY_MESSAGE
+from ml_git.commands.storage import storage
 from ml_git.commands.wizard import WizardMode, WIZARD_KEY
 from ml_git.constants import GLOBAL_ML_GIT_CONFIG
 from ml_git.ml_git_message import output_messages
-from tests.integration.commands import MLGIT_CONFIG_WIZARD, MLGIT_INIT, MLGIT_CREATE
+from tests.integration.commands import MLGIT_CONFIG_WIZARD, MLGIT_INIT, MLGIT_CREATE, MLGIT_ENTITY_INIT
 from tests.integration.helper import GLOBAL_CONFIG_PATH, check_output, yaml_processor, \
-    DATASETS
+    DATASETS, LABELS, entity_init, add_file, init_repository, ERROR_MESSAGE
 
 
 @pytest.mark.usefixtures('tmp_dir')
@@ -64,3 +65,28 @@ class WizardConfigCommandAcceptanceTests(unittest.TestCase):
         entity_type = DATASETS
         self.assertIn('Missing option "--mutability"',
                       check_output(MLGIT_CREATE % (entity_type, entity_type + '-ex') + ' --categories=test'))
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_05_commit_with_wizard_enabled(self):
+        entity_type = LABELS
+        entity_init(entity_type, self)
+        add_file(self, entity_type, '--bumpversion', 'new')
+        runner = CliRunner()
+        result = runner.invoke(entity.labels, ['commit', 'ENTITY_NAME', '--wizard'], input='LABEL_USER_INPUT\n')
+        self.assertIn(help_msg.LINK_DATASET_TO_LABEL, result.output)
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_06_create_with_wizard_enabled(self):
+        entity_type = DATASETS
+        entity_init(entity_type, self)
+        add_file(self, entity_type, '--bumpversion', 'new')
+        runner = CliRunner()
+        result = runner.invoke(entity.datasets, ['create', 'ENTITY_NAME', '--wizard'], input='test\nstrict')
+        self.assertIn(prompt_msg.CATEGORIES_MESSAGE, result.output)
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_07_storage_add_with_wizard_enabled(self):
+        self.assertIn(output_messages['INFO_INITIALIZED_PROJECT_IN'] % self.tmp_dir, check_output(MLGIT_INIT))
+        runner = CliRunner()
+        result = runner.invoke(storage, ['storage add', 'STORAGE_NAME', '--wizard'], input='azureblobh')
+        self.assertIn(prompt_msg.STORAGE_TYPE_MESSAGE, result.output)

--- a/tests/integration/test_40_wizard_config.py
+++ b/tests/integration/test_40_wizard_config.py
@@ -88,5 +88,5 @@ class WizardConfigCommandAcceptanceTests(unittest.TestCase):
     def test_07_storage_add_with_wizard_enabled(self):
         self.assertIn(output_messages['INFO_INITIALIZED_PROJECT_IN'] % self.tmp_dir, check_output(MLGIT_INIT))
         runner = CliRunner()
-        result = runner.invoke(storage, ['storage add', 'STORAGE_NAME', '--wizard'], input='azureblobh')
+        result = runner.invoke(storage, ['add', 'STORAGE_NAME', '--wizard'], input='azureblobh')
         self.assertIn(prompt_msg.STORAGE_TYPE_MESSAGE, result.output)


### PR DESCRIPTION

This PR adds a `--wizard` flag to launch the wizard on commands that support it. The following commands have been modified:

- ml-git <entity> add 
- ml-git <entity> commit
- ml-git <entity> create
- ml-git repository storage add


Usage example without the flag:

```
$ ml-git datasets create data-demo
Usage: ml-git datasets create [OPTIONS] ARTIFACT_NAME

Error: Missing option "--categories".
```

Usage example with the flag:

```
$ ml-git datasets create data-demo --wizard
At least one category must be defined. The categories' names must be comma-separated. Please inform the value for the categories option: demo
An entity must have a defined mutability. Please inform the value for the mutability option (strict, flexible, mutable): strict
INFO - MLGit: Dataset artifact created.
```
