### PR TITLE
Updating add command to save previous hash when detect corrupted files

### DIFF
--- a/ml_git/manifest.py
+++ b/ml_git/manifest.py
@@ -19,7 +19,9 @@ class Manifest(object):
         mf = self._manifest
 
         from ml_git.file_system.index import Status
-        if previous_key is not None and file['status'] != Status.c.name:
+        if previous_key is not None and \
+                ((file is not None) and ('status' in file and file['status'] != Status.c.name)
+                 or ('status' not in file)):
             if previous_key in mf and file in mf[previous_key]:
                 self.rm(previous_key, file)
 

--- a/ml_git/manifest.py
+++ b/ml_git/manifest.py
@@ -18,7 +18,8 @@ class Manifest(object):
     def add(self, key, file, previous_key=None):
         mf = self._manifest
 
-        if previous_key is not None:
+        from ml_git.file_system.index import Status
+        if previous_key is not None and file['status'] != Status.c.name:
             if previous_key in mf and file in mf[previous_key]:
                 self.rm(previous_key, file)
 

--- a/ml_git/ml_git_message.py
+++ b/ml_git/ml_git_message.py
@@ -83,6 +83,7 @@ output_messages = {
     'DEBUG_UNPUBLISHED_COMMITS': 'Could not get unpublished commits quantity. Returning default value (0) for %s. %s',
     'DEBUG_ENTITIES_RELATIONSHIP': 'Could not get the entities to list its relationships. {}.',
     'DEBUG_UNZIPPING_FILE': 'Unzipping file: {}',
+    'DEBUG_RESTORED_FILE': 'The file [{}] has been restored to the original version.',
 
     'INFO_INITIALIZED_PROJECT_IN': 'Initialized empty ml-git repository in %s',
     'INFO_ADD_REMOTE': 'Add remote repository [%s] for [%s]',


### PR DESCRIPTION
With this change it is now possible to identify when a file is manually corrected in the workspace by the user.