### PR TITLE
Fixing ubuntu version in workflows

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -12,7 +12,7 @@ jobs:
   flake8:
     name: Flake8
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
   unit-tests:
     name: Unit Tests
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
@@ -64,7 +64,7 @@ jobs:
   integration-tests:
     name: Integration Tests
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]

--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout main
         uses: actions/checkout@v1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -10,7 +10,7 @@ jobs:
   build-linux:
     name: Build Linux
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       BUILD_NAME: 0
@@ -91,7 +91,7 @@ jobs:
     name: Flake8
     needs: [build-linux, build-windows]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -112,7 +112,7 @@ jobs:
     name: Unit Tests
     needs: [build-linux, build-windows]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -150,7 +150,7 @@ jobs:
     name: Integration Tests
     needs: [build-linux, build-windows]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Recently github started using Ubuntu 22.04 as the latest, and because of that, the settings with python 3.6 stopped working. In this PR we set the version used for 20.04, which was used by this project so far.