### PR TITLE
Adding validation for multiple values in related entities options

### DIFF
--- a/docs/mlgit_commands.md
+++ b/docs/mlgit_commands.md
@@ -224,6 +224,8 @@ Options:
                                   import_url, credentials_path.
   --wizard-config                 If specified, ask interactive questions at
                                   console for git & storage configurations.
+                                  [DEPRECATED: This option should no longer be
+                                  used.]
   --bucket-name TEXT              Bucket name
   --import-url TEXT               Import data from a google drive url. NOTE:
                                   Mutually exclusive with argument: import.

--- a/ml_git/commands/custom_options.py
+++ b/ml_git/commands/custom_options.py
@@ -2,7 +2,7 @@
 © Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
-
+import click
 from click import Option, UsageError, Command, MissingParameter
 
 from ml_git import log
@@ -106,3 +106,10 @@ class DeprecatedOptionsCommand(Command):
                 return process
             option.process = make_process(option)
         return parser
+
+
+def check_multiple(ctx, param, value):
+    if len(value) > 1:
+        raise click.BadParameter(output_messages['ERROR_OPTION_WITH_MULTIPLE_VALUES'].format(param))
+    else:
+        return value

--- a/ml_git/commands/custom_options.py
+++ b/ml_git/commands/custom_options.py
@@ -109,7 +109,8 @@ class DeprecatedOptionsCommand(Command):
 
 
 def check_multiple(ctx, param, value):
-    if len(value) > 1:
+    if len(value) == 0:
+        return None
+    elif len(value) > 1:
         raise click.BadParameter(output_messages['ERROR_OPTION_WITH_MULTIPLE_VALUES'].format(param))
-    else:
-        return value
+    return value[0]

--- a/ml_git/commands/descriptor.py
+++ b/ml_git/commands/descriptor.py
@@ -9,7 +9,7 @@ import click
 
 from ml_git.commands import entity, help_msg, storage
 from ml_git.commands.custom_options import MutuallyExclusiveOption, OptionRequiredIf, DeprecatedOptionsCommand, \
-    DeprecatedOption
+    DeprecatedOption, check_multiple
 from ml_git.commands.custom_types import CategoriesType, NotEmptyString
 from ml_git.commands.utils import set_verbose_mode
 from ml_git.commands.wizard import is_wizard_enabled
@@ -299,7 +299,7 @@ commands = [
         },
 
         'options': {
-            '--dataset': {'help': help_msg.LINK_DATASET_TO_LABEL, 'type': NotEmptyString()},
+            '--dataset': {'help': help_msg.LINK_DATASET_TO_LABEL, 'multiple': True, 'type': NotEmptyString(), 'callback': check_multiple},
             '--tag': {'help': help_msg.TAG_OPTION},
             '--version': {'type': click.IntRange(0, int(8 * '9')), 'help': help_msg.SET_VERSION_NUMBER},
             ('--message', '-m'): {'help': help_msg.COMMIT_MSG},
@@ -321,8 +321,8 @@ commands = [
         },
 
         'options': {
-            '--dataset': {'help': help_msg.LINK_DATASET, 'type': NotEmptyString()},
-            '--labels': {'help': help_msg.LINK_LABELS, 'type': NotEmptyString()},
+            '--dataset': {'help': help_msg.LINK_DATASET, 'multiple': True, 'type': NotEmptyString(), 'callback': check_multiple},
+            '--labels': {'help': help_msg.LINK_LABELS, 'multiple': True, 'type': NotEmptyString(), 'callback': check_multiple},
             '--tag': {'help': help_msg.TAG_OPTION},
             '--version': {'type': click.IntRange(0, int(8 * '9')), 'help': help_msg.SET_VERSION_NUMBER},
             ('--message', '-m'): {'help': help_msg.COMMIT_MSG},

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -333,6 +333,7 @@ output_messages = {
     'ERROR_TAGS_NOT_MATCH_WITH_ENTITY': 'The tags do not match the entity name',
     'ERROR_INVALID_METRICS_FILE': 'It was not possible to obtain the metrics from the informed file, please check if the file is correctly formatted.',
     'ERROR_ENTITY_NOT_FIND': 'Could not find an entity with the name \'{}\'. Please check again.',
+    'ERROR_OPTION_WITH_MULTIPLE_VALUES': 'Multiple options are not accepted! The option should only take one value.',
 
     'WARN_CORRUPTED_CANNOT_BE_ADD': 'The following files cannot be added because they are corrupted:',
     'WARN_HAS_CONFIGURED_REMOTE': 'YOU ALREADY HAS A CONFIGURED REMOTE. All data stored in this repository will be sent to the new one on the first push.',

--- a/tests/integration/test_06_commit_files.py
+++ b/tests/integration/test_06_commit_files.py
@@ -184,6 +184,6 @@ class CommitFilesAcceptanceTests(unittest.TestCase):
         self.assertIn(output_messages['ERROR_OPTION_WITH_MULTIPLE_VALUES'],
                       check_output(MLGIT_COMMIT % (entity_type, entity_name, ' --labels=A --labels=B')))
         self.assertIn(output_messages['ERROR_OPTION_WITH_MULTIPLE_VALUES'],
-                      check_output(MLGIT_COMMIT % (entity_type, entity_name, ' --datasets=A --datasets=B')))
+                      check_output(MLGIT_COMMIT % (entity_type, entity_name, ' --dataset=A --dataset=B')))
         HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'refs', entity_name, 'HEAD')
         self.assertFalse(os.path.exists(HEAD))

--- a/tests/integration/test_06_commit_files.py
+++ b/tests/integration/test_06_commit_files.py
@@ -172,3 +172,18 @@ class CommitFilesAcceptanceTests(unittest.TestCase):
                       check_output(MLGIT_COMMIT % (entity_type, entity_name, ' --labels=wrong-entity')))
         HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'refs', entity_name, 'HEAD')
         self.assertFalse(os.path.exists(HEAD))
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_14_commit_with_multiple_related_entities(self):
+        entity_type = MODELS
+        entity_name = entity_type + '-ex'
+        entity_init(entity_type, self)
+        add_file(self, entity_type, '--bumpversion', 'new')
+        self.assertIn(output_messages['ERROR_OPTION_WITH_MULTIPLE_VALUES'].format('wrong-entity'),
+                      check_output(MLGIT_COMMIT % (entity_type, entity_name, ' --labels=A --labels=B')))
+        self.assertIn(output_messages['ERROR_OPTION_WITH_MULTIPLE_VALUES'],
+                      check_output(MLGIT_COMMIT % (entity_type, entity_name, ' --labels=A --labels=B')))
+        self.assertIn(output_messages['ERROR_OPTION_WITH_MULTIPLE_VALUES'],
+                      check_output(MLGIT_COMMIT % (entity_type, entity_name, ' --datasets=A --datasets=B')))
+        HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'refs', entity_name, 'HEAD')
+        self.assertFalse(os.path.exists(HEAD))


### PR DESCRIPTION
**Behaviour after fix:**
```
$ ml-git models commit models-ex --labels=A --labels=B
Usage: ml-git models commit [OPTIONS] ML_ENTITY_NAME

Error: Invalid value for "--labels": Multiple options are not accepted! The option should only take one value.
```

**Behaviour before fix (Uses only the last value provided in the option):**
```
$ ml-git models commit models-ex --labels=A --labels=B
INFO - Multihash: File models-ex.spec has been automatically added to staged files.
INFO - Local Repository: Associate labels [labels-ex]-[demo__B__1] to the models.
INFO - Metadata Manager: Commit repo[D:\demo\.ml-git\models\metadata] --- file[models-ex]
```
