### PR TITLE
Adding method to validate the input in the wizard-config option of create

### DIFF
--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -399,12 +399,12 @@ def _get_configured_buckets(configured_storages):
 
 
 def start_wizard_questions(repo_type):
-    print('Current configured storages:\n   ')
+    print(output_messages['INFO_CONFIGURED_STORAGES'])
     configured_storages = config_load()[STORAGE_CONFIG_KEY]
 
     valid_buckets, temp_map = _get_configured_buckets(configured_storages)
-    print('[X] - Create new data storage\n   ')
-    selected = input(USER_INPUT_MESSAGE.format('storage do you want to use'))
+    print(output_messages['INFO_CREATE_NEW_STORAGE_OPTION'])
+    selected = input(USER_INPUT_MESSAGE.format('storage you want to use'))
 
     valid_buckets_options = range(1, len(valid_buckets) + 1)
     if selected.upper() == 'X':

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -357,8 +357,7 @@ def _get_user_input(message, default=None, required=False):
         if required:
             log.warn(output_messages['ERROR_EMPTY_VALUE'])
             return _get_user_input(message, default, required)
-        else:
-            return default
+        return default
     return value
 
 

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020-2021 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from halo import Halo
 
-from ml_git import spec
+from ml_git import spec, log
 from ml_git.constants import FAKE_STORAGE, BATCH_SIZE_VALUE, BATCH_SIZE, StorageType, GLOBAL_ML_GIT_CONFIG, \
     PUSH_THREADS_COUNT, SPEC_EXTENSION, EntityType, STORAGE_CONFIG_KEY, STORAGE_SPEC_KEY, DATASET_SPEC_KEY, \
     MultihashStorageType
@@ -351,6 +351,17 @@ def _configure_metadata_remote(repo_type):
         remote_add(repo_type, git_repo)
 
 
+def _get_user_input(message, default=None, required=False):
+    value = input(message)
+    if not value:
+        if required:
+            log.warn(output_messages['ERROR_EMPTY_VALUE'])
+            return _get_user_input(message, default, required)
+        else:
+            return default
+    return value
+
+
 def _create_new_bucket():
     storages_types = [item.value for item in MultihashStorageType]
     storage_type = input(USER_INPUT_MESSAGE.format('storage type {}'.format(str(storages_types)))).lower()
@@ -361,17 +372,17 @@ def _create_new_bucket():
 
     if storage_type not in storages_types:
         raise RuntimeError(output_messages['ERROR_INVALID_STORAGE_TYPE'])
-    bucket = input(USER_INPUT_MESSAGE.format('bucket name'))
+    bucket = _get_user_input(USER_INPUT_MESSAGE.format('bucket name'), required=True)
     if storage_type == StorageType.S3H.value:
-        credential_profile = input(USER_INPUT_MESSAGE.format('credentials'))
-        endpoint = input('If you are using MinIO inform the endpoint URL, otherwise press ENTER: ')
+        credential_profile = _get_user_input(USER_INPUT_MESSAGE.format('credentials'))
+        endpoint = _get_user_input('If you are using MinIO inform the endpoint URL, otherwise press ENTER: ')
     elif storage_type == StorageType.GDRIVEH.value:
-        credential_profile = input(USER_INPUT_MESSAGE.format('credentials path'))
+        credential_profile = _get_user_input(USER_INPUT_MESSAGE.format('credentials path'), default='.')
     elif storage_type == StorageType.SFTPH.value:
-        endpoint = input(USER_INPUT_MESSAGE.format('endpoint URL'))
-        sftp_configs = {'username': input(USER_INPUT_MESSAGE.format('username')),
-                        'private_key': input(USER_INPUT_MESSAGE.format('credentials path')),
-                        'port': int(input(USER_INPUT_MESSAGE.format('port')))}
+        endpoint = _get_user_input(USER_INPUT_MESSAGE.format('endpoint URL'))
+        sftp_configs = {'username': _get_user_input(USER_INPUT_MESSAGE.format('username')),
+                        'private_key': _get_user_input(USER_INPUT_MESSAGE.format('credentials path'), default='.'),
+                        'port': int(_get_user_input(USER_INPUT_MESSAGE.format('port'), default=22))}
     from ml_git.admin import storage_add
     storage_add(storage_type, bucket, credential_profile, endpoint_url=endpoint, sftp_configs=sftp_configs)
     return storage_type, bucket

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -353,7 +353,7 @@ def _configure_metadata_remote(repo_type):
 
 def _get_user_input(message, default=None, required=False):
     value = input(message)
-    if not value:
+    if not value.strip():
         if required:
             log.warn(output_messages['ERROR_EMPTY_VALUE'])
             return _get_user_input(message, default, required)

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -185,6 +185,8 @@ output_messages = {
     'INFO_LIST_OF_MISSING_FILES': 'List of missing descriptor files: %s',
     'INFO_SEE_COMPLETE_LIST_OF_MISSING_FILES': 'You can use the --full option to see the complete list of missing descriptor files.',
     'INFO_WIZARD_MODE_CHANGED': 'Wizard mode changed to \'{}\'',
+    'INFO_CONFIGURED_STORAGES': 'Currently configured storages:\n   ',
+    'INFO_CREATE_NEW_STORAGE_OPTION': '[X] - Create new data storage\n   ',
 
     'ERROR_PATH_NOT_EMPTY': 'The path [%s] is not an empty directory. Consider using --folder to create an empty folder.',
     'ERROR_WITHOUT_TAG_FOR_THIS_ENTITY': 'No entity with that name was found.',

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020-2021 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
@@ -16,7 +16,7 @@ from ml_git.config import validate_config_spec_hash, get_sample_config_spec, get
     get_index_path, get_objects_path, get_cache_path, get_metadata_path, import_dir, \
     extract_storage_info_from_list, create_workspace_tree_structure, get_batch_size, merge_conf, \
     merge_local_with_global_config, mlgit_config, save_global_config_in_local, start_wizard_questions, \
-    merged_config_load
+    merged_config_load, _get_user_input
 from ml_git.constants import BATCH_SIZE_VALUE, BATCH_SIZE, STORAGE_CONFIG_KEY, STORAGE_SPEC_KEY, DATASET_SPEC_KEY, \
     PUSH_THREADS_COUNT
 from ml_git.utils import get_root_path, yaml_load, yaml_processor
@@ -259,3 +259,14 @@ class ConfigTestCases(unittest.TestCase):
                 self.assertEqual(config_file[DATASETS]['git'], 'url')
                 self.assertEqual(config_file[MODELS]['git'], 'url')
                 self.assertEqual(config_file[PUSH_THREADS_COUNT], 10)
+
+    @pytest.mark.usefixtures('switch_to_test_dir')
+    def test_get_user_input(self):
+        with mock.patch('builtins.input', return_value=''):
+            self.assertEquals('Test', _get_user_input('', default='Test'))
+
+        with mock.patch('builtins.input', return_value=''):
+            self.assertEquals(None, _get_user_input(''))
+
+        with mock.patch('builtins.input', return_value='Test'):
+            self.assertEquals('Test', _get_user_input(''))


### PR DESCRIPTION
It was observed that when using the `--wizard-config` option of the create command, the fields that the user pressed enter were filled with `''`. However, the storage name field is mandatory and must be other than empty.
In addition, the other fields, when not informed, must be filled with the value `null` instead of `''`.
When filling with `''`, it was also observed that the value for a sftp storage port ended up generating an error.

**config.yaml before fix:**

```
datasets:
  git: [GIT-URL]
labels:
  git: [GIT-URL]
models:
  git: [GIT-URL]
storages:
  s3h:
    '':
      aws-credentials:
        profile: ''
      endpoint-url: ''
      region: ''
```

**WARNING message added when empty is informed for the bucket name:**
```
$ ml-git datasets create dataset-ex --categories=test --mutability=strict --wizard-config
Currently configured storages:

[X] - Create new data storage

Inform the storage you want to use: X
Inform the storage type ['s3h', 'azureblobh', 'gdriveh', 'sftph']: s3h
Inform the bucket name:
WARNING - MLGit: Value cannot be empty.
Inform the bucket name: test
Inform the credentials:
If you are using MinIO inform the endpoint URL, otherwise press ENTER:
INFO - Admin: Add storage [s3h://test]
INFO - Admin: When making changes to the config file we strongly recommend that you upload these changes to the Git repository. For this, see: ml-git repository config push --help
INFO - MLGit: Dataset artifact created.
```

**config.yaml after fix:**

```
datasets:
  git: [GIT-URL]
labels:
  git: [GIT-URL]
models:
  git: [GIT-URL]
storages:
  s3h:
    test:
      aws-credentials:
        profile: null
      endpoint-url: null
      region: null
```
