### PR TITLE
Adding treatment for commit attempt with no data to commit

### DIFF
--- a/ml_git/file_system/objects.py
+++ b/ml_git/file_system/objects.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 import os
@@ -28,6 +28,7 @@ class Objects(MultihashFS):
     def commit_objects(self, index_path, ws_path):
         added_files = []
         deleted_files = []
+        changed_files = []
         idx = MultihashFS(self._objects_path)
         fidx = FullIndex(self.__spec, index_path)
         findex = fidx.get_index()
@@ -40,9 +41,11 @@ class Objects(MultihashFS):
                     idx.fetch_scid(v['hash'], log_file)
                     v['status'] = Status.u.name
                     if 'previous_hash' in v:
-                        added_files.append((v['previous_hash'], k))
+                        changed_files.append((v['previous_hash'], k))
+                    else:
+                        added_files.append(k)
         fidx.get_manifest_index().save()
-        return added_files, deleted_files
+        return changed_files, deleted_files, added_files
 
     def _get_used_blobs(self, descriptor_hashes):
         used_blobs = []

--- a/ml_git/metadata.py
+++ b/ml_git/metadata.py
@@ -102,7 +102,7 @@ class Metadata(MetadataManager):
         except Exception as e:
             log.error(e, class_name=METADATA_CLASS_NAME)
             return None, None, None
-        metadata = yaml_load(spec_file)
+        metadata = yaml_load(spec_file, raise_exception=True)
         full_metadata_path = os.path.join(self.__path, entity_dir)
         return full_metadata_path, entity_dir, metadata
 

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -333,6 +333,7 @@ output_messages = {
     'ERROR_TAGS_NOT_MATCH_WITH_ENTITY': 'The tags do not match the entity name',
     'ERROR_INVALID_METRICS_FILE': 'It was not possible to obtain the metrics from the informed file, please check if the file is correctly formatted.',
     'ERROR_ENTITY_NOT_FIND': 'Could not find an entity with the name \'{}\'. Please check again.',
+    'ERROR_COMMIT_WITHOUT_ADD': 'Nothing to commit (create/add files and use "ml-git {} add" command to track this files)',
 
     'WARN_CORRUPTED_CANNOT_BE_ADD': 'The following files cannot be added because they are corrupted:',
     'WARN_HAS_CONFIGURED_REMOTE': 'YOU ALREADY HAS A CONFIGURED REMOTE. All data stored in this repository will be sent to the new one on the first push.',

--- a/ml_git/utils.py
+++ b/ml_git/utils.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020-2021 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 import bisect
@@ -76,12 +76,14 @@ def check_spec_file(file, hash):
     return hash
 
 
-def yaml_load(file):
+def yaml_load(file, raise_exception=False):
     hash = {}
     try:
         with open(file) as y_file:
             hash = yaml_processor.load(y_file)
-    except Exception:
+    except Exception as e:
+        if raise_exception:
+            raise e
         pass
     if SPEC_EXTENSION in posix_path(file):
         hash = check_spec_file(file, hash)

--- a/tests/integration/test_06_commit_files.py
+++ b/tests/integration/test_06_commit_files.py
@@ -172,3 +172,17 @@ class CommitFilesAcceptanceTests(unittest.TestCase):
                       check_output(MLGIT_COMMIT % (entity_type, entity_name, ' --labels=wrong-entity')))
         HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'refs', entity_name, 'HEAD')
         self.assertFalse(os.path.exists(HEAD))
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_14_first_commit_without_add(self):
+        entity_type = DATASETS
+        entity_init(entity_type, self)
+        self.assertIn(output_messages['ERROR_COMMIT_WITHOUT_ADD'].format(DATASETS), check_output(MLGIT_COMMIT % (entity_type, entity_type + '-ex', '')))
+        HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'refs', entity_type + '-ex', 'HEAD')
+        self.assertFalse(os.path.exists(HEAD))
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_15_commit_twice_after_add(self):
+        entity_type = DATASETS
+        self._commit_entity(entity_type)
+        self.assertIn(output_messages['ERROR_COMMIT_WITHOUT_ADD'].format(DATASETS), check_output(MLGIT_COMMIT % (entity_type, entity_type + '-ex', '')))

--- a/tests/integration/test_06_commit_files.py
+++ b/tests/integration/test_06_commit_files.py
@@ -185,4 +185,5 @@ class CommitFilesAcceptanceTests(unittest.TestCase):
     def test_15_commit_twice_after_add(self):
         entity_type = DATASETS
         self._commit_entity(entity_type)
-        self.assertIn(output_messages['ERROR_COMMIT_WITHOUT_ADD'].format(DATASETS), check_output(MLGIT_COMMIT % (entity_type, entity_type + '-ex', '')))
+        self.assertIn(output_messages['ERROR_COMMIT_WITHOUT_ADD'].format(DATASETS),
+                      check_output(MLGIT_COMMIT % (entity_type, entity_type + '-ex', ' --version=2')))

--- a/tests/integration/test_24_api.py
+++ b/tests/integration/test_24_api.py
@@ -549,11 +549,11 @@ class APIAcceptanceTests(unittest.TestCase):
         self.assertTrue(os.path.exists(head))
 
         self.create_file_in_ws(DATASETS, 'file2', '2')
-        api.add(DATASETS, DATASET_NAME, bumpversion=True, fsck=False, file_path=['file'])
+        api.add(DATASETS, DATASET_NAME, bumpversion=True, fsck=False, file_path=['file2'])
         api.commit(DATASETS, DATASET_NAME)
 
         self.create_file_in_ws(DATASETS, 'file3', '3')
-        api.add(DATASETS, DATASET_NAME, bumpversion=True, fsck=False, file_path=['file'])
+        api.add(DATASETS, DATASET_NAME, bumpversion=True, fsck=False, file_path=['file3'])
         api.commit(DATASETS, DATASET_NAME)
 
         tag = 'computer-vision__images__{}__'.format(DATASET_NAME)
@@ -596,7 +596,7 @@ class APIAcceptanceTests(unittest.TestCase):
             api.commit(MODELS, model_name)
 
             self.create_file_in_ws(MODELS, 'file2', '2')
-            api.add(MODELS, model_name, bumpversion=True, fsck=False, file_path=['file'])
+            api.add(MODELS, model_name, bumpversion=True, fsck=False, file_path=['file2'])
             api.commit(MODELS, model_name, related_dataset=DATASET_NAME, related_labels=label_name)
 
             models_metadata = os.path.join(self.tmp_dir, ML_GIT_DIR, MODELS, 'metadata')
@@ -736,10 +736,10 @@ class APIAcceptanceTests(unittest.TestCase):
         api.add(DATASETS, DATASET_NAME, file_path=['file'])
         api.commit(DATASETS, DATASET_NAME)
         self.create_file_in_ws(DATASETS, 'file2', '1')
-        api.add(DATASETS, DATASET_NAME, bumpversion=True, file_path=['file'])
+        api.add(DATASETS, DATASET_NAME, bumpversion=True, file_path=['file2'])
         api.commit(DATASETS, DATASET_NAME)
         self.create_file_in_ws(DATASETS, 'file3', '1')
-        api.add(DATASETS, DATASET_NAME, file_path=['file'])
+        api.add(DATASETS, DATASET_NAME, file_path=['file3'])
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, '--version=10')))
         local_manager = api.init_local_entity_manager()
         entities_relationships = local_manager.get_project_entities_relationships(export_type=FileType.DOT.value)

--- a/tests/integration/test_29_log.py
+++ b/tests/integration/test_29_log.py
@@ -11,9 +11,9 @@ from prettytable import PrettyTable
 
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_ADD, MLGIT_COMMIT, MLGIT_LOG
-from tests.integration.helper import ML_GIT_DIR, add_file, create_spec, delete_file, ERROR_MESSAGE, DATASETS, \
-    DATASET_NAME, DATASET_TAG, MODELS
-from tests.integration.helper import check_output, init_repository
+from tests.integration.helper import ML_GIT_DIR, add_file, delete_file, ERROR_MESSAGE, DATASETS, \
+    DATASET_NAME, DATASET_TAG, MODELS, entity_init, create_file
+from tests.integration.helper import check_output
 
 
 @pytest.mark.usefixtures('tmp_dir')
@@ -23,8 +23,9 @@ class LogTests(unittest.TestCase):
 
     def set_up_test(self, repo_type=DATASETS, with_metrics=False):
         entity = '{}-ex'.format(repo_type)
-        init_repository(repo_type, self)
-        create_spec(self, repo_type, self.tmp_dir)
+        entity_init(repo_type, self)
+        data_path = os.path.join(self.tmp_dir, repo_type, entity)
+        create_file(data_path, 'file', '0', '')
         metrics_options = ''
         if with_metrics:
             metrics_options = '--metric Accuracy 1 --metric Recall 2'
@@ -61,8 +62,8 @@ class LogTests(unittest.TestCase):
         add_file(self, DATASETS, '--bumpversion')
         check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, ''))
         added = 5
-        amount_files = 5
-        workspace_size = 14
+        amount_files = 6
+        workspace_size = 16.5
 
         output = check_output(MLGIT_LOG % (DATASETS, DATASET_NAME, '--stat'))
 
@@ -81,8 +82,8 @@ class LogTests(unittest.TestCase):
         self.set_up_test()
         add_file(self, DATASETS, '--bumpversion')
         check_output(MLGIT_COMMIT % (DATASETS, DATASET_NAME, ''))
-        amount_files = 5
-        workspace_size = 14
+        amount_files = 6
+        workspace_size = 16.5
 
         output = check_output(MLGIT_LOG % (DATASETS, DATASET_NAME, '--fullstat'))
 

--- a/tests/integration/test_33_checkout_entity.py
+++ b/tests/integration/test_33_checkout_entity.py
@@ -194,6 +194,7 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         entity_dir = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME)
         with open(os.path.join(entity_dir, 'tag2'), 'wt') as z:
             z.write('0' * 100)
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '')))
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (entity, entity + '-ex', '--version=3')))
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_PUSH % (entity, entity + '-ex')))
 
@@ -211,6 +212,13 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
         init_repository(entity, self)
         self._create_new_tag(entity, 'tag1')
 
+        data_path = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME)
+        create_file(data_path, 'file', '0', '')
+
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % (DATASETS, DATASET_NAME, '')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (entity, entity + '-ex', '--version=3')))
+        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_PUSH % (entity, entity + '-ex')))
+
         entity_dir = os.path.join('folderB')
         unsaved_files_dir = os.path.join(self.tmp_dir, DATASETS, DATASET_NAME, entity_dir)
         ensure_path_exists(unsaved_files_dir)
@@ -218,8 +226,6 @@ class CheckoutTagAcceptanceTests(unittest.TestCase):
             file_name = 'test-unsaved-file' + str(x)
             with open(os.path.join(unsaved_files_dir, file_name), 'wt') as z:
                 z.write('0' * 100)
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (entity, entity + '-ex', '--version=3')))
-        self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_PUSH % (entity, entity + '-ex')))
 
         output_command = check_output(MLGIT_CHECKOUT % (DATASETS, DATASET_NAME + ' --version=2'))
         self.assertIn(output_messages['ERROR_DISCARDED_LOCAL_CHANGES'], output_command)

--- a/tests/integration/test_38_models_metrics.py
+++ b/tests/integration/test_38_models_metrics.py
@@ -16,8 +16,8 @@ from ml_git.commands import entity
 from ml_git.constants import FileType, DATE, RELATED_DATASET_TABLE_INFO, RELATED_LABELS_TABLE_INFO, TAG
 from ml_git.ml_git_message import output_messages
 from tests.integration.commands import MLGIT_COMMIT, MLGIT_ADD, MLGIT_MODELS_METRICS
-from tests.integration.helper import ERROR_MESSAGE, create_spec, MODELS, init_repository, ML_GIT_DIR, create_file
-from tests.integration.helper import check_output
+from tests.integration.helper import ERROR_MESSAGE, MODELS, ML_GIT_DIR, create_file, \
+    entity_init, check_output
 
 
 @pytest.mark.usefixtures('tmp_dir', 'start_local_git_server', 'switch_to_tmp_dir')
@@ -36,8 +36,9 @@ class ModelsMetricsAcceptanceTests(unittest.TestCase):
     def set_up_test(self, repo_type=MODELS):
         self.TAG_TIMES = []
         entity_name = '{}-ex'.format(repo_type)
-        init_repository(repo_type, self)
-        create_spec(self, repo_type, self.tmp_dir)
+        entity_init(repo_type, self)
+        data_path = os.path.join(self.tmp_dir, repo_type, entity_name)
+        create_file(data_path, 'file', '0', '')
         metrics_options = '--metric Accuracy 10 --metric Recall 10'
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_ADD % (repo_type, entity_name, metrics_options)))
         self.assertNotIn(ERROR_MESSAGE, check_output(MLGIT_COMMIT % (repo_type, entity_name, '')))


### PR DESCRIPTION
**Behaviour after fix:**
```
$ ml-git datasets commit dataset-ex
WARNING - Repository: Nothing to commit (create/add files and use "ml-git datasets add" command to track this files)
```

**Behaviour before fix:**
```
$ ml-git datasets commit dataset-ex
INFO - Metadata Manager: Commit repo[D:\demo\.ml-git\datasets\metadata] --- file[dataset-ex]
```

