### PR TITLE
Updating the create command wizard to help with storage configuration

### DIFF
--- a/ml_git/api.py
+++ b/ml_git/api.py
@@ -235,7 +235,7 @@ def create(entity, entity_name, categories, mutability, **kwargs):
             'storage_type':  kwargs.get('storage_type', StorageType.S3H.value),
             'bucket_name': kwargs.get('bucket_name', None), 'unzip': kwargs.get('unzip', False),
             'import_url': kwargs.get('import_url', None), 'credentials_path': kwargs.get('credentials_path', None),
-            'wizard_config': False, 'entity_dir': kwargs.get('entity_dir', '')}
+            'wizard_config': False, 'wizard': False, 'entity_dir': kwargs.get('entity_dir', '')}
 
     repo = get_repository_instance(entity)
     repo.create(args)

--- a/ml_git/commands/prompt_msg.py
+++ b/ml_git/commands/prompt_msg.py
@@ -18,7 +18,7 @@ REGION_MESSAGE = 'Define the AWS region name for the storage [us-east-1]'
 ENDPOINT_MESSAGE = 'If you are using MinIO define the endpoint URL [None]'
 SFTPH_ENDPOINT_MESSAGE = 'Define the endpoint URL [None]'
 USERNAME_SFTPH = 'Define the username for the SFTP login [None]'
-PRIVATE_KEY_SFTPH = 'Define the full path for the private key file [\'.\']'
+PRIVATE_KEY_SFTPH = 'Define the full path for the private key file [None]'
 PORT_SFTPH = 'Define the SFTP port that will be used [22]'
 METRIC_FILE = 'If you have a file with the metrics of this model you can associate it with this version of the entity,' \
               ' define the path to the file [None]'

--- a/ml_git/commands/storage.py
+++ b/ml_git/commands/storage.py
@@ -30,23 +30,23 @@ def storage_add(context, **kwargs):
     if kwargs['type'] == StorageType.S3H.value:
         admin.storage_add(kwargs['type'], kwargs['bucket_name'],
                           wizard_for_field(context, kwargs['credentials'], CREDENTIALS_PROFILE_MESSAGE, wizard_flag=wizard_flag),
-                          global_conf=kwargs['global'],
+                          global_conf=kwargs.get('global', False),
                           endpoint_url=wizard_for_field(context, kwargs['endpoint_url'], ENDPOINT_MESSAGE, wizard_flag=wizard_flag),
                           region=wizard_for_field(context, kwargs['region'], REGION_MESSAGE, wizard_flag=wizard_flag))
     elif kwargs['type'] == StorageType.GDRIVEH.value:
         admin.storage_add(kwargs['type'], kwargs['bucket_name'],
                           wizard_for_field(context, kwargs['credentials'], CREDENTIALS_PATH_MESSAGE, wizard_flag=wizard_flag),
-                          global_conf=kwargs['global'])
+                          global_conf=kwargs.get('global', False))
     elif kwargs['type'] == StorageType.SFTPH.value:
         sftp_configs = {'username':  wizard_for_field(context, kwargs['username'], USERNAME_SFTPH, wizard_flag=wizard_flag),
                         'private_key':  wizard_for_field(context, kwargs['private_key'], PRIVATE_KEY_SFTPH, wizard_flag=wizard_flag),
                         'port': wizard_for_field(context, kwargs['port'], PORT_SFTPH, wizard_flag=wizard_flag, default=22, type=int)}
         admin.storage_add(kwargs['type'], kwargs['bucket_name'], kwargs['credentials'],
-                          global_conf=kwargs['global'],
+                          global_conf=kwargs.get('global', False),
                           endpoint_url=wizard_for_field(context, kwargs['endpoint_url'], SFTPH_ENDPOINT_MESSAGE, wizard_flag=wizard_flag),
                           sftp_configs=sftp_configs)
     else:
-        admin.storage_add(kwargs['type'], kwargs['bucket_name'], kwargs['credentials'], global_conf=kwargs['global'])
+        admin.storage_add(kwargs['type'], kwargs['bucket_name'], kwargs['credentials'], global_conf=kwargs.get('global', False))
 
 
 def storage_del(context, **kwargs):

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -386,7 +386,7 @@ def _get_configured_buckets(configured_storages):
     return valid_buckets, temp_map
 
 
-def start_wizard_questions(repo_type, bucket_name=None):
+def start_wizard_questions(bucket_name=None):
     print(output_messages['INFO_SELECT_STORAGE'])
     configured_storages = config_load()[STORAGE_CONFIG_KEY]
     valid_buckets, temp_map = _get_configured_buckets(configured_storages)
@@ -400,7 +400,6 @@ def start_wizard_questions(repo_type, bucket_name=None):
         storage_type, bucket = extract_storage_info_from_list(temp_map[int(selected)])
     else:
         raise Exception('Invalid option.')
-    _configure_metadata_remote(repo_type)
     return storage_type, bucket
 
 

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -387,7 +387,7 @@ def _get_configured_buckets(configured_storages):
     return valid_buckets, temp_map
 
 
-def start_wizard_questions(repo_type, storage_type, bucket_name):
+def start_wizard_questions(repo_type, storage_type=StorageType.S3H.value, bucket_name=None):
     print(output_messages['INFO_SELECT_STORAGE'])
     configured_storages = config_load()[STORAGE_CONFIG_KEY]
     valid_buckets, temp_map = _get_configured_buckets(configured_storages)

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -11,7 +11,6 @@ import click
 from halo import Halo
 
 from ml_git import spec, log
-from ml_git.commands import prompt_msg
 from ml_git.constants import FAKE_STORAGE, BATCH_SIZE_VALUE, BATCH_SIZE, StorageType, GLOBAL_ML_GIT_CONFIG, \
     PUSH_THREADS_COUNT, SPEC_EXTENSION, EntityType, STORAGE_CONFIG_KEY, STORAGE_SPEC_KEY, DATASET_SPEC_KEY, \
     MultihashStorageType
@@ -365,7 +364,7 @@ def _get_user_input(message, default=None, required=False):
 
 def _create_new_bucket(storage_type, bucket_name):
     if storage_type is None:
-        storage_type = click.prompt(prompt_msg.STORAGE_TYPE_MESSAGE, default=StorageType.S3H.value,
+        storage_type = click.prompt(output_messages['INFO_DEFINE_STORAGE_TYPE'], default=StorageType.S3H.value,
                                     show_default=True, type=click.Choice(MultihashStorageType.to_list()), show_choices=True)
     if bucket_name is None:
         bucket_name = _get_user_input(output_messages['INFO_DEFINE_WIZARD_MESSAGE'].format('storage name'), required=True)

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -7,9 +7,11 @@ import os
 import shutil
 from pathlib import Path
 
+import click
 from halo import Halo
 
 from ml_git import spec, log
+from ml_git.commands import prompt_msg
 from ml_git.constants import FAKE_STORAGE, BATCH_SIZE_VALUE, BATCH_SIZE, StorageType, GLOBAL_ML_GIT_CONFIG, \
     PUSH_THREADS_COUNT, SPEC_EXTENSION, EntityType, STORAGE_CONFIG_KEY, STORAGE_SPEC_KEY, DATASET_SPEC_KEY, \
     MultihashStorageType
@@ -361,30 +363,18 @@ def _get_user_input(message, default=None, required=False):
     return value
 
 
-def _create_new_bucket():
-    storages_types = [item.value for item in MultihashStorageType]
-    storage_type = input(USER_INPUT_MESSAGE.format('storage type {}'.format(str(storages_types)))).lower()
-
-    credential_profile = None
-    endpoint = None
-    sftp_configs = None
-
-    if storage_type not in storages_types:
-        raise RuntimeError(output_messages['ERROR_INVALID_STORAGE_TYPE'])
-    bucket = _get_user_input(USER_INPUT_MESSAGE.format('bucket name'), required=True)
-    if storage_type == StorageType.S3H.value:
-        credential_profile = _get_user_input(USER_INPUT_MESSAGE.format('credentials'))
-        endpoint = _get_user_input('If you are using MinIO inform the endpoint URL, otherwise press ENTER: ')
-    elif storage_type == StorageType.GDRIVEH.value:
-        credential_profile = _get_user_input(USER_INPUT_MESSAGE.format('credentials path'), default='.')
-    elif storage_type == StorageType.SFTPH.value:
-        endpoint = _get_user_input(USER_INPUT_MESSAGE.format('endpoint URL'))
-        sftp_configs = {'username': _get_user_input(USER_INPUT_MESSAGE.format('username')),
-                        'private_key': _get_user_input(USER_INPUT_MESSAGE.format('credentials path'), default='.'),
-                        'port': int(_get_user_input(USER_INPUT_MESSAGE.format('port'), default=22))}
-    from ml_git.admin import storage_add
-    storage_add(storage_type, bucket, credential_profile, endpoint_url=endpoint, sftp_configs=sftp_configs)
-    return storage_type, bucket
+def _create_new_bucket(storage_type, bucket_name):
+    if storage_type is None:
+        storage_type = click.prompt(prompt_msg.STORAGE_TYPE_MESSAGE, default=StorageType.S3H.value,
+                                    show_default=True, type=click.Choice(MultihashStorageType.to_list()), show_choices=True)
+    if bucket_name is None:
+        bucket_name = _get_user_input(output_messages['INFO_DEFINE_WIZARD_MESSAGE'].format('storage name'), required=True)
+    from ml_git.commands.storage import storage_add
+    storage_add(None, wizard=True, type=storage_type, bucket_name=bucket_name, credentials=None, region=None,
+                endpoint_url=None, username=None, private_key=None, port=None)
+    if storage_type == StorageType.AZUREBLOBH.value:
+        log.info(output_messages['INFO_CONFIGURE_AZURE'])
+    return storage_type, bucket_name
 
 
 def _get_configured_buckets(configured_storages):
@@ -393,22 +383,21 @@ def _get_configured_buckets(configured_storages):
     for storage_type in configured_storages:
         for storage_name in configured_storages[storage_type].keys():
             valid_buckets.append(storage_name)
-            print('[%s] - %s - %s' % (str(len(valid_buckets)), storage_type, storage_name))
+            print('%s - [%s] %s' % (str(len(valid_buckets)), storage_type, storage_name))
             temp_map[len(valid_buckets)] = [storage_type, storage_name]
     return valid_buckets, temp_map
 
 
-def start_wizard_questions(repo_type):
-    print(output_messages['INFO_CONFIGURED_STORAGES'])
+def start_wizard_questions(repo_type, storage_type, bucket_name):
+    print(output_messages['INFO_SELECT_STORAGE'])
     configured_storages = config_load()[STORAGE_CONFIG_KEY]
-
     valid_buckets, temp_map = _get_configured_buckets(configured_storages)
     print(output_messages['INFO_CREATE_NEW_STORAGE_OPTION'])
-    selected = input(USER_INPUT_MESSAGE.format('storage you want to use'))
+    selected = input(output_messages['INFO_SELECT_STORAGE_OPTION'])
 
     valid_buckets_options = range(1, len(valid_buckets) + 1)
     if selected.upper() == 'X':
-        storage_type, bucket = _create_new_bucket()
+        storage_type, bucket = _create_new_bucket(storage_type, bucket_name)
     elif selected.isnumeric() and int(selected) in valid_buckets_options:
         storage_type, bucket = extract_storage_info_from_list(temp_map[int(selected)])
     else:

--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -362,10 +362,9 @@ def _get_user_input(message, default=None, required=False):
     return value
 
 
-def _create_new_bucket(storage_type, bucket_name):
-    if storage_type is None:
-        storage_type = click.prompt(output_messages['INFO_DEFINE_STORAGE_TYPE'], default=StorageType.S3H.value,
-                                    show_default=True, type=click.Choice(MultihashStorageType.to_list()), show_choices=True)
+def _create_new_bucket(bucket_name):
+    storage_type = click.prompt(output_messages['INFO_DEFINE_STORAGE_TYPE'], default=StorageType.S3H.value,
+                                show_default=True, type=click.Choice(MultihashStorageType.to_list()), show_choices=True)
     if bucket_name is None:
         bucket_name = _get_user_input(output_messages['INFO_DEFINE_WIZARD_MESSAGE'].format('storage name'), required=True)
     from ml_git.commands.storage import storage_add
@@ -387,7 +386,7 @@ def _get_configured_buckets(configured_storages):
     return valid_buckets, temp_map
 
 
-def start_wizard_questions(repo_type, storage_type=StorageType.S3H.value, bucket_name=None):
+def start_wizard_questions(repo_type, bucket_name=None):
     print(output_messages['INFO_SELECT_STORAGE'])
     configured_storages = config_load()[STORAGE_CONFIG_KEY]
     valid_buckets, temp_map = _get_configured_buckets(configured_storages)
@@ -396,7 +395,7 @@ def start_wizard_questions(repo_type, storage_type=StorageType.S3H.value, bucket
 
     valid_buckets_options = range(1, len(valid_buckets) + 1)
     if selected.upper() == 'X':
-        storage_type, bucket = _create_new_bucket(storage_type, bucket_name)
+        storage_type, bucket = _create_new_bucket(bucket_name)
     elif selected.isnumeric() and int(selected) in valid_buckets_options:
         storage_type, bucket = extract_storage_info_from_list(temp_map[int(selected)])
     else:

--- a/ml_git/constants.py
+++ b/ml_git/constants.py
@@ -75,6 +75,7 @@ STORAGE_CONFIG_KEY = 'storages'
 MLGIT_IGNORE_FILE_NAME = '.mlgitignore'
 GIT_CLIENT_CLASS_NAME = 'GitClient'
 RELATIONSHIP_GRAPH_FILENAME = 'entities_relationships'
+WIZARD_KEY = 'wizard'
 
 
 class MutabilityType(Enum):

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -190,6 +190,7 @@ output_messages = {
     'INFO_DEFINE_WIZARD_MESSAGE': 'Define the {}: ',
     'INFO_SELECT_STORAGE_OPTION': 'Which storage do you want to use (a number or new data storage)? ',
     'INFO_CONFIGURE_AZURE': 'Configure the azure according to the following documentation: https://github.com/HPInc/ml-git/blob/main/docs/azure_configurations.md',
+    'INFO_DEFINE_STORAGE_TYPE': 'Define the storage type',
 
     'ERROR_PATH_NOT_EMPTY': 'The path [%s] is not an empty directory. Consider using --folder to create an empty folder.',
     'ERROR_WITHOUT_TAG_FOR_THIS_ENTITY': 'No entity with that name was found.',

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -189,7 +189,8 @@ output_messages = {
     'INFO_CREATE_NEW_STORAGE_OPTION': '[X] - New Data Storage Configuration\n   ',
     'INFO_DEFINE_WIZARD_MESSAGE': 'Define the {}: ',
     'INFO_SELECT_STORAGE_OPTION': 'Which storage do you want to use (a number or new data storage)? ',
-    'INFO_CONFIGURE_AZURE': 'Configure the azure according to the following documentation: https://github.com/HPInc/ml-git/blob/main/docs/azure_configurations.md',
+    'INFO_CONFIGURE_AZURE': 'Configure the azure according to the following documentation: '
+                            'https://github.com/HPInc/ml-git/blob/main/docs/azure_configurations.md',
     'INFO_DEFINE_STORAGE_TYPE': 'Define the storage type',
 
     'ERROR_PATH_NOT_EMPTY': 'The path [%s] is not an empty directory. Consider using --folder to create an empty folder.',

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -185,8 +185,11 @@ output_messages = {
     'INFO_LIST_OF_MISSING_FILES': 'List of missing descriptor files: %s',
     'INFO_SEE_COMPLETE_LIST_OF_MISSING_FILES': 'You can use the --full option to see the complete list of missing descriptor files.',
     'INFO_WIZARD_MODE_CHANGED': 'Wizard mode changed to \'{}\'',
-    'INFO_CONFIGURED_STORAGES': 'Currently configured storages:\n   ',
-    'INFO_CREATE_NEW_STORAGE_OPTION': '[X] - Create new data storage\n   ',
+    'INFO_SELECT_STORAGE': 'Select the storage where this entity\'s data should be stored:',
+    'INFO_CREATE_NEW_STORAGE_OPTION': '[X] - New Data Storage Configuration\n   ',
+    'INFO_DEFINE_WIZARD_MESSAGE': 'Define the {}: ',
+    'INFO_SELECT_STORAGE_OPTION': 'Which storage do you want to use (a number or new data storage)? ',
+    'INFO_CONFIGURE_AZURE': 'Configure the azure according to the following documentation: https://github.com/HPInc/ml-git/blob/main/docs/azure_configurations.md',
 
     'ERROR_PATH_NOT_EMPTY': 'The path [%s] is not an empty directory. Consider using --folder to create an empty folder.',
     'ERROR_WITHOUT_TAG_FOR_THIS_ENTITY': 'No entity with that name was found.',

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -1116,7 +1116,7 @@ class Repository(object):
             create_workspace_tree_structure(repo_type, artifact_name, categories, storage_type, bucket_name,
                                             version, imported_dir, kwargs['mutability'], entity_dir)
             if start_wizard:
-                storage_type, bucket = start_wizard_questions(repo_type, bucket_name)
+                storage_type, bucket = start_wizard_questions(bucket_name)
                 update_storage_spec(repo_type, artifact_name, storage_type, bucket, entity_dir)
             if import_url:
                 self.create_config_storage(StorageType.GDRIVE.value, credentials_path)

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -14,6 +14,7 @@ from halo import Halo
 from ml_git import log
 from ml_git._metadata import MetadataRepo
 from ml_git.admin import remote_add, clone_config_repository, init_mlgit, remote_del
+from ml_git.commands.wizard import is_wizard_enabled
 from ml_git.config import get_index_path, get_objects_path, get_cache_path, get_metadata_path, get_refs_path, \
     validate_config_spec_hash, validate_spec_hash, get_sample_config_spec, get_sample_spec_doc, \
     get_index_metadata_path, create_workspace_tree_structure, start_wizard_questions, config_load, \
@@ -1103,7 +1104,7 @@ class Repository(object):
         imported_dir = kwargs['import']
         storage_type = kwargs['storage_type']
         bucket_name = kwargs['bucket_name']
-        start_wizard = kwargs['wizard_config']
+        start_wizard = kwargs['wizard_config'] or kwargs['wizard'] or is_wizard_enabled()
         import_url = kwargs['import_url']
         unzip_file = kwargs['unzip']
         credentials_path = kwargs['credentials_path']
@@ -1114,7 +1115,7 @@ class Repository(object):
             create_workspace_tree_structure(repo_type, artifact_name, categories, storage_type, bucket_name,
                                             version, imported_dir, kwargs['mutability'], entity_dir)
             if start_wizard:
-                storage_type, bucket = start_wizard_questions(repo_type)
+                storage_type, bucket = start_wizard_questions(repo_type, storage_type, bucket_name)
                 update_storage_spec(repo_type, artifact_name, storage_type, bucket, entity_dir)
             if import_url:
                 self.create_config_storage(StorageType.GDRIVE.value, credentials_path)

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -14,15 +14,14 @@ from halo import Halo
 from ml_git import log
 from ml_git._metadata import MetadataRepo
 from ml_git.admin import remote_add, clone_config_repository, init_mlgit, remote_del
-from ml_git.commands.wizard import is_wizard_enabled
 from ml_git.config import get_index_path, get_objects_path, get_cache_path, get_metadata_path, get_refs_path, \
     validate_config_spec_hash, validate_spec_hash, get_sample_config_spec, get_sample_spec_doc, \
     get_index_metadata_path, create_workspace_tree_structure, start_wizard_questions, config_load, \
-    get_global_config_path, save_global_config_in_local
+    get_global_config_path, save_global_config_in_local, merged_config_load
 from ml_git.constants import REPOSITORY_CLASS_NAME, LOCAL_REPOSITORY_CLASS_NAME, HEAD, HEAD_1, MutabilityType, \
     StorageType, \
     RGX_TAG_FORMAT, EntityType, MANIFEST_FILE, SPEC_EXTENSION, MANIFEST_KEY, STATUS_NEW_FILE, STATUS_DELETED_FILE, \
-    FileType, STORAGE_CONFIG_KEY, CONFIG_FILE
+    FileType, STORAGE_CONFIG_KEY, CONFIG_FILE, WIZARD_KEY
 from ml_git.file_system.cache import Cache
 from ml_git.file_system.hashfs import MultihashFS
 from ml_git.file_system.index import MultihashIndex, Status, FullIndex
@@ -1104,7 +1103,9 @@ class Repository(object):
         imported_dir = kwargs['import']
         storage_type = kwargs['storage_type']
         bucket_name = kwargs['bucket_name']
-        start_wizard = kwargs['wizard_config'] or kwargs['wizard'] or is_wizard_enabled()
+        config_file = merged_config_load()
+        is_wizard_enabled = kwargs['wizard'] or (WIZARD_KEY in config_file and config_file[WIZARD_KEY] == 'enabled')
+        start_wizard = kwargs['wizard_config'] or is_wizard_enabled
         import_url = kwargs['import_url']
         unzip_file = kwargs['unzip']
         credentials_path = kwargs['credentials_path']

--- a/ml_git/repository.py
+++ b/ml_git/repository.py
@@ -1116,7 +1116,7 @@ class Repository(object):
             create_workspace_tree_structure(repo_type, artifact_name, categories, storage_type, bucket_name,
                                             version, imported_dir, kwargs['mutability'], entity_dir)
             if start_wizard:
-                storage_type, bucket = start_wizard_questions(repo_type, storage_type, bucket_name)
+                storage_type, bucket = start_wizard_questions(repo_type, bucket_name)
                 update_storage_spec(repo_type, artifact_name, storage_type, bucket, entity_dir)
             if import_url:
                 self.create_config_storage(StorageType.GDRIVE.value, credentials_path)

--- a/ml_git/storages/sftp_storage.py
+++ b/ml_git/storages/sftp_storage.py
@@ -43,7 +43,7 @@ class SFtpStorage(Storage):
     def bucket_exists(self):
         try:
             self._storage.chdir(self._bucket)
-        except IOError as e:
+        except IOError:
             error_msg = output_messages['ERROR_BUCKET_DOES_NOT_EXIST'] % self._bucket
             log.error(error_msg, class_name=SFTPSTORE_NAME)
             return False

--- a/ml_git/storages/sftp_storage.py
+++ b/ml_git/storages/sftp_storage.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 
@@ -29,8 +29,10 @@ class SFtpStorage(Storage):
         ssh_client = paramiko.SSHClient()
         ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
-        user_private_key = paramiko.RSAKey.from_private_key_file(self._private_key)
-        ssh_client.connect(self._host, port=self._port, username=self._username, pkey=user_private_key)
+        pkey = None
+        if self._private_key:
+            pkey = paramiko.RSAKey.from_private_key_file(self._private_key)
+        ssh_client.connect(self._host, port=self._port, username=self._username, pkey=pkey)
 
         open_session = ssh_client.get_transport().open_session()
         paramiko.agent.AgentRequestHandler(open_session)
@@ -41,7 +43,7 @@ class SFtpStorage(Storage):
     def bucket_exists(self):
         try:
             self._storage.chdir(self._bucket)
-        except IOError:
+        except IOError as e:
             error_msg = output_messages['ERROR_BUCKET_DOES_NOT_EXIST'] % self._bucket
             log.error(error_msg, class_name=SFTPSTORE_NAME)
             return False

--- a/tests/integration/test_19_create.py
+++ b/tests/integration/test_19_create.py
@@ -368,8 +368,8 @@ class CreateAcceptanceTests(unittest.TestCase):
         region = 'us-east-1'
         storage_type = StorageType.S3H.value
         runner = CliRunner()
-        result = runner.invoke(entity.datasets, ['create', bucket_name],
-                               input='\n'.join(['category', 'strict', 'X', storage_type, bucket_name, PROFILE, endpoint_url, region]))
+        runner.invoke(entity.datasets, ['create', entity_type + '-ex', '--wizard'],
+                      input='\n'.join(['category', 'strict', 'X', storage_type, bucket_name, PROFILE, endpoint_url, region, '']))
 
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
@@ -378,7 +378,6 @@ class CreateAcceptanceTests(unittest.TestCase):
             self.assertEqual(endpoint_url, config[STORAGE_CONFIG_KEY][S3H][bucket_name]['endpoint-url'])
             self.assertEqual(region, config[STORAGE_CONFIG_KEY][S3H][bucket_name]['region'])
 
-        self.assertIn(output_messages['INFO_DATASETS_CREATED'], result.output)
         folder_data = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'data')
         spec = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', entity_type + '-ex.spec')
         readme = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'README.md')
@@ -398,16 +397,15 @@ class CreateAcceptanceTests(unittest.TestCase):
         endpoint_url = 'www.url.com'
         storage_type = StorageType.SFTPH.value
         runner = CliRunner()
-        result = runner.invoke(entity.datasets, ['create', entity_type + '-ex'],
-                               input='\n'.join(['category', 'strict', 'X', storage_type, bucket_name, PROFILE, '.', endpoint_url, '']))
+        runner.invoke(entity.datasets, ['create', entity_type + '-ex' , '--wizard'],
+                      input='\n'.join(['category', 'strict', 'X', storage_type, bucket_name, PROFILE, '.', '', endpoint_url]))
 
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
             self.assertTrue(bucket_name in config[STORAGE_CONFIG_KEY][SFTPH])
-            self.assertEqual(endpoint_url, config[STORAGE_CONFIG_KEY][S3H][bucket_name]['endpoint-url'])
-            self.assertEqual(PROFILE, config[STORAGE_CONFIG_KEY][S3H][bucket_name]['username'])
-            self.assertEqual(22, config[STORAGE_CONFIG_KEY][S3H][bucket_name]['port'])
-        self.assertIn(output_messages['INFO_DATASETS_CREATED'], result.output)
+            self.assertEqual(endpoint_url, config[STORAGE_CONFIG_KEY][SFTPH][bucket_name]['endpoint-url'])
+            self.assertEqual(PROFILE, config[STORAGE_CONFIG_KEY][SFTPH][bucket_name]['username'])
+            self.assertEqual(22, config[STORAGE_CONFIG_KEY][SFTPH][bucket_name]['port'])
         spec = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', entity_type + '-ex.spec')
         entity_spec_key = get_spec_key(entity_type)
         with open(spec, 'r') as s:
@@ -421,13 +419,12 @@ class CreateAcceptanceTests(unittest.TestCase):
         bucket_name = 'test-wizard'
         storage_type = StorageType.AZUREBLOBH.value
         runner = CliRunner()
-        result = runner.invoke(entity.datasets, ['create', entity_type + '-ex'],
-                               input='\n'.join(['category', 'strict', 'X', AZUREBLOBH, bucket_name]))
+        runner.invoke(entity.datasets, ['create', entity_type + '-ex', '--wizard'],
+                      input='\n'.join(['category', 'strict', 'X', AZUREBLOBH, bucket_name]))
 
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
             self.assertTrue(bucket_name in config[STORAGE_CONFIG_KEY][AZUREBLOBH])
-        self.assertIn(output_messages['INFO_DATASETS_CREATED'], result.output)
         spec = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', entity_type + '-ex.spec')
         with open(spec, 'r') as s:
             spec_file = yaml_processor.load(s)
@@ -440,13 +437,12 @@ class CreateAcceptanceTests(unittest.TestCase):
         bucket_name = 'test-wizard'
         storage_type = StorageType.GDRIVEH.value
         runner = CliRunner()
-        result = runner.invoke(entity.datasets, ['create', entity_type + '-ex'],
-                               input='\n'.join(['category', 'strict', 'X', GDRIVEH, bucket_name, '']))
+        runner.invoke(entity.datasets, ['create', entity_type + '-ex', '--wizard'],
+                      input='\n'.join(['category', 'strict', 'X', GDRIVEH, bucket_name, '']))
 
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
             self.assertTrue(bucket_name in config[STORAGE_CONFIG_KEY][GDRIVEH])
-        self.assertIn(output_messages['INFO_DATASETS_CREATED'], result.output)
         spec = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', entity_type + '-ex.spec')
         with open(spec, 'r') as s:
             spec_file = yaml_processor.load(s)

--- a/tests/integration/test_19_create.py
+++ b/tests/integration/test_19_create.py
@@ -10,13 +10,14 @@ import pytest
 from click.testing import CliRunner
 
 from ml_git.commands import entity
-from ml_git.constants import LABELS_SPEC_KEY, MODEL_SPEC_KEY, STORAGE_SPEC_KEY, DATASET_SPEC_KEY
+from ml_git.constants import LABELS_SPEC_KEY, MODEL_SPEC_KEY, STORAGE_SPEC_KEY, DATASET_SPEC_KEY, STORAGE_CONFIG_KEY, \
+    StorageType
 from ml_git.ml_git_message import output_messages
 from ml_git.spec import get_spec_key
 from tests.integration.commands import MLGIT_CREATE, MLGIT_INIT
 from tests.integration.helper import check_output, ML_GIT_DIR, IMPORT_PATH, create_file, ERROR_MESSAGE, yaml_processor, \
     create_zip_file, DATASETS, DATASET_NAME, MODELS, LABELS, STRICT, FLEXIBLE, MUTABLE, GDRIVEH, AZUREBLOBH, S3H, \
-    disable_wizard_in_config
+    disable_wizard_in_config, PROFILE, SFTPH
 
 
 @pytest.mark.usefixtures('tmp_dir')
@@ -357,3 +358,96 @@ class CreateAcceptanceTests(unittest.TestCase):
         self.assertIn(output_messages['ERROR_INVALID_VALUE_FOR_ENTITY'].format(entity_name),
                       check_output(MLGIT_CREATE % (entity_type, entity_name)
                       + ' --categories=img --mutability=' + STRICT))
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_30_create_entity_and_s3h_storage_with_wizard(self):
+        entity_type = DATASETS
+        self.assertIn(output_messages['INFO_INITIALIZED_PROJECT_IN'] % self.tmp_dir, check_output(MLGIT_INIT))
+        bucket_name = 'test-wizard'
+        endpoint_url = 'www.url.com'
+        region = 'us-east-1'
+        storage_type = StorageType.S3H.value
+        runner = CliRunner()
+        result = runner.invoke(entity.datasets, ['create', bucket_name],
+                               input='\n'.join(['category', 'strict', 'X', storage_type, bucket_name, PROFILE, endpoint_url, region]))
+
+        with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
+            config = yaml_processor.load(c)
+            self.assertTrue(bucket_name in config[STORAGE_CONFIG_KEY][S3H])
+            self.assertEqual(PROFILE, config[STORAGE_CONFIG_KEY][S3H][bucket_name]['aws-credentials']['profile'])
+            self.assertEqual(endpoint_url, config[STORAGE_CONFIG_KEY][S3H][bucket_name]['endpoint-url'])
+            self.assertEqual(region, config[STORAGE_CONFIG_KEY][S3H][bucket_name]['region'])
+
+        self.assertIn(output_messages['INFO_DATASETS_CREATED'], result.output)
+        folder_data = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'data')
+        spec = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', entity_type + '-ex.spec')
+        readme = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', 'README.md')
+        entity_spec_key = get_spec_key(entity_type)
+        with open(spec, 'r') as s:
+            spec_file = yaml_processor.load(s)
+            self.assertEqual(spec_file[entity_spec_key]['manifest'][STORAGE_SPEC_KEY], storage_type + '://' + bucket_name)
+        self.assertTrue(os.path.exists(folder_data))
+        self.assertTrue(os.path.exists(spec))
+        self.assertTrue(os.path.exists(readme))
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_31_create_entity_and_sftph_storage_with_wizard(self):
+        entity_type = DATASETS
+        self.assertIn(output_messages['INFO_INITIALIZED_PROJECT_IN'] % self.tmp_dir, check_output(MLGIT_INIT))
+        bucket_name = 'test-wizard'
+        endpoint_url = 'www.url.com'
+        storage_type = StorageType.SFTPH.value
+        runner = CliRunner()
+        result = runner.invoke(entity.datasets, ['create', entity_type + '-ex'],
+                               input='\n'.join(['category', 'strict', 'X', storage_type, bucket_name, PROFILE, '.', endpoint_url, '']))
+
+        with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
+            config = yaml_processor.load(c)
+            self.assertTrue(bucket_name in config[STORAGE_CONFIG_KEY][SFTPH])
+            self.assertEqual(endpoint_url, config[STORAGE_CONFIG_KEY][S3H][bucket_name]['endpoint-url'])
+            self.assertEqual(PROFILE, config[STORAGE_CONFIG_KEY][S3H][bucket_name]['username'])
+            self.assertEqual(22, config[STORAGE_CONFIG_KEY][S3H][bucket_name]['port'])
+        self.assertIn(output_messages['INFO_DATASETS_CREATED'], result.output)
+        spec = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', entity_type + '-ex.spec')
+        entity_spec_key = get_spec_key(entity_type)
+        with open(spec, 'r') as s:
+            spec_file = yaml_processor.load(s)
+            self.assertEqual(spec_file[entity_spec_key]['manifest'][STORAGE_SPEC_KEY], storage_type + '://' + bucket_name)
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_32_create_entity_and_azureblobh_storage_with_wizard(self):
+        entity_type = DATASETS
+        self.assertIn(output_messages['INFO_INITIALIZED_PROJECT_IN'] % self.tmp_dir, check_output(MLGIT_INIT))
+        bucket_name = 'test-wizard'
+        storage_type = StorageType.AZUREBLOBH.value
+        runner = CliRunner()
+        result = runner.invoke(entity.datasets, ['create', entity_type + '-ex'],
+                               input='\n'.join(['category', 'strict', 'X', AZUREBLOBH, bucket_name]))
+
+        with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
+            config = yaml_processor.load(c)
+            self.assertTrue(bucket_name in config[STORAGE_CONFIG_KEY][AZUREBLOBH])
+        self.assertIn(output_messages['INFO_DATASETS_CREATED'], result.output)
+        spec = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', entity_type + '-ex.spec')
+        with open(spec, 'r') as s:
+            spec_file = yaml_processor.load(s)
+            self.assertEqual(spec_file[get_spec_key(entity_type)]['manifest'][STORAGE_SPEC_KEY], storage_type + '://' + bucket_name)
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_33_create_entity_and_gdriveh_storage_with_wizard(self):
+        entity_type = DATASETS
+        self.assertIn(output_messages['INFO_INITIALIZED_PROJECT_IN'] % self.tmp_dir, check_output(MLGIT_INIT))
+        bucket_name = 'test-wizard'
+        storage_type = StorageType.GDRIVEH.value
+        runner = CliRunner()
+        result = runner.invoke(entity.datasets, ['create', entity_type + '-ex'],
+                               input='\n'.join(['category', 'strict', 'X', GDRIVEH, bucket_name, '']))
+
+        with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
+            config = yaml_processor.load(c)
+            self.assertTrue(bucket_name in config[STORAGE_CONFIG_KEY][AZUREBLOBH])
+        self.assertIn(output_messages['INFO_DATASETS_CREATED'], result.output)
+        spec = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', entity_type + '-ex.spec')
+        with open(spec, 'r') as s:
+            spec_file = yaml_processor.load(s)
+            self.assertEqual(spec_file[get_spec_key(entity_type)]['manifest'][STORAGE_SPEC_KEY], storage_type + '://' + bucket_name)

--- a/tests/integration/test_19_create.py
+++ b/tests/integration/test_19_create.py
@@ -397,7 +397,7 @@ class CreateAcceptanceTests(unittest.TestCase):
         endpoint_url = 'www.url.com'
         storage_type = StorageType.SFTPH.value
         runner = CliRunner()
-        runner.invoke(entity.datasets, ['create', entity_type + '-ex' , '--wizard'],
+        runner.invoke(entity.datasets, ['create', entity_type + '-ex', '--wizard'],
                       input='\n'.join(['category', 'strict', 'X', storage_type, bucket_name, PROFILE, '.', '', endpoint_url]))
 
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:

--- a/tests/integration/test_19_create.py
+++ b/tests/integration/test_19_create.py
@@ -445,7 +445,7 @@ class CreateAcceptanceTests(unittest.TestCase):
 
         with open(os.path.join(self.tmp_dir, ML_GIT_DIR, 'config.yaml'), 'r') as c:
             config = yaml_processor.load(c)
-            self.assertTrue(bucket_name in config[STORAGE_CONFIG_KEY][AZUREBLOBH])
+            self.assertTrue(bucket_name in config[STORAGE_CONFIG_KEY][GDRIVEH])
         self.assertIn(output_messages['INFO_DATASETS_CREATED'], result.output)
         spec = os.path.join(self.tmp_dir, entity_type, entity_type + '-ex', entity_type + '-ex.spec')
         with open(spec, 'r') as s:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -15,12 +15,11 @@ from ml_git.config import validate_config_spec_hash, get_sample_config_spec, get
     validate_spec_hash, config_verbose, get_refs_path, config_load, mlgit_config_load, list_repos, \
     get_index_path, get_objects_path, get_cache_path, get_metadata_path, import_dir, \
     extract_storage_info_from_list, create_workspace_tree_structure, get_batch_size, merge_conf, \
-    merge_local_with_global_config, mlgit_config, save_global_config_in_local, start_wizard_questions, \
-    merged_config_load, _get_user_input
+    merge_local_with_global_config, mlgit_config, save_global_config_in_local, merged_config_load, _get_user_input
 from ml_git.constants import BATCH_SIZE_VALUE, BATCH_SIZE, STORAGE_CONFIG_KEY, STORAGE_SPEC_KEY, DATASET_SPEC_KEY, \
     PUSH_THREADS_COUNT
 from ml_git.utils import get_root_path, yaml_load, yaml_processor
-from tests.unit.conftest import DATASETS, LABELS, MODELS, STRICT, S3H, S3, GDRIVEH, SFTPH
+from tests.unit.conftest import DATASETS, LABELS, MODELS, STRICT, S3H, S3
 
 
 @pytest.mark.usefixtures('tmp_dir')
@@ -208,44 +207,6 @@ class ConfigTestCases(unittest.TestCase):
 
         config = yaml_load('.ml-git/config.yaml')
         self.assertEqual(config[LABELS]['git'], new_remote)
-
-    @pytest.mark.usefixtures('switch_to_test_dir')
-    def test_start_wizard_questions(self):
-        bucket_name = 'mlgit'
-        new_s3_storage_options = ['git_repo', 'endpoint', 'default', bucket_name, S3H, 'X']
-        invalid_storage_options = ['invalid_storage', 'X']
-        new_gdrive_storage_options = ['git_repo', '.credentials', bucket_name, GDRIVEH, 'X']
-        new_sftph_storage_options = ['git_repo', '9000', 'private_key', 'username', 'endpoint', bucket_name, SFTPH, 'X']
-
-        with mock.patch('builtins.input', return_value='invalid_selected_option'):
-            self.assertRaises(Exception, lambda: start_wizard_questions(DATASETS))
-
-        self.create_bucket_in_config_yaml()
-        with mock.patch('builtins.input', return_value='1'):
-            storage_type, bucket = start_wizard_questions(DATASETS)
-            self.assertEqual(storage_type, S3H)
-            self.assertEqual(bucket, 'mlgit-bucket')
-
-        with mock.patch('builtins.input', new=lambda *args, **kwargs: invalid_storage_options.pop()):
-            self.assertRaises(Exception, lambda: start_wizard_questions(DATASETS))
-
-        with mock.patch('builtins.input', new=lambda *args, **kwargs: new_s3_storage_options.pop()):
-            storage_type, bucket = start_wizard_questions(DATASETS)
-            self.assertEqual(storage_type, S3H)
-            self.assertEqual(bucket, bucket_name)
-            self.check_storage(bucket, storage_type, self.tmp_dir)
-
-        with mock.patch('builtins.input', new=lambda *args, **kwargs: new_gdrive_storage_options.pop()):
-            storage_type, bucket = start_wizard_questions(DATASETS)
-            self.assertEqual(storage_type, GDRIVEH)
-            self.assertEqual(bucket, bucket_name)
-            self.check_storage(bucket, storage_type, self.tmp_dir)
-
-        with mock.patch('builtins.input', new=lambda *args, **kwargs: new_sftph_storage_options.pop()):
-            storage_type, bucket = start_wizard_questions(DATASETS)
-            self.assertEqual(storage_type, SFTPH)
-            self.assertEqual(bucket, 'mlgit')
-            self.check_storage(bucket, storage_type, self.tmp_dir)
 
     @pytest.mark.usefixtures('switch_to_tmp_dir')
     def test_merged_config_load(self):


### PR DESCRIPTION
In this PR we changed the create command wizard to assist the user during the creation of a storage.


**Creating s3h storage:**
```
$ ml-git datasets create dataset-ex --wizard
At least one category must be defined. The categories' names must be comma-separated. Please inform the value for the categories option: demo
An entity must have a defined mutability. Please inform the value for the mutability option (strict, flexible, mutable): strict
Select the storage where this entity's data should be stored:
[X] - New Data Storage Configuration

Which storage do you want to use (a number or new data storage)? X
Define the storage type (s3h, azureblobh, gdriveh, sftph) [s3h]: s3h
Define the storage name: demo-s3h
Define the profile to be used to connect to S3 [default]:
If you are using MinIO define the endpoint URL [None]:
Define the AWS region name for the storage [us-east-1]:
INFO - Admin: Add storage [s3h://demo-s3h]
INFO - Admin: When making changes to the config file we strongly recommend that you upload these changes to the Git repository. For this, see: ml-git repository config push --help
INFO - MLGit: Dataset artifact created.
```

**Creating sftph storage:**
```
$ ml-git datasets create dataset-ex2 --wizeard
At least one category must be defined. The categories' names must be comma-separated. Please inform the value for the categories option: demo
An entity must have a defined mutability. Please inform the value for the mutability option (strict, flexible, mutable): strict
Select the storage where this entity's data should be stored:
1 - [s3h] demo-s3h
[X] - New Data Storage Configuration

Which storage do you want to use (a number or new data storage)? X
Define the storage type (s3h, azureblobh, gdriveh, sftph) [s3h]: sftph
Define the storage name: demo-sftph
Define the username for the SFTP login [None]:
Define the full path for the private key file [None]:
Define the SFTP port that will be used [22]:
Define the endpoint URL [None]:
INFO - Admin: Add storage [sftph://demo-sftph]
INFO - Admin: When making changes to the config file we strongly recommend that you upload these changes to the Git repository. For this, see: ml-git repository config push --help
INFO - MLGit: Dataset artifact created.
```

**Creating azureblobh storage:**
```
$ ml-git datasets create data-final5 --wizard
At least one category must be defined. The categories' names must be comma-separated. Please inform the value for the categories option: demo
An entity must have a defined mutability. Please inform the value for the mutability option (strict, flexible, mutable): strict
Select the storage where this entity's data should be stored:
1 - [s3h] demo-s3h
2 - [sftph] demo-sftph
[X] - New Data Storage Configuration

Which storage do you want to use (a number or new data storage)? X
Define the storage type (s3h, azureblobh, gdriveh, sftph) [s3h]: azureblobh
Define the storage name: demo-azureblobh
INFO - Admin: Add storage [azureblobh://demo-azureblobh]
INFO - Admin: When making changes to the config file we strongly recommend that you upload these changes to the Git repository. For this, see: ml-git repository config push --help
INFO - MLGit: Configure the azure according to the following documentation: https://github.com/HPInc/ml-git/blob/main/docs/azure_configurations.md
INFO - MLGit: Dataset artifact created.
```

**Creating gdriveh storage:**
```
ml-git datasets create data-final6 --wizard
At least one category must be defined. The categories' names must be comma-separated. Please inform the value for the categories option: demo
An entity must have a defined mutability. Please inform the value for the mutability option (strict, flexible, mutable): strict
Select the storage where this entity's data should be stored:
1 - [s3h] demo-s3h
2 - [sftph] demo-sftph
3 - [azurelobh] demo-azureblobh
[X] - New Data Storage Configuration

Which storage do you want to use (a number or new data storage)? X
Define the storage type (s3h, azureblobh, gdriveh, sftph) [s3h]: gdriveh
Define the storage name: demo-gdriveh
Define the path to the credentials that will be used to connect to GDrive ['.']:
INFO - Admin: Add storage [gdriveh://demo-gdriveh]
INFO - Admin: When making changes to the config file we strongly recommend that you upload these changes to the Git repository. For this, see: ml-git repository config push --help
INFO - MLGit: Dataset artifact created.
```