### PR TITLE
Adding validation to the informed directory for entity creation

### DIFF
--- a/ml_git/config.py
+++ b/ml_git/config.py
@@ -16,7 +16,8 @@ from ml_git.constants import FAKE_STORAGE, BATCH_SIZE_VALUE, BATCH_SIZE, Storage
     MultihashStorageType
 from ml_git.ml_git_message import output_messages
 from ml_git.spec import get_spec_key
-from ml_git.utils import getOrElse, yaml_load, yaml_save, get_root_path, yaml_load_str, RootPathException
+from ml_git.utils import getOrElse, yaml_load, yaml_save, get_root_path, yaml_load_str, RootPathException, \
+    path_is_parent
 
 push_threads = os.cpu_count()*5
 
@@ -302,8 +303,10 @@ def validate_spec_hash(the_hash, entity_key=DATASET_SPEC_KEY):
 def create_workspace_tree_structure(repo_type, artifact_name, categories, storage_type, bucket_name, version,
                                     imported_dir, mutability, entity_dir=''):
     # get root path to create directories and files
-    path = get_root_path()
-    artifact_path = os.path.join(path, repo_type, entity_dir, artifact_name)
+    repo_type_dir = os.path.join(get_root_path(), repo_type)
+    artifact_path = os.path.join(repo_type_dir, entity_dir, artifact_name)
+    if not path_is_parent(repo_type_dir, artifact_path):
+        raise Exception(output_messages['ERROR_INVALID_ENTITY_DIR'].format(entity_dir))
     if os.path.exists(artifact_path):
         raise PermissionError(output_messages['INFO_ENTITY_NAME_EXISTS'])
     data_path = os.path.join(artifact_path, 'data')

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -346,6 +346,7 @@ output_messages = {
     'ERROR_COMMIT_WITHOUT_ADD': 'Nothing to commit (create/add files and use "ml-git {} add" command to track them)',
     'ERROR_STORAGE_TYPE_INPUT_INVALID': "invalid choice: {}. (choose from s3h, azureblobh, gdriveh, sftph)",
     'ERROR_BADLY_FORMATTED_URL': 'Badly formatted url {}',
+    'ERROR_INVALID_ENTITY_DIR': 'The entity data directory must be inside the ml-git project entities directory. \'{}\' is not a valid value.',
 
     'WARN_CORRUPTED_CANNOT_BE_ADD': 'The following files cannot be added because they are corrupted:',
     'WARN_HAS_CONFIGURED_REMOTE': 'YOU ALREADY HAS A CONFIGURED REMOTE. All data stored in this repository will be sent to the new one on the first push.',

--- a/ml_git/utils.py
+++ b/ml_git/utils.py
@@ -417,3 +417,9 @@ def get_ignore_rules(path):
                 ignore_rules.append(rule)
         return ignore_rules
     return None
+
+
+def path_is_parent(parent_path, child_path):
+    parent_path = os.path.abspath(parent_path)
+    child_path = os.path.abspath(child_path)
+    return os.path.commonpath([parent_path]) == os.path.commonpath([parent_path, child_path])

--- a/tests/integration/test_19_create.py
+++ b/tests/integration/test_19_create.py
@@ -447,3 +447,11 @@ class CreateAcceptanceTests(unittest.TestCase):
         with open(spec, 'r') as s:
             spec_file = yaml_processor.load(s)
             self.assertEqual(spec_file[get_spec_key(entity_type)]['manifest'][STORAGE_SPEC_KEY], storage_type + '://' + bucket_name)
+
+    @pytest.mark.usefixtures('start_local_git_server', 'switch_to_tmp_dir')
+    def test_34_create_entity_out_of_project_dir(self):
+        entity_type = DATASETS
+        self.assertIn(output_messages['INFO_INITIALIZED_PROJECT_IN'] % self.tmp_dir, check_output(MLGIT_INIT))
+        command = MLGIT_CREATE % (entity_type, entity_type + '-ex' + ' --categories=img --mutability=strict --entity-dir=../')
+        self.assertIn(output_messages['ERROR_INVALID_ENTITY_DIR'].format('../'), check_output(command))
+        self.assertFalse(os.path.exists(os.path.join(self.tmp_dir, '../', entity_type + '-ex')))

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,5 @@
 """
-© Copyright 2020 HP Development Company, L.P.
+© Copyright 2020-2022 HP Development Company, L.P.
 SPDX-License-Identifier: GPL-2.0-only
 """
 import csv
@@ -20,7 +20,7 @@ from ml_git.utils import json_load, yaml_load, yaml_save, RootPathException, get
     ensure_path_exists, yaml_load_str, get_yaml_str, run_function_per_group, unzip_files_in_directory, \
     remove_from_workspace, group_files_by_path, remove_other_files, remove_unnecessary_files, change_keys_in_config, \
     update_directories_to_plural, validate_config_keys, create_csv_file, create_or_update_gitignore, should_ignore_file, \
-    get_ignore_rules
+    get_ignore_rules, path_is_parent
 from tests.unit.conftest import DATASETS, MODELS, S3H, S3
 
 
@@ -336,3 +336,9 @@ class UtilsTestCases(unittest.TestCase):
         expected_rules = ['data/*.png', 'ignored-folder/']
         self.assertEqual(result, expected_rules)
         self.assertEqual(None, get_ignore_rules('wrong-path'))
+
+    def test_path_is_parent(self):
+        self.assertTrue(path_is_parent('A/B', 'A/B/C'))
+        self.assertTrue(path_is_parent('A/B', 'A/B/../B/C'))
+        self.assertFalse(path_is_parent('A/B', 'A/B/../C'))
+        self.assertFalse(path_is_parent('A/B', 'A/B/../../C'))


### PR DESCRIPTION
**Behaviour after fix:**
```
$ ml-git datasets create data-out --categories=test --mutability=strict --entity-dir=../
ERROR - MLGit: The entity data directory must be inside the ml-git project entities directory. '../' is not a valid value.
A complete log of this run can be found in: ml-git_execution.log
```
