### PR TITLE
Updating clone command to receive directory as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,23 +88,19 @@ Commands:
 <br>
 
 ```
-mkdir my-project
-cd my-project
 ml-git clone https://github.com/user/ml_git_configuration_file_example.git
 ```
 
-If you prefer not to create the directory:
+If you prefer to create a new directory to clone into:
 
 ```
-ml-git clone https://github.com/user/ml_git_configuration_file_example.git --folder=my-project
+ml-git clone https://github.com/user/ml_git_configuration_file_example.git my-project-dir
 ```
 
 
 If you prefer keep git tracking files in the project:
 
 ```
-mkdir my-project
-cd my-project
 ml-git clone https://github.com/user/ml_git_configuration_file_example.git --track
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Options:
   --version  Show the version and exit.
 
 Commands:
-  clone       Clone a ml-git repository ML_GIT_REPOSITORY_URL
+  clone       Clone an ml-git repository ML_GIT_REPOSITORY_URL
   datasets    Management of datasets within this ml-git repository.
   labels      Management of labels sets within this ml-git repository.
   models      Management of models within this ml-git repository.

--- a/docs/first_project.md
+++ b/docs/first_project.md
@@ -508,7 +508,12 @@ To download a dataset, you need to be in an initialized and configured ML-Git pr
 ml-git clone git@github.com:example/your-mlgit-repository.git
 ```
 
-If you are in a configured ML-Git project directory, the following command will update the metadata repository, allowing visibility of what has been shared since the last update (new ML entity, new versions).
+Then, go to the project directory:
+```
+cd your-mlgit-repository
+```
+
+Inside the configured ML-Git project directory, the following command will update the metadata repository, allowing visibility of what has been shared since the last update (new ML entity, new versions).
 
 ```
 ml-git datasets update

--- a/docs/first_steps.md
+++ b/docs/first_steps.md
@@ -112,7 +112,12 @@ To clone a repository use the command:
 ml-git clone git@github.com:example/your-mlgit-repository.git
 ```
 
-Then, you can discover which datasets are under ML-Git management by executing the command:
+Then, go to the project directory:
+```
+cd your-mlgit-repository
+```
+
+Now you can discover which datasets are under ML-Git management by executing the command:
 ```
 ml-git datasets list
 ```

--- a/docs/mlgit_commands.md
+++ b/docs/mlgit_commands.md
@@ -11,7 +11,7 @@ Options:
   --version  Show the version and exit.
 
 Commands:
-  clone       Clone a ml-git repository ML_GIT_REPOSITORY_URL
+  clone       Clone an ml-git repository ML_GIT_REPOSITORY_URL
   datasets    Management of datasets within this ml-git repository.
   labels      Management of labels sets within this ml-git repository.
   models      Management of models within this ml-git repository.
@@ -804,7 +804,7 @@ You should only use this command for the flexible mutability option.
 ```
 Usage: ml-git clone [OPTIONS] REPOSITORY_URL [DIRECTORY]
 
-  Clone a ml-git repository ML_GIT_REPOSITORY_URL
+  Clone an ml-git repository ML_GIT_REPOSITORY_URL
 
 Options:
   --untracked  Does not preserve git repository tracking.

--- a/docs/mlgit_commands.md
+++ b/docs/mlgit_commands.md
@@ -802,14 +802,13 @@ You should only use this command for the flexible mutability option.
 <br>
 
 ```
-Usage: ml-git clone [OPTIONS] REPOSITORY_URL
+Usage: ml-git clone [OPTIONS] REPOSITORY_URL [DIRECTORY]
 
   Clone a ml-git repository ML_GIT_REPOSITORY_URL
 
 Options:
-  --folder TEXT  The configuration files are cloned in specified folder.
-  --untracked    Does not preserve git repository tracking.
-  --verbose      Debug mode
+  --untracked  Does not preserve git repository tracking.
+  --verbose    Debug mode
 ```
 
 Example:

--- a/docs/qs_checkout.md
+++ b/docs/qs_checkout.md
@@ -6,7 +6,12 @@ To download a dataset, you need to be in an initialized and configured ML-Git pr
 ml-git clone git@github.com:example/your-mlgit-repository.git
 ```
 
-Then, you can retrieve a specific version of a dataset to run an experiment. To achieve that, you can use the version tag to download this version to your local environment using one of the following commands:
+Then, go to the project folder:
+```
+cd your-mlgit-repository
+```
+
+Now you can retrieve a specific version of a dataset to run an experiment. To achieve that, you can use the version tag to download this version to your local environment using one of the following commands:
 
 ```
 ml-git datasets checkout computer-vision__images__faces__fddb__1

--- a/ml_git/commands/general.py
+++ b/ml_git/commands/general.py
@@ -21,7 +21,7 @@ def mlgit():
     check_metadata_directories()
 
 
-@mlgit.command('clone', help='Clone a ml-git repository ML_GIT_REPOSITORY_URL')
+@mlgit.command('clone', help='Clone an ml-git repository ML_GIT_REPOSITORY_URL')
 @click.argument('repository_url')
 @click.argument('directory', required=False)
 @click.option('--untracked', is_flag=True, default=False, help='Does not preserve git repository tracking.')

--- a/ml_git/commands/general.py
+++ b/ml_git/commands/general.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
@@ -23,9 +23,9 @@ def mlgit():
 
 @mlgit.command('clone', help='Clone a ml-git repository ML_GIT_REPOSITORY_URL')
 @click.argument('repository_url')
-@click.option('--folder', default=None, help='The configuration files are cloned in specified folder.')
+@click.argument('directory', required=False)
 @click.option('--untracked', is_flag=True, default=False, help='Does not preserve git repository tracking.')
 @click.help_option(hidden=True)
 @click.option('--verbose', is_flag=True, expose_value=False, callback=set_verbose_mode, help='Debug mode')
 def clone(**kwargs):
-    repositories[PROJECT].clone_config(kwargs['repository_url'], kwargs['folder'], kwargs['untracked'])
+    repositories[PROJECT].clone_config(kwargs['repository_url'], kwargs['directory'], kwargs['untracked'])

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -188,7 +188,7 @@ output_messages = {
     'INFO_CONFIGURED_STORAGES': 'Currently configured storages:\n   ',
     'INFO_CREATE_NEW_STORAGE_OPTION': '[X] - Create new data storage\n   ',
 
-    'ERROR_PATH_NOT_EMPTY': 'The path [%s] is not an empty directory. Consider using --folder to create an empty folder.',
+    'ERROR_PATH_NOT_EMPTY': 'The path [%s] is not an empty directory.',
     'ERROR_WITHOUT_TAG_FOR_THIS_ENTITY': 'No entity with that name was found.',
     'ERROR_MULTIPLES_ENTITIES_WITH_SAME_NAME': 'You have more than one entity with the same name. Use one of the following tags to perform the checkout:\n',
     'ERROR_WRONG_VERSION_NUMBER_TO_CHECKOUT': 'The version specified for that entity does not exist. Last entity tag:\n\t%s',
@@ -340,6 +340,7 @@ output_messages = {
     'ERROR_OPTION_WITH_MULTIPLE_VALUES': 'Multiple options are not accepted! The option should only take one value.',
     'ERROR_COMMIT_WITHOUT_ADD': 'Nothing to commit (create/add files and use "ml-git {} add" command to track them)',
     'ERROR_STORAGE_TYPE_INPUT_INVALID': "invalid choice: {}. (choose from s3h, azureblobh, gdriveh, sftph)",
+    'ERROR_BADLY_FORMATTED_URL': 'Badly formatted url {}',
 
     'WARN_CORRUPTED_CANNOT_BE_ADD': 'The following files cannot be added because they are corrupted:',
     'WARN_HAS_CONFIGURED_REMOTE': 'YOU ALREADY HAS A CONFIGURED REMOTE. All data stored in this repository will be sent to the new one on the first push.',

--- a/tests/integration/test_20_clone.py
+++ b/tests/integration/test_20_clone.py
@@ -30,7 +30,7 @@ class CloneTest(unittest.TestCase):
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_01_clone(self):
         self.set_up_clone()
-        self.assertIn(output_messages['INFO_SUCCESS_LOAD_CONFIGURATION'], check_output(MLGIT_CLONE % (self.GIT_CLONE, '--folder=' + CLONE_FOLDER)))
+        self.assertIn(output_messages['INFO_SUCCESS_LOAD_CONFIGURATION'], check_output(MLGIT_CLONE % (self.GIT_CLONE, CLONE_FOLDER)))
         clone_dir = os.path.join(CLONE_FOLDER, '.ml-git')
         self.check_metadata_entity(clone_dir)
         self.assertTrue(os.path.isdir(os.path.join(CLONE_FOLDER, '.git')))
@@ -42,24 +42,24 @@ class CloneTest(unittest.TestCase):
         with open(os.path.join(CLONE_FOLDER, 'file'), 'wt') as file:
             file.write('0' * 2048)
 
-        self.assertIn(output_messages['ERROR_PATH_NOT_EMPTY'] % (os.path.join(self.tmp_dir, CLONE_FOLDER)),
-                      check_output(MLGIT_CLONE % (self.GIT_CLONE, '--folder=' + CLONE_FOLDER)))
+        self.assertIn(output_messages['ERROR_PATH_ALREAD_EXISTS'] % (os.path.join(self.tmp_dir, CLONE_FOLDER)),
+                      check_output(MLGIT_CLONE % (self.GIT_CLONE, CLONE_FOLDER)))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_03_clone_wrong_url(self):
-        self.assertIn(output_messages['INFO_NOT_READY_REMOTE_REPOSITORY'], check_output(MLGIT_CLONE % (self.GIT_CLONE+'wrong', '--folder=' + CLONE_FOLDER)))
+        self.assertIn(output_messages['INFO_NOT_READY_REMOTE_REPOSITORY'], check_output(MLGIT_CLONE % (self.GIT_CLONE+'wrong', CLONE_FOLDER)))
         self.assertFalse(os.path.exists(os.path.join(PATH_TEST, CLONE_FOLDER)))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_folder_without_permissions')
     def test_04_clone_inside_folder_without_permission(self):
         self.set_up_clone()
-        self.assertIn(output_messages['ERROR_FOLDER_PERMISSION_DENIED'], check_output(MLGIT_CLONE % (self.GIT_CLONE, '--folder=' + CLONE_FOLDER)))
+        self.assertIn(output_messages['ERROR_FOLDER_PERMISSION_DENIED'], check_output(MLGIT_CLONE % (self.GIT_CLONE, CLONE_FOLDER)))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_05_clone_folder_with_untracked(self):
         self.set_up_clone()
         self.assertIn(output_messages['INFO_SUCCESS_LOAD_CONFIGURATION'],
-                      check_output((MLGIT_CLONE + ' --untracked') % (self.GIT_CLONE, '--folder=' + CLONE_FOLDER)))
+                      check_output((MLGIT_CLONE + ' --untracked') % (self.GIT_CLONE, CLONE_FOLDER)))
         os.chdir(CLONE_FOLDER)
         self.assertFalse(os.path.exists('.git'))
 
@@ -74,11 +74,11 @@ class CloneTest(unittest.TestCase):
     def test_07_clone_to_folder_without_permission(self):
         self.set_up_clone()
         os.chdir(PATH_TEST)
-        self.assertIn(output_messages['ERROR_FOLDER_PERMISSION_DENIED'], check_output(MLGIT_CLONE % (self.GIT_CLONE, '--folder=test_permission')))
+        self.assertIn(output_messages['ERROR_FOLDER_PERMISSION_DENIED'], check_output(MLGIT_CLONE % (self.GIT_CLONE, 'test_permission')))
 
     @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
     def test_08_clone_repository_with_wrong_configurations(self):
         os.makedirs(self.GIT_CLONE, exist_ok=True)
         create_git_clone_repo(self.GIT_CLONE, self.tmp_dir, 'wrong_git_path')
         self.assertIn(output_messages['WARN_CANNOT_INITIALIZE_METADATA_FOR'] % (DATASETS, ''),
-                      check_output(MLGIT_CLONE % (self.GIT_CLONE, '--folder=' + CLONE_FOLDER)))
+                      check_output(MLGIT_CLONE % (self.GIT_CLONE, CLONE_FOLDER)))

--- a/tests/integration/test_33_config.py
+++ b/tests/integration/test_33_config.py
@@ -78,7 +78,7 @@ class ConfigAcceptanceTests(unittest.TestCase):
         git_repository = os.path.join(PATH_TEST, 'git_clone.git')
         os.makedirs(git_repository, exist_ok=True)
         create_git_clone_repo(git_repository, self.tmp_dir)
-        self.assertIn(output_messages['INFO_SUCCESS_LOAD_CONFIGURATION'], check_output(MLGIT_CLONE % (git_repository, '--folder=' + CLONE_FOLDER)))
+        self.assertIn(output_messages['INFO_SUCCESS_LOAD_CONFIGURATION'], check_output(MLGIT_CLONE % (git_repository, CLONE_FOLDER)))
         self.assertTrue(os.path.exists(os.path.join(CLONE_FOLDER, '.git')))
         self.assertTrue(os.path.exists(os.path.join(CLONE_FOLDER, '.gitignore')))
 


### PR DESCRIPTION
In this PR the `--folder` option was removed from the clone command. To maintain support for creating directories, the optional argument `[DIRECTORY]` has been added. 

```
Usage: ml-git clone [OPTIONS] REPOSITORY_URL [DIRECTORY]

  Clone an ml-git repository ML_GIT_REPOSITORY_URL

Options:
  --untracked  Does not preserve git repository tracking.
  --verbose    Debug mode
```