### PR TITLE
Checking if have new data before change version in spec

### DIFF
--- a/ml_git/metadata.py
+++ b/ml_git/metadata.py
@@ -32,11 +32,14 @@ class Metadata(MetadataManager):
         self.__config = config
         super(Metadata, self).__init__(config, repo_type)
 
-    def tag_exists(self, index_path):
+    def tag_exists(self, index_path, version=None):
         spec_file = os.path.join(index_path, 'metadata', self._spec, self._spec + SPEC_EXTENSION)
         full_metadata_path, entity_sub_path, metadata = self._full_metadata_path(spec_file)
         if metadata is None:
             return full_metadata_path, entity_sub_path, metadata
+
+        if version:
+            metadata[get_spec_key(self.__repo_type)]['version'] = version
 
         # generates a tag to associate to the commit
         tag = self.metadata_tag(metadata)

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -336,7 +336,7 @@ output_messages = {
     'ERROR_INVALID_METRICS_FILE': 'It was not possible to obtain the metrics from the informed file, please check if the file is correctly formatted.',
     'ERROR_ENTITY_NOT_FIND': 'Could not find an entity with the name \'{}\'. Please check again.',
     'ERROR_OPTION_WITH_MULTIPLE_VALUES': 'Multiple options are not accepted! The option should only take one value.',
-    'ERROR_COMMIT_WITHOUT_ADD': 'Nothing to commit (create/add files and use "ml-git {} add" command to track this files)',
+    'ERROR_COMMIT_WITHOUT_ADD': 'Nothing to commit (create/add files and use "ml-git {} add" command to track them)',
 
     'WARN_CORRUPTED_CANNOT_BE_ADD': 'The following files cannot be added because they are corrupted:',
     'WARN_HAS_CONFIGURED_REMOTE': 'YOU ALREADY HAS A CONFIGURED REMOTE. All data stored in this repository will be sent to the new one on the first push.',

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -450,7 +450,7 @@ class Repository(object):
 
         idx = MultihashIndex(spec, index_path, objects_path)
         try:
-            full_metadata_path, entity_sub_path, metadata = m.tag_exists(index_path)
+            full_metadata_path, entity_sub_path, metadata = m.tag_exists(index_path, version)
             if metadata is None:
                 return None
         except OSError:

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -449,10 +449,6 @@ class Repository(object):
             return
 
         idx = MultihashIndex(spec, index_path, objects_path)
-        if version:
-            set_version_in_spec(version, spec_path, self.__repo_type)
-            idx.add_metadata(path, file, automatically_added=True)
-
         try:
             full_metadata_path, entity_sub_path, metadata = m.tag_exists(index_path)
             if metadata is None:
@@ -472,6 +468,10 @@ class Repository(object):
         if (len(changed_files + deleted_files + added_files)) == 0:
             log.warn(output_messages['ERROR_COMMIT_WITHOUT_ADD'].format(self.__repo_type), class_name=REPOSITORY_CLASS_NAME)
             return None
+
+        if version:
+            set_version_in_spec(version, spec_path, self.__repo_type)
+            idx.add_metadata(path, file, automatically_added=True)
 
         bare_mode = os.path.exists(os.path.join(index_path, 'metadata', spec, 'bare'))
 

--- a/tests/integration/test_06_commit_files.py
+++ b/tests/integration/test_06_commit_files.py
@@ -202,3 +202,11 @@ class CommitFilesAcceptanceTests(unittest.TestCase):
                       check_output(MLGIT_COMMIT % (entity_type, entity_name, ' --dataset=A --dataset=B')))
         HEAD = os.path.join(self.tmp_dir, ML_GIT_DIR, entity_type, 'refs', entity_name, 'HEAD')
         self.assertFalse(os.path.exists(HEAD))
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_15_commit_with_version_without_new_data(self):
+        entity_type = DATASETS
+        self._commit_entity(entity_type)
+        output = check_output(MLGIT_COMMIT % (entity_type, entity_type + '-ex', ' --version=2'))
+        self.assertNotIn(output_messages['INFO_FILE_AUTOMATICALLY_ADDED'].format(entity_type + '-ex.spec'), output)
+        self.assertIn(output_messages['ERROR_COMMIT_WITHOUT_ADD'].format(DATASETS), output)


### PR DESCRIPTION
**Behaviour after fix:**
```
$ ml-git datasets commit dataset-ex --version=2
WARNING - Repository: Nothing to commit (create/add files and use "ml-git datasets add" command to track this files)
```


**Behaviour before fix:**
```
$ ml-git datasets commit dataset-ex --version=2
INFO - Multihash: File dataset-ex.spec has been automatically added to staged files.
WARNING - Repository: Nothing to commit (create/add files and use "ml-git datasets add" command to track them)
```
